### PR TITLE
Address build failure

### DIFF
--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -290,9 +290,11 @@ def verify_signature(public_key, method, signature, data):
       raise securesystemslib.exceptions.FormatError('Invalid signature or'
         ' data: ' + str(e))
 
-    # verify() returns either True or raises an 'InvalidSignature' exception.
+    # verify() raises an 'InvalidSignature' exception if 'signature'
+    # is invalid.
     try:
-      return verifier.verify()
+      verifier.verify()
+      return True
 
     except cryptography.exceptions.InvalidSignature:
       return False


### PR DESCRIPTION
Fix unit test failure introduced by backwards-incompatible change introduced in cryptography 1.9, where verify() does not return True if the signature is valid (i.e., only an exception is raised for invalid signatures).