### PR TITLE
Fixes issue #43

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1699,7 +1699,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
 
   elif _RSA_CRYPTO_LIBRARY == 'pyca-cryptography':
     encrypted_pem = \
-      securesystemslib.pycrypto_keys.create_rsa_encrypted_pem(private_key, passphrase)
+      securesystemslib.pyca_crypto_keys.create_rsa_encrypted_pem(private_key, passphrase)
 
   # check_crypto_libraries() should have fully verified _RSA_CRYPTO_LIBRARY.
   else: # pragma: no cover


### PR DESCRIPTION
Correctly call the pyca_crypto_keys.py module if `pyca-cryptography` is set installed and enabled in settings.py.