### PR TITLE
Removes ssl_crypto/ssl_commons relicts in docstrings

### DIFF
--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -17,7 +17,7 @@
   signatures (64 bytes) and small public keys (32 bytes).
   http://ed25519.cr.yp.to/
 
-  'ssl_crypto/ed25519_keys.py' calls 'ed25519.py', which is the pure Python
+  'securesystemslib/ed25519_keys.py' calls 'ed25519.py', which is the pure Python
   implementation of ed25519 optimized for a faster runtime.  The Python
   reference implementation is concise, but very slow (verifying signatures
   takes ~9 seconds on an Intel core 2 duo @ 2.2 ghz x 2).  The optimized
@@ -220,7 +220,7 @@ def create_signature(public_key, private_key, data):
     nacl.signing.SigningKey.sign() called to generate the actual signature.
 
   <Returns>
-    A signature dictionary conformat to 'ssl_crypto.format.SIGNATURE_SCHEMA'.
+    A signature dictionary conformat to 'securesystemslib.format.SIGNATURE_SCHEMA'.
     ed25519 signatures are 64 bytes, however, the hexlified signature is
     stored in the dictionary returned.
   """
@@ -297,7 +297,7 @@ def verify_signature(public_key, method, signature, data, use_pynacl=False):
       The signature is a 64-byte string.
 
     data:
-      Data object used by ssl_crypto.ed25519_keys.create_signature() to generate
+      Data object used by securesystemslib.ed25519_keys.create_signature() to generate
       'signature'.  'data' is needed here to verify the signature.
 
     use_pynacl:
@@ -307,12 +307,12 @@ def verify_signature(public_key, method, signature, data, use_pynacl=False):
 
   <Exceptions>
     securesystemslib.exceptions.UnknownMethodError.  Raised if the signing method used by
-    'signature' is not one supported by ssl_crypto.ed25519_keys.create_signature().
+    'signature' is not one supported by securesystemslib.ed25519_keys.create_signature().
 
     securesystemslib.exceptions.FormatError. Raised if the arguments are improperly formatted.
 
   <Side Effects>
-    ssl_crypto._vendor.ed25519.ed25519.checkvalid() called to do the actual
+    securesystemslib._vendor.ed25519.ed25519.checkvalid() called to do the actual
     verification.  nacl.signing.VerifyKey.verify() called if 'use_pynacl' is
     True.
 

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -773,7 +773,7 @@ def encode_canonical(object, output_function=None):
       (e.g., output_function('result')).
 
   <Exceptions>
-    ssl_commons.exceptions.FormatError, if 'object' cannot be encoded or 'output_function'
+    securesystemslib.exceptions.FormatError, if 'object' cannot be encoded or 'output_function'
     is not callable.
 
   <Side Effects>

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -37,13 +37,13 @@ import six
 
 import securesystemslib.exceptions
 
-# Import ssl_crypto logger to log warning messages.
+# Import securesystemslib logger to log warning messages.
 logger = logging.getLogger('securesystemslib.hash')
 
 # The list of hash libraries imported successfully.
 _supported_libraries = []
 
-# Hash libraries currently supported by ssl_crypto.hash.
+# Hash libraries currently supported by securesystemslib.hash.
 _SUPPORTED_LIB_LIST = ['hashlib', 'pycrypto']
 
 # Let's try importing the pycrypto hash algorithms.  Pycrypto will
@@ -101,9 +101,9 @@ def digest(algorithm=_DEFAULT_HASH_ALGORITHM,
 
     # Creation of a digest object using defaults
     # or by specifying hash algorithm and library.
-    digest_object = ssl_crypto.hash.digest()
-    digest_object = ssl_crypto.hash.digest('sha384')
-    digest_object = ssl_crypto.hash.digest('pycrypto')
+    digest_object = securesystemslib.hash.digest()
+    digest_object = securesystemslib.hash.digest('sha384')
+    digest_object = securesystemslib.hash.digest('pycrypto')
 
     # The expected interface for digest objects.
     digest_object.digest_size
@@ -112,8 +112,8 @@ def digest(algorithm=_DEFAULT_HASH_ALGORITHM,
     digest_object.digest()
 
     # Added hash routines by this module.
-    digest_object = ssl_crypto.hash.digest_fileobject(file_object)
-    digest_object = ssl_crypto.hash.digest_filename(filename)
+    digest_object = securesystemslib.hash.digest_fileobject(file_object)
+    digest_object = securesystemslib.hash.digest_filename(filename)
 
   <Arguments>
     algorithm:
@@ -199,7 +199,7 @@ def digest_fileobject(file_object, algorithm=_DEFAULT_HASH_ALGORITHM,
     securesystemslib.exceptions.Error
 
   <Side Effects>
-    Calls ssl_crypto.hash.digest() to create the actual digest object.
+    Calls securesystemslib.hash.digest() to create the actual digest object.
 
   <Returns>
     Digest object (e.g., hashlib.new(algorithm) or
@@ -260,7 +260,7 @@ def digest_filename(filename, algorithm=_DEFAULT_HASH_ALGORITHM,
     securesystemslib.exceptions.Error
 
   <Side Effects>
-    Calls ssl_crypto.hash.digest_fileobject() after opening 'filename'.
+    Calls securesystemslib.hash.digest_fileobject() after opening 'filename'.
     File closed before returning.
 
   <Returns>

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -101,7 +101,7 @@ from cryptography.hazmat.primitives import hmac
 from cryptography.hazmat.primitives.asymmetric import padding
 
 # Import pyca/cryptography's Key Derivation Function (KDF) module.
-# 'ssl_crypto.keys.py' needs this module to derive a secret key according to the
+# 'securesystemslib.keys.py' needs this module to derive a secret key according to the
 # Password-Based Key Derivation Function 2 specification.  The derived key is
 # used as the symmetric key to encrypt TUF key information.
 # PKCS#5 v2.0 PBKDF2 specification: http://tools.ietf.org/html/rfc2898#section-5.2
@@ -376,7 +376,7 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
       The RSA public key, a string in PEM format.
 
     data:
-      Data used by ssl_crypto.keys.create_signature() to generate
+      Data used by securesystemslib.keys.create_signature() to generate
       'signature'.  'data' (a string) is needed here to verify 'signature'.
 
   <Exceptions>
@@ -384,7 +384,7 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
     'data' are improperly formatted.
 
     securesystemslib.exceptions.UnknownMethodError, if the signing method used by
-    'signature' is not one supported by ssl_crypto.keys.create_signature().
+    'signature' is not one supported by securesystemslib.keys.create_signature().
 
     securesystemslib.exceptions.CryptoError, if the private key cannot be decoded or its key type
     is unsupported.
@@ -426,7 +426,7 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
                                                    backend=default_backend())
 
     # 'salt_length' is set to the digest size of the hashing algorithm (to
-    # match the default size used by 'ssl_crypto.pycrypto_keys.py').
+    # match the default size used by 'securesystemslib.pycrypto_keys.py').
     verifier = public_key_object.verifier(signature,
                                 padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
                                 salt_length=hashes.SHA256().digest_size),

--- a/securesystemslib/pycrypto_keys.py
+++ b/securesystemslib/pycrypto_keys.py
@@ -353,13 +353,13 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
       The RSA public key, a string in PEM format.
 
     data:
-      Data object used by securesystemslib__keys.create_signature() to generate
+      Data object used by securesystemslib.keys.create_signature() to generate
       'signature'.  'data' is needed here to verify the signature.
 
   <Exceptions>
     securesystemslib.exceptions.UnknownMethodError.  Raised if the signing method
     used by 'signature' is not one supported by
-    securesystemslib__keys.create_signature().
+    securesystemslib.keys.create_signature().
 
     securesystemslib.exceptions.FormatError. Raised if 'signature',
     'signature_method', or 'public_key' is improperly formatted.

--- a/securesystemslib/pycrypto_keys.py
+++ b/securesystemslib/pycrypto_keys.py
@@ -353,13 +353,13 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
       The RSA public key, a string in PEM format.
 
     data:
-      Data object used by ssl_crypto__keys.create_signature() to generate
+      Data object used by securesystemslib__keys.create_signature() to generate
       'signature'.  'data' is needed here to verify the signature.
 
   <Exceptions>
     securesystemslib.exceptions.UnknownMethodError.  Raised if the signing method
     used by 'signature' is not one supported by
-    ssl_crypto__keys.create_signature().
+    securesystemslib__keys.create_signature().
 
     securesystemslib.exceptions.FormatError. Raised if 'signature',
     'signature_method', or 'public_key' is improperly formatted.
@@ -543,10 +543,10 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
       it is used to derive a stronger symmetric key.
 
   <Exceptions>
-    ssl_commons.exceptions.FormatError, if the arguments are improperly
+    securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
 
-    ssl_commons.exceptions.CryptoError, if the public and private RSA keys
+    securesystemslib.exceptions.CryptoError, if the public and private RSA keys
     cannot be generated from 'encrypted_pem', or exported in PEM format.
 
   <Side Effects>

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -24,18 +24,19 @@
   For example:
   >>> good = {'first': 'Marty', 'last': 'McFly'}
   >>> bad = {'sdfsfd': 'Biff', 'last': 'Tannen'}
+  >>> bad = {'sdfsfd': 'Biff', 'last': 'Tannen'}
   >>> schema = Object(first=AnyString(), last=AnyString())
   >>> schema.matches(good)
   True
   >>> schema.matches(bad)
   False
   In the process of determining if the two objects matched the template,
-  ssl_commons.schema.Object() inspected the named keys of both dictionaries.
+  securesystemslib.schema.Object() inspected the named keys of both dictionaries.
   In the case of the 'bad' dict, a 'first' dict key could not be found.
   As a result, 'bad' was flagged a mismatch.
 
   'schema.py' provides additional schemas for testing objects based on other
-  criteria.  See 'ssl_crypto.formats.py' and the rest of this module for extensive
+  criteria.  See 'securesystemslib.formats.py' and the rest of this module for extensive
   examples.  Anything related to the checking of TUF objects and their formats
   can be found in 'formats.py'.
 """


### PR DESCRIPTION
`securesystemslib` is a merge of `ssl_crypto` and `ssl_commons`.
This PR removes all remaining occurrences of `ssl_crypto` and `ssl_commons` *(only affects docstrings)*.