### PR TITLE
Adds keyid_hash_algorithms to returned key objects

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -237,10 +237,11 @@ KEY_SCHEMA = SCHEMA.Object(
   keyval = KEYVAL_SCHEMA,
   expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
-# Like KEY_SCHEMA, but requires keyval's private portion to be not set or empty
+# Like ANYKEY_SCHEMA, but requires keyval's private portion to be not set or empty
 PUBLIC_KEY_SCHEMA = SCHEMA.Object(
   object_name = 'KEY_SCHEMA',
   keytype = SCHEMA.AnyString(),
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
   keyval = PUBLIC_KEYVAL_SCHEMA,
   expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -42,7 +42,7 @@ import gzip
 import random
 
 import securesystemslib.formats
-import securesystemslib.formats
+import securesystemslib.settings
 import securesystemslib.util
 import securesystemslib.keys
 
@@ -525,6 +525,11 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
     message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
     raise securesystemslib.exceptions.FormatError(message)
 
+  # Add "keyid_hash_algorithms" so equal ed25519 keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  key_object['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
+
   return key_object
 
 
@@ -744,6 +749,11 @@ def import_ecdsa_privatekey_from_file(filepath, password=None):
   if key_object['keytype'] != 'ecdsa-sha2-nistp256':
     message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
     raise securesystemslib.exceptions.FormatError(message)
+
+  # Add "keyid_hash_algorithms" equal ecdsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  key_object['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
 
   return key_object
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -358,6 +358,11 @@ def generate_ecdsa_key(algorithm='ecdsa-sha2-nistp256'):
   ecdsa_key['keyid'] = keyid
   ecdsa_key['keyval'] = key_value
 
+  # Add "keyid_hash_algorithms" so equal ecdsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  ecdsa_key['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
+
   return ecdsa_key
 
 
@@ -1245,6 +1250,11 @@ def import_rsakey_from_public_pem(pem):
   rsakey_dict['keyid'] = keyid
   rsakey_dict['keyval'] = key_value
 
+  # Add "keyid_hash_algorithms" so equal rsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  rsakey_dict['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
+
   return rsakey_dict
 
 
@@ -1315,6 +1325,11 @@ def import_rsakey_from_pem(pem):
   rsakey_dict['keytype'] = keytype
   rsakey_dict['keyid'] = keyid
   rsakey_dict['keyval'] = key_value
+
+  # Add "keyid_hash_algorithms" so equal ecdsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  rsakey_dict['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
 
   return rsakey_dict
 
@@ -1894,6 +1909,11 @@ def import_ecdsakey_from_private_pem(pem, password=None):
   ecdsakey_dict['keyid'] = keyid
   ecdsakey_dict['keyval'] = key_value
 
+  # Add "keyid_hash_algorithms" so equal ecdsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  ecdsakey_dict['keyid_hash_algorithms'] = \
+    securesystemslib.settings.HASH_ALGORITHMS
+
   return ecdsakey_dict
 
 
@@ -1971,6 +1991,11 @@ def import_ecdsakey_from_public_pem(pem):
   ecdsakey_dict['keytype'] = keytype
   ecdsakey_dict['keyid'] = keyid
   ecdsakey_dict['keyval'] = key_value
+
+  # Add "keyid_hash_algorithms" so equal ecdsa keys with
+  # different keyids can be associated using supported keyid_hash_algorithms
+  ecdsakey_dict['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
 
   return ecdsakey_dict
 


### PR DESCRIPTION
Fixes https://github.com/secure-systems-lab/securesystemslib/issues/36 and, once integrated and TUF is updated to use the new version, https://github.com/theupdateframework/tuf/issues/412.

The functions listed below all return key objects that can carry an optional `keyid_hash_algorithms` field according to their schema. With this PR we always add the `keyid_hash_algorithm` field to the returned object, in:
```python
interface.import_ed25519_privatekey_from_file
interface.import_ecdsa_privatekey_from_file
keys.generate_ecdsa_key
keys.import_rsakey_from_public_pem
keys.import_rsakey_from_pem
keys.import_ecdsakey_from_private_pem
keys.import_ecdsakey_from_public_pem
```
e.g.:
```python
>>> from securesystemslib import interface
>>> interface.generate_and_write_ed25519_keypair('testkey', 'pw')
>>> interface.import_ed25519_privatekey_from_file('testkey', 'pw')
{
  u'keytype': u'ed25519',
  u'keyid': u'8f68ef937c031aad4862aa0bac8b45b719c4f2ba8f186b289ba66991f82c8041',
  u'keyval': {
    u'public': u'78fa9cf9b787beb754806c15cf88950a5e3c30ff8cad57dba79c623fd8c5ae00',
    u'private': u'f8919b50f6ea8c4e2060e6177970b7e8cde97950ff284973fbe54485e78689c1'
  },
  u'keyid_hash_algorithms': [u'sha256', u'sha512']
}

>>> interface.import_ed25519_publickey_from_file('testkey.pub')
{
  u'keytype': u'ed25519',
  u'keyid': '8f68ef937c031aad4862aa0bac8b45b719c4f2ba8f186b289ba66991f82c8041',
  u'keyval': {
    u'public': u'78fa9cf9b787beb754806c15cf88950a5e3c30ff8cad57dba79c623fd8c5ae00'
  },
  u'keyid_hash_algorithms': [u'sha256', u'sha512']
}
```


The PR also changes PUBLIC_KEY_SCHEMA to accept the optional `keyid_hash_algorithm` (like ANYKEY_SCHEMA).

The reason for adding this field is to be able to associate a key with e.g. a signature created by that key, but listing a different keyid, because a different keyid hash algorithm was used. By trying all possible algorithms, the key can still be matched.

