### PR TITLE
Remove relative import statements from remaining unit tests

### DIFF
--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -4,11 +4,11 @@
 <Program Name>
   test_pyca_crypto_keys.py
 
-<Author> 
+<Author>
   Vladimir Diaz <vladimir.v.diaz@gmail.com>
 
 <Started>
-  June 3, 2015. 
+  June 3, 2015.
 
 <Copyright>
   See LICENSE for licensing information.
@@ -28,25 +28,14 @@ from __future__ import unicode_literals
 import unittest
 import logging
 
-# Are these tests expected to be standalone?
-# TODO: The following import statement results in a ValueError because it
-# "Attempted relative import in non-package."  In other words, 'ssl_commons'
-# lives outside of this package.  The following block of commented statements
-# (after this first one) is used instead in TUF.
-from ...ssl_commons import exceptions as ssl_commons_exceptions
-from .. import formats as ssl_crypto_formats
-from .. import pyca_crypto_keys as ssl_crypto_pyca_crypto_keys
+import securesystemslib.exceptions
+import securesystemslib.formats
+import securesystemslib.pyca_crypto_keys
 
-"""
-import tuf.ssl_commons.exceptions as ssl_commons_exceptions
-import tuf.ssl_crypto.formats as ssl_crypto_formats
-import tuf.ssl_crypto.pyca_crypto_keys as ssl_crypto_pyca_crypto_keys
-"""
+logger = logging.getLogger('securesystemslib.test_pyca_crypto_keys')
 
-logger = logging.getLogger('ssl_crypto_test_pyca_crypto_keys')
-
-public_rsa, private_rsa = ssl_crypto_pyca_crypto_keys.generate_rsa_public_and_private()
-FORMAT_ERROR_MSG = 'ssl_commons_exceptions.FormatError raised.  Check object\'s format.'
+public_rsa, private_rsa = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private()
+FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'
 
 
 class TestPyca_crypto_keys(unittest.TestCase):
@@ -55,52 +44,52 @@ class TestPyca_crypto_keys(unittest.TestCase):
 
 
   def test_generate_rsa_public_and_private(self):
-    pub, priv = ssl_crypto_pyca_crypto_keys.generate_rsa_public_and_private()
-    
+    pub, priv = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private()
+
     # Check format of 'pub' and 'priv'.
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(pub),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(pub),
                      FORMAT_ERROR_MSG)
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(priv),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(priv),
                      FORMAT_ERROR_MSG)
 
     # Check for an invalid "bits" argument.  bits >= 2048.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pyca_crypto_keys.generate_rsa_public_and_private, 1024)
-   
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pyca_crypto_keys.generate_rsa_public_and_private, '2048')
-  
-  
-  
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private, 1024)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private, '2048')
+
+
+
   def test_create_rsa_signature(self):
     global private_rsa
     global public_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, method = ssl_crypto_pyca_crypto_keys.create_rsa_signature(private_rsa, data)
+    signature, method = securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data)
 
     # Verify format of returned values.
     self.assertNotEqual(None, signature)
-    self.assertEqual(None, ssl_crypto_formats.NAME_SCHEMA.check_match(method),
+    self.assertEqual(None, securesystemslib.formats.NAME_SCHEMA.check_match(method),
                      FORMAT_ERROR_MSG)
     self.assertEqual('RSASSA-PSS', method)
 
     # Check for improperly formatted arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pyca_crypto_keys.create_rsa_signature, 123, data)
-    
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pyca_crypto_keys.create_rsa_signature, 123, data)
+
     self.assertRaises(ValueError,
-                      ssl_crypto_pyca_crypto_keys.create_rsa_signature, '', data)
-   
+                      securesystemslib.pyca_crypto_keys.create_rsa_signature, '', data)
+
     # Check for invalid 'data'.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pyca_crypto_keys.create_rsa_signature, private_rsa, '')
-    
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pyca_crypto_keys.create_rsa_signature, private_rsa, 123)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, '')
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, 123)
 
     # Check for missing private key.
-    self.assertRaises(ssl_commons_exceptions.CryptoError,
-                      ssl_crypto_pyca_crypto_keys.create_rsa_signature, public_rsa, data)
+    self.assertRaises(securesystemslib.exceptions.CryptoError,
+                      securesystemslib.pyca_crypto_keys.create_rsa_signature, public_rsa, data)
 
 
 
@@ -108,39 +97,39 @@ class TestPyca_crypto_keys(unittest.TestCase):
     global public_rsa
     global private_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, method = ssl_crypto_pyca_crypto_keys.create_rsa_signature(private_rsa, data)
+    signature, method = securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data)
 
-    valid_signature = ssl_crypto_pyca_crypto_keys.verify_rsa_signature(signature, method, public_rsa,
+    valid_signature = securesystemslib.pyca_crypto_keys.verify_rsa_signature(signature, method, public_rsa,
                                                 data)
     self.assertEqual(True, valid_signature)
 
     # Check for improperly formatted arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pyca_crypto_keys.verify_rsa_signature, signature,
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
                                        123, public_rsa, data)
-    
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pyca_crypto_keys.verify_rsa_signature, signature,
+
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
                                        method, 123, data)
-    
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pyca_crypto_keys.verify_rsa_signature, 123, method,
+
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pyca_crypto_keys.verify_rsa_signature, 123, method,
                                        public_rsa, data)
-    
-    self.assertRaises(ssl_commons_exceptions.UnknownMethodError,
-                      ssl_crypto_pyca_crypto_keys.verify_rsa_signature,
+
+    self.assertRaises(securesystemslib.exceptions.UnknownMethodError,
+                      securesystemslib.pyca_crypto_keys.verify_rsa_signature,
                       signature,
                       'invalid_method',
                       public_rsa, data)
-    
+
     # Check for invalid 'signature' and 'data' arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pyca_crypto_keys.verify_rsa_signature,
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pyca_crypto_keys.verify_rsa_signature,
                       signature, method, public_rsa, 123)
-    
-    self.assertEqual(False, ssl_crypto_pyca_crypto_keys.verify_rsa_signature(signature, method,
+
+    self.assertEqual(False, securesystemslib.pyca_crypto_keys.verify_rsa_signature(signature, method,
                             public_rsa, b'mismatched data'))
 
-    mismatched_signature, method = ssl_crypto_pyca_crypto_keys.create_rsa_signature(private_rsa,
+    mismatched_signature, method = securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa,
                                                              b'mismatched data')
-    
-    self.assertEqual(False, ssl_crypto_pyca_crypto_keys.verify_rsa_signature(mismatched_signature,
+
+    self.assertEqual(False, securesystemslib.pyca_crypto_keys.verify_rsa_signature(mismatched_signature,
                             method, public_rsa, data))
 
 

--- a/tests/test_pycrypto_keys.py
+++ b/tests/test_pycrypto_keys.py
@@ -4,11 +4,11 @@
 <Program Name>
   test_pycrypto_keys.py
 
-<Author> 
+<Author>
   Vladimir Diaz <vladimir.v.diaz@gmail.com>
 
 <Started>
-  October 10, 2013. 
+  October 10, 2013.
 
 <Copyright>
   See LICENSE for licensing information.
@@ -28,25 +28,14 @@ from __future__ import unicode_literals
 import unittest
 import logging
 
-# Are these tests expected to be standalone?
-# TODO: The following import statement results in a ValueError because it
-# "Attempted relative import in non-package."  In other words, 'ssl_commons'
-# lives outside of this package.  The following block of commented statements
-# (after this first one) is used instead in TUF.
-from ...ssl_commons import exceptions as ssl_commons_exceptions
-from .. import formats as ssl_crypto_formats
-from .. import pycrypto_keys as ssl_crypto_pycrypto_keys
+import securesystemslib.exceptions
+import securesystemslib.formats
+import securesystemslib.pycrypto_keys
 
-"""
-import tuf.ssl_commons.exceptions as ssl_commons_exceptions
-import tuf.ssl_crypto.formats as ssl_crypto_formats
-import tuf.ssl_crypto.pycrypto_keys as ssl_crypto_pycrypto_keys
-"""
+logger = logging.getLogger('securesystemslib.test_pycrypto_keys')
 
-logger = logging.getLogger('ssl_crypto_test_pycrypto_keys')
-
-public_rsa, private_rsa = ssl_crypto_pycrypto_keys.generate_rsa_public_and_private()
-FORMAT_ERROR_MSG = 'ssl_commons_exceptions.FormatError raised.  Check object\'s format.'
+public_rsa, private_rsa = securesystemslib.pycrypto_keys.generate_rsa_public_and_private()
+FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'
 
 
 class TestPycrypto_keys(unittest.TestCase):
@@ -55,94 +44,94 @@ class TestPycrypto_keys(unittest.TestCase):
 
 
   def test_generate_rsa_public_and_private(self):
-    pub, priv = ssl_crypto_pycrypto_keys.generate_rsa_public_and_private()
-    
+    pub, priv = securesystemslib.pycrypto_keys.generate_rsa_public_and_private()
+
     # Check format of 'pub' and 'priv'.
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(pub),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(pub),
                      FORMAT_ERROR_MSG)
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(priv),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(priv),
                      FORMAT_ERROR_MSG)
 
     # Check for invalid bits argument.  bit >= 2048 and a multiple of 256.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.generate_rsa_public_and_private, 1024)
-    
-    self.assertRaises(ValueError,
-                      ssl_crypto_pycrypto_keys.generate_rsa_public_and_private, 2049)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.generate_rsa_public_and_private, 1024)
 
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.generate_rsa_public_and_private, '2048')
-    
+    self.assertRaises(ValueError,
+                      securesystemslib.pycrypto_keys.generate_rsa_public_and_private, 2049)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.generate_rsa_public_and_private, '2048')
+
 
   def test_create_rsa_signature(self):
     global private_rsa
     global public_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, method = ssl_crypto_pycrypto_keys.create_rsa_signature(private_rsa, data)
+    signature, method = securesystemslib.pycrypto_keys.create_rsa_signature(private_rsa, data)
 
     # Verify format of returned values.
     self.assertNotEqual(None, signature)
-    self.assertEqual(None, ssl_crypto_formats.NAME_SCHEMA.check_match(method),
+    self.assertEqual(None, securesystemslib.formats.NAME_SCHEMA.check_match(method),
                      FORMAT_ERROR_MSG)
     self.assertEqual('RSASSA-PSS', method)
 
     # Check for improperly formatted arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_signature, 123, data)
-    
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_signature, 123, data)
+
     self.assertRaises(ValueError,
-                      ssl_crypto_pycrypto_keys.create_rsa_signature, '', data)
-   
+                      securesystemslib.pycrypto_keys.create_rsa_signature, '', data)
+
     # Check for invalid 'data'.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_signature, private_rsa, '')
-   
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_signature, private_rsa, '')
+
     # create_rsa_signature should reject non-string data.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_signature, private_rsa, 123)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_signature, private_rsa, 123)
 
     # Check for missing private key.
-    self.assertRaises(ssl_commons_exceptions.CryptoError,
-                      ssl_crypto_pycrypto_keys.create_rsa_signature, public_rsa, data)
+    self.assertRaises(securesystemslib.exceptions.CryptoError,
+                      securesystemslib.pycrypto_keys.create_rsa_signature, public_rsa, data)
 
 
   def test_verify_rsa_signature(self):
     global public_rsa
     global private_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, method = ssl_crypto_pycrypto_keys.create_rsa_signature(private_rsa, data)
+    signature, method = securesystemslib.pycrypto_keys.create_rsa_signature(private_rsa, data)
 
-    valid_signature = ssl_crypto_pycrypto_keys.verify_rsa_signature(signature, method, public_rsa,
+    valid_signature = securesystemslib.pycrypto_keys.verify_rsa_signature(signature, method, public_rsa,
                                                 data)
     self.assertEqual(True, valid_signature)
 
     # Check for improperly formatted arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pycrypto_keys.verify_rsa_signature, signature,
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pycrypto_keys.verify_rsa_signature, signature,
                                        123, public_rsa, data)
-    
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pycrypto_keys.verify_rsa_signature, signature,
+
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pycrypto_keys.verify_rsa_signature, signature,
                                        method, 123, data)
-    
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pycrypto_keys.verify_rsa_signature, 123, method,
+
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pycrypto_keys.verify_rsa_signature, 123, method,
                                        public_rsa, data)
-    
-    self.assertRaises(ssl_commons_exceptions.UnknownMethodError, ssl_crypto_pycrypto_keys.verify_rsa_signature,
+
+    self.assertRaises(securesystemslib.exceptions.UnknownMethodError, securesystemslib.pycrypto_keys.verify_rsa_signature,
                                                       signature,
                                                       'invalid_method',
                                                       public_rsa, data)
-    
+
     # Check for invalid signature and data.
     # Verify_rsa_signature should reject non-string data.
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pycrypto_keys.verify_rsa_signature, signature,
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pycrypto_keys.verify_rsa_signature, signature,
                                        method, public_rsa, 123)
-   
-    self.assertEqual(False, ssl_crypto_pycrypto_keys.verify_rsa_signature(signature, method,
+
+    self.assertEqual(False, securesystemslib.pycrypto_keys.verify_rsa_signature(signature, method,
                             public_rsa, b'mismatched data'))
 
-    mismatched_signature, method = ssl_crypto_pycrypto_keys.create_rsa_signature(private_rsa,
+    mismatched_signature, method = securesystemslib.pycrypto_keys.create_rsa_signature(private_rsa,
                                                              b'mismatched data')
-    
-    self.assertEqual(False, ssl_crypto_pycrypto_keys.verify_rsa_signature(mismatched_signature,
+
+    self.assertEqual(False, securesystemslib.pycrypto_keys.verify_rsa_signature(mismatched_signature,
                             method, public_rsa, data))
 
 
@@ -152,30 +141,30 @@ class TestPycrypto_keys(unittest.TestCase):
     passphrase = 'pw'
 
     # Check format of 'public_rsa'.
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(public_rsa),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(public_rsa),
                      FORMAT_ERROR_MSG)
-    
+
     # Check format of 'passphrase'.
-    self.assertEqual(None, ssl_crypto_formats.PASSWORD_SCHEMA.check_match(passphrase),
+    self.assertEqual(None, securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase),
                      FORMAT_ERROR_MSG)
 
     # Generate the encrypted PEM string of 'public_rsa'.
-    pem_rsakey = ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem(private_rsa, passphrase)
+    pem_rsakey = securesystemslib.pycrypto_keys.create_rsa_encrypted_pem(private_rsa, passphrase)
 
     # Check format of 'pem_rsakey'.
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(pem_rsakey),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem_rsakey),
                      FORMAT_ERROR_MSG)
 
     # Check for invalid arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem, 1, passphrase)
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem, private_rsa, ['pw'])
- 
-    self.assertRaises(ssl_commons_exceptions.CryptoError, ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem,
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_encrypted_pem, 1, passphrase)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_encrypted_pem, private_rsa, ['pw'])
+
+    self.assertRaises(securesystemslib.exceptions.CryptoError, securesystemslib.pycrypto_keys.create_rsa_encrypted_pem,
                                        'abc', passphrase)
-    self.assertRaises(TypeError, ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem, '', passphrase)
- 
+    self.assertRaises(TypeError, securesystemslib.pycrypto_keys.create_rsa_encrypted_pem, '', passphrase)
+
 
 
   def test_create_rsa_public_and_private_from_pem(self):
@@ -183,23 +172,23 @@ class TestPycrypto_keys(unittest.TestCase):
     passphrase = 'pw'
 
     # Generate the encrypted PEM string of 'private_rsa'.
-    pem_rsakey = ssl_crypto_pycrypto_keys.create_rsa_encrypted_pem(private_rsa, passphrase)
-   
+    pem_rsakey = securesystemslib.pycrypto_keys.create_rsa_encrypted_pem(private_rsa, passphrase)
+
     # Check format of 'passphrase'.
-    self.assertEqual(None, ssl_crypto_formats.PASSWORD_SCHEMA.check_match(passphrase),
+    self.assertEqual(None, securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase),
                      FORMAT_ERROR_MSG)
 
     # Decrypt 'pem_rsakey' and verify the decrypted object is properly
     # formatted.
     public_decrypted, private_decrypted = \
-    ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem(pem_rsakey,
+    securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem(pem_rsakey,
                                                              passphrase)
     self.assertEqual(None,
-                     ssl_crypto_formats.PEMRSA_SCHEMA.check_match(public_decrypted),
+                     securesystemslib.formats.PEMRSA_SCHEMA.check_match(public_decrypted),
                      FORMAT_ERROR_MSG)
-    
+
     self.assertEqual(None,
-                     ssl_crypto_formats.PEMRSA_SCHEMA.check_match(private_decrypted),
+                     securesystemslib.formats.PEMRSA_SCHEMA.check_match(private_decrypted),
                      FORMAT_ERROR_MSG)
 
     # Does 'public_decrypted' and 'private_decrypted' match the originals?
@@ -207,31 +196,31 @@ class TestPycrypto_keys(unittest.TestCase):
     self.assertEqual(private_rsa, private_decrypted)
 
     # Attempt decryption of 'pem_rsakey' using an incorrect passphrase.
-    self.assertRaises(ssl_commons_exceptions.CryptoError,
-                      ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem,
+    self.assertRaises(securesystemslib.exceptions.CryptoError,
+                      securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem,
                       pem_rsakey, 'bad_pw')
 
     # Check for non-encrypted PEM strings.
     # create_rsa_public_and_private_from_pem() returns a tuple of
-    # ssl_crypto_formats.PEMRSA_SCHEMA objects if the PEM formatted string is
+    # securesystemslib.formats.PEMRSA_SCHEMA objects if the PEM formatted string is
     # not actually encrypted but still a valid PEM string.
-    pub, priv = ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem(
+    pub, priv = securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem(
                               private_rsa, passphrase)
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(pub),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(pub),
                      FORMAT_ERROR_MSG)
-    self.assertEqual(None, ssl_crypto_formats.PEMRSA_SCHEMA.check_match(priv),
+    self.assertEqual(None, securesystemslib.formats.PEMRSA_SCHEMA.check_match(priv),
                      FORMAT_ERROR_MSG)
 
     # Check for invalid arguments.
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem,
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem,
                       123, passphrase)
-    self.assertRaises(ssl_commons_exceptions.FormatError,
-                      ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem,
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem,
                       pem_rsakey, ['pw'])
-    
-    self.assertRaises(ssl_commons_exceptions.CryptoError,
-                      ssl_crypto_pycrypto_keys.create_rsa_public_and_private_from_pem,
+
+    self.assertRaises(securesystemslib.exceptions.CryptoError,
+                      securesystemslib.pycrypto_keys.create_rsa_public_and_private_from_pem,
                       'invalid_pem', passphrase)
 
 
@@ -241,16 +230,16 @@ class TestPycrypto_keys(unittest.TestCase):
     global public_rsa
     global private_rsa
     passphrase = 'pw'
-    
+
     rsa_key = {'keytype': 'rsa',
     'keyid': 'd62247f817883f593cf6c66a5a55292488d457bcf638ae03207dbbba9dbe457d',
     'keyval': {'public': public_rsa, 'private': private_rsa}}
 
-    encrypted_rsa_key = ssl_crypto_pycrypto_keys.encrypt_key(rsa_key, passphrase)
+    encrypted_rsa_key = securesystemslib.pycrypto_keys.encrypt_key(rsa_key, passphrase)
 
     # Test for invalid arguments.
     rsa_key['keyval']['private'] = ''
-    self.assertRaises(ssl_commons_exceptions.FormatError, ssl_crypto_pycrypto_keys.encrypt_key, rsa_key,
+    self.assertRaises(securesystemslib.exceptions.FormatError, securesystemslib.pycrypto_keys.encrypt_key, rsa_key,
                                        'passphrase')
 
 
@@ -259,34 +248,34 @@ class TestPycrypto_keys(unittest.TestCase):
     global public_rsa
     global private_rsa
     passphrase = 'pw'
-    
+
     rsa_key = {'keytype': 'rsa',
     'keyid': 'd62247f817883f593cf6c66a5a55292488d457bcf638ae03207dbbba9dbe457d',
     'keyval': {'public': public_rsa, 'private': private_rsa}}
 
-    encrypted_rsa_key = ssl_crypto_pycrypto_keys.encrypt_key(rsa_key, passphrase).encode('utf-8')
-    
-    decrypted_rsa_key = ssl_crypto_pycrypto_keys.decrypt_key(encrypted_rsa_key, passphrase)
+    encrypted_rsa_key = securesystemslib.pycrypto_keys.encrypt_key(rsa_key, passphrase).encode('utf-8')
+
+    decrypted_rsa_key = securesystemslib.pycrypto_keys.decrypt_key(encrypted_rsa_key, passphrase)
 
 
     # Test for invalid arguments.
-    self.assertRaises(ssl_commons_exceptions.CryptoError, ssl_crypto_pycrypto_keys.decrypt_key, b'bad',
+    self.assertRaises(securesystemslib.exceptions.CryptoError, securesystemslib.pycrypto_keys.decrypt_key, b'bad',
                                        passphrase)
 
     # Test for invalid encrypted content (i.e., invalid hmac and ciphertext.)
-    encryption_delimiter = ssl_crypto_pycrypto_keys._ENCRYPTION_DELIMITER 
+    encryption_delimiter = securesystemslib.pycrypto_keys._ENCRYPTION_DELIMITER
     salt, iterations, hmac, iv, ciphertext = \
       encrypted_rsa_key.decode('utf-8').split(encryption_delimiter)
-   
+
     # Set an invalid hmac.  The decryption routine sould raise a
-    # ssl_commons_exceptions.CryptoError exception because 'hmac' does not
+    # securesystemslib.exceptions.CryptoError exception because 'hmac' does not
     # match the hmac calculated by the decryption routine.
     bad_hmac = '12345abcd'
     invalid_encrypted_rsa_key = \
       salt + encryption_delimiter + iterations + encryption_delimiter + \
       bad_hmac + encryption_delimiter + iv + encryption_delimiter + ciphertext
-      
-    self.assertRaises(ssl_commons_exceptions.CryptoError, ssl_crypto_pycrypto_keys.decrypt_key,
+
+    self.assertRaises(securesystemslib.exceptions.CryptoError, securesystemslib.pycrypto_keys.decrypt_key,
                       invalid_encrypted_rsa_key.encode('utf-8'), passphrase)
 
     # Test for invalid 'ciphertext'
@@ -294,19 +283,19 @@ class TestPycrypto_keys(unittest.TestCase):
     invalid_encrypted_rsa_key = \
       salt + encryption_delimiter + iterations + encryption_delimiter + \
       hmac + encryption_delimiter + iv + encryption_delimiter + bad_ciphertext
-    
-    self.assertRaises(ssl_commons_exceptions.CryptoError, ssl_crypto_pycrypto_keys.decrypt_key,
+
+    self.assertRaises(securesystemslib.exceptions.CryptoError, securesystemslib.pycrypto_keys.decrypt_key,
                       invalid_encrypted_rsa_key.encode('utf-8'), passphrase)
 
 
 
   def test__decrypt_key(self):
     # Test for invalid arguments.
-    salt, iterations, derived_key = ssl_crypto_pycrypto_keys._generate_derived_key('pw')
+    salt, iterations, derived_key = securesystemslib.pycrypto_keys._generate_derived_key('pw')
     derived_key_information = {'salt': salt, 'derived_key': derived_key,
                                'iterations': iterations}
-    
-    self.assertRaises(ssl_commons_exceptions.CryptoError, ssl_crypto_pycrypto_keys._encrypt,
+
+    self.assertRaises(securesystemslib.exceptions.CryptoError, securesystemslib.pycrypto_keys._encrypt,
                           8, derived_key_information)
 
 


### PR DESCRIPTION
test_pycrypto_keys.py and test_pyca_crypto_keys.py (remove relative import statements)