### PR TITLE
Remove simple-settings dependency and import securesystemslib.settings instead

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -131,7 +131,8 @@ import securesystemslib.exceptions
 import securesystemslib.hash
 import securesystemslib.formats
 
-from simple_settings import settings
+# TODO: from simple_settings import settings
+import securesystemslib.settings
 
 # The hash algorithm to use in the generation of keyids.
 _KEY_ID_HASH_ALGORITHM = 'sha256'
@@ -145,9 +146,9 @@ _DEFAULT_RSA_KEY_BITS = 3072
 # The crypto libraries to use in 'keys.py', set by default or by the user.
 # The following cryptography libraries are currently supported:
 # ['pycrypto', 'pynacl', 'ed25519', 'pyca-cryptography']
-_RSA_CRYPTO_LIBRARY = settings.RSA_CRYPTO_LIBRARY
-_ED25519_CRYPTO_LIBRARY = settings.ED25519_CRYPTO_LIBRARY
-_GENERAL_CRYPTO_LIBRARY = settings.GENERAL_CRYPTO_LIBRARY
+_RSA_CRYPTO_LIBRARY = securesystemslib.settings.RSA_CRYPTO_LIBRARY
+_ED25519_CRYPTO_LIBRARY = securesystemslib.settings.ED25519_CRYPTO_LIBRARY
+_GENERAL_CRYPTO_LIBRARY = securesystemslib.settings.GENERAL_CRYPTO_LIBRARY
 
 
 def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS):
@@ -429,7 +430,7 @@ def format_keyval_to_metadata(keytype, key_value, private=False):
     public_key_value = {'public': key_value['public']}
 
     return {'keytype': keytype,
-            'keyid_hash_algorithms': settings.REPOSITORY_HASH_ALGORITHMS,
+            'keyid_hash_algorithms': securesystemslib.settings.HASH_ALGORITHMS,
             'keyval': public_key_value}
 
 
@@ -506,7 +507,7 @@ def format_metadata_to_key(key_metadata):
   keyids = set()
   keyids.add(default_keyid)
 
-  for hash_algorithm in settings.REPOSITORY_HASH_ALGORITHMS:
+  for hash_algorithm in securesystemslib.settings.HASH_ALGORITHMS:
     keyid = _get_keyid(keytype, key_value, hash_algorithm)
     keyids.add(keyid)
 
@@ -514,7 +515,7 @@ def format_metadata_to_key(key_metadata):
   # 'keyid_hash_algorithms'
   key_dict['keytype'] = keytype
   key_dict['keyid'] = default_keyid
-  key_dict['keyid_hash_algorithms'] = settings.REPOSITORY_HASH_ALGORITHMS
+  key_dict['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
   key_dict['keyval'] = key_value
 
   return key_dict, keyids
@@ -685,7 +686,7 @@ def create_signature(key_dict, data):
     securesystemslib.exceptions.UnsupportedLibraryError, if an unsupported or unavailable library is
     detected.
 
-    TypeError, if 'key_dict' contains an invalid keytype.
+    ValueError, if 'key_dict' contains an invalid keytype.
 
   <Side Effects>
     The cryptography library specified in 'settings' called to perform the
@@ -751,7 +752,7 @@ def create_signature(key_dict, data):
 
   # 'securesystemslib.formats.ANYKEY_SCHEMA' should detect invalid key types.
   else: # pragma: no cover
-    raise TypeError('Invalid key type.')
+    raise ValueError('Invalid key type.')
 
   # Build the signature dictionary to be returned.
   # The hexadecimal representation of 'sig' is stored in the signature.

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -126,8 +126,8 @@ import securesystemslib.formats
 import securesystemslib.util
 
 # Extract/reference the cryptography library settings.
-from simple_settings import settings
-
+# TODO: from simple_settings import settings
+import securesystemslib.settings
 
 # Recommended RSA key sizes:
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
@@ -159,7 +159,7 @@ _SALT_SIZE = 16
 # derived key+PBDKF2 combination if the key is loaded and re-saved, overriding
 # any previous iteration setting used by the old '<keyid>.key'.
 # https://en.wikipedia.org/wiki/PBKDF2
-_PBKDF2_ITERATIONS = settings.PBKDF2_ITERATIONS
+_PBKDF2_ITERATIONS = securesystemslib.settings.PBKDF2_ITERATIONS
 
 
 

--- a/securesystemslib/pycrypto_keys.py
+++ b/securesystemslib/pycrypto_keys.py
@@ -110,8 +110,8 @@ import securesystemslib.formats
 import securesystemslib.util
 
 # Extract the cryptography library settings.
-from simple_settings import settings
-
+# TODO: from simple_settings import settings
+import securesystemslib.settings
 
 # Recommended RSA key sizes:
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
@@ -143,7 +143,7 @@ _SALT_SIZE = 16
 # derived key+PBDKF2 combination if the key is loaded and re-saved, overriding
 # any previous iteration setting used by the old '<keyid>.key'.
 # https://en.wikipedia.org/wiki/PBKDF2
-_PBKDF2_ITERATIONS = settings.PBKDF2_ITERATIONS
+_PBKDF2_ITERATIONS = securesystemslib.settings.PBKDF2_ITERATIONS
 
 
 def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):

--- a/securesystemslib/settings.py
+++ b/securesystemslib/settings.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  settings.py
+
+<Author>
+  Vladimir Diaz <vladimir.v.diaz@gmail.com>
+
+<Started>
+  December 7, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Store all crypto-related settings used by securesystemslib.
+"""
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+
+
+
+
+# The current "good enough" number of PBKDF2 passphrase iterations.
+# We recommend that important keys, such as root, be kept offline.
+# 'toto.settings.PBKDF2_ITERATIONS' should increase as CPU speeds increase, set here
+# at 100,000 iterations by default (in 2013).  The repository maintainer may opt
+# to modify the default setting according to their security needs and
+# computational restrictions.  A strong user password is still important.
+# Modifying the number of iterations will result in a new derived key+PBDKF2
+# combination if the key is loaded and re-saved, overriding any previous
+# iteration setting used in the old '<keyid>' key file.
+# https://en.wikipedia.org/wiki/PBKDF2
+PBKDF2_ITERATIONS = 100000
+
+# Supported cryptography libraries that can be used to generate and verify RSA
+# keys and signatures:  ['pycrypto', 'pyca-cryptography']
+RSA_CRYPTO_LIBRARY = 'pyca-cryptography'
+
+# Supported Ed25519 cryptography libraries: ['pynacl', 'ed25519']
+ED25519_CRYPTO_LIBRARY = 'ed25519'
+
+# General purpose cryptography. Algorithms and functions that fall under
+# general purpose include AES, PBKDF2, cryptographically strong random number
+# generators, and cryptographic hash functions.  The majority of the general
+# cryptography is needed by the repository and developer tools.
+# RSA_CRYPTO_LIBRARY and ED25519_CRYPTO_LIBRARY are needed on the client side
+# of the software updater.
+# Supported libraries for general-purpose cryptography:  ['pycrypto',
+# 'pyca-cryptography']
+GENERAL_CRYPTO_LIBRARY = 'pycrypto'
+
+# The algorithm(s) in HASH_ALGORITHMS are used to generate key IDs.
+HASH_ALGORITHMS = ['sha256', 'sha512']

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -32,13 +32,13 @@ import logging
 import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.keys
+import securesystemslib.settings
 
 logger = logging.getLogger('securesystemslib.test_keys')
 
 KEYS = securesystemslib.keys
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError was raised! Check object\'s format.'
 DATA = 'SOME DATA REQUIRING AUTHENTICITY.'
-
 
 
 class TestKeys(unittest.TestCase):
@@ -132,13 +132,13 @@ class TestKeys(unittest.TestCase):
     keyid = self.rsakey_dict['keyid']
     del self.rsakey_dict['keyid']
 
-    rsakey_dict_from_meta = KEYS.format_metadata_to_key(self.rsakey_dict)
+    rsakey_dict_from_meta, junk = KEYS.format_metadata_to_key(self.rsakey_dict)
 
     # Check if the format of the object returned by this function corresponds
     # to RSAKEY_SCHEMA format.
     self.assertEqual(None,
-           securesystemslib.formats.RSAKEY_SCHEMA.check_match(rsakey_dict_from_meta),
-           FORMAT_ERROR_MSG)
+      securesystemslib.formats.RSAKEY_SCHEMA.check_match(rsakey_dict_from_meta),
+      FORMAT_ERROR_MSG)
     self.rsakey_dict['keyid'] = keyid
 
     # Supplying a wrong number of arguments.
@@ -192,7 +192,7 @@ class TestKeys(unittest.TestCase):
     self.rsakey_dict['keyval']['private'] = ''
 
     args = (self.rsakey_dict, DATA)
-    self.assertRaises(TypeError, KEYS.create_signature, *args)
+    self.assertRaises(ValueError, KEYS.create_signature, *args)
 
     # Supplying an incorrect number of arguments.
     self.assertRaises(TypeError, KEYS.create_signature)


### PR DESCRIPTION
Change exception raised (ValueError instead of TypeError, since it's correct type, but unsupported value