### PR TITLE
Test multi python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 dist: trusty
 sudo: false
-
 cache: pip
+python: 3.6
 
-python:
-  - 2.7
+env:
+  - TOXENV=py27
+  - TOXENV=py34
+  - TOXENV=py36
 
 before_script:
   - pip install -U pip wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: trusty
 sudo: false
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ cache: pip
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
 
 before_script:
   - pip install -U pip wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ sudo: false
 cache: pip
 
 python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
   - "3.5"
+  - "3.6"
 
 before_script:
   - pip install -U pip wheel tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ sudo: false
 cache: pip
 
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 before_script:
   - pip install -U pip wheel tox

--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,12 @@ setup(
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35
+envlist = py27, py33, py34, py35, py36
 
 [testenv]
 changedir = tests


### PR DESCRIPTION
 `securesystemslib` officially supports Python 2.7, 3.3, 3.4, 3.5, and 3.6.

It appears that we cannot currently run CI tests under Python 3.3 (interpreter not found) and Python 3.5 due to issues with Travis.  For now, this pull request ensures testing under Python versions 2.7, 3.4, and 3.6.

We should enable testing under Python 3.5 and possibly 3.3 (it is nearing its End of Life) once Travis resolves the current problems with Python interpreters.