### PR TITLE
Discontinue unittests in Python2.6 (tox)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py35
+envlist = py27, py35
 
 [testenv]
 changedir = tests
@@ -16,13 +16,5 @@ commands =
 
 deps =
     -r{toxinidir}/requirements.txt
-
-install_command = pip install --pre {opts} {packages}
-
-[testenv:py26]
-deps =
-    -r{toxinidir}/requirements.txt
-    unittest2
-    importlib
 
 install_command = pip install --pre {opts} {packages}


### PR DESCRIPTION
It seems that Travis CI has discontinued out-of-the box Python2.6 builds in a [recent update of their trusty boxes](https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/). Let's seize the opportunity to discontinue Python2.6 unittesting.

This should probably entail an update of the [version specification in TUF](https://github.com/theupdateframework/tuf/blob/develop/setup.py#L98).