### PR TITLE
Adds PUBLIC_KEY_SCHEMA and PUBLIC_KEYVAL_SCHEMA

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -217,6 +217,13 @@ KEYVAL_SCHEMA = SCHEMA.Object(
   public = SCHEMA.AnyString(),
   private = SCHEMA.Optional(SCHEMA.AnyString()))
 
+# Public keys CAN have a private portion (for backwards compatibility) which
+# MUST be an empty string
+PUBLIC_KEYVAL_SCHEMA = SCHEMA.Object(
+  object_name = 'KEYVAL_SCHEMA',
+  public = SCHEMA.AnyString(),
+  private = SCHEMA.Optional(SCHEMA.String("")))
+
 # Supported TUF key types.
 KEYTYPE_SCHEMA = SCHEMA.OneOf(
   [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
@@ -228,6 +235,13 @@ KEY_SCHEMA = SCHEMA.Object(
   object_name = 'KEY_SCHEMA',
   keytype = SCHEMA.AnyString(),
   keyval = KEYVAL_SCHEMA,
+  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+
+# Like KEY_SCHEMA, but requires keyval's private portion to be not set or empty
+PUBLIC_KEY_SCHEMA = SCHEMA.Object(
+  object_name = 'KEY_SCHEMA',
+  keytype = SCHEMA.AnyString(),
+  keyval = PUBLIC_KEYVAL_SCHEMA,
   expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # A TUF key object.  This schema simplifies validation of keys that may be

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -102,10 +102,25 @@ class TestFormats(unittest.TestCase):
       'KEYVAL_SCHEMA': (securesystemslib.formats.KEYVAL_SCHEMA,
                         {'public': 'pubkey', 'private': 'privkey'}),
 
+      'PUBLIC_KEYVAL_SCHEMA': (securesystemslib.formats.PUBLIC_KEYVAL_SCHEMA,
+                        {'public': 'pubkey'}),
+
+      'PUBLIC_KEYVAL_SCHEMA2': (securesystemslib.formats.PUBLIC_KEYVAL_SCHEMA,
+                        {'public': 'pubkey', 'private': ''}),
+
       'KEY_SCHEMA': (securesystemslib.formats.KEY_SCHEMA,
                      {'keytype': 'rsa',
                       'keyval': {'public': 'pubkey',
                                  'private': 'privkey'}}),
+
+      'PUBLIC_KEY_SCHEMA': (securesystemslib.formats.KEY_SCHEMA,
+                     {'keytype': 'rsa',
+                      'keyval': {'public': 'pubkey'}}),
+
+      'PUBLIC_KEY_SCHEMA2': (securesystemslib.formats.KEY_SCHEMA,
+                     {'keytype': 'rsa',
+                      'keyval': {'public': 'pubkey',
+                                 'private': ''}}),
 
       'RSAKEY_SCHEMA': (securesystemslib.formats.RSAKEY_SCHEMA,
                         {'keytype': 'rsa',


### PR DESCRIPTION
These schemas require the private portion of the key value to be
either omitted or an empty string.