### PR TITLE
Fix requirements.txt issue #69

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,6 @@
+cryptography
+pynacl
+tox
+coverage
+coveralls
+six

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,8 @@
 --editable .
 
-tox==2.9.1
 cryptography==2.1.1
 pynacl==1.1.2
+six==1.11.0
+tox==2.9.1
+coveralls==1.2.0
+coverage==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 cryptography
 pynacl
-tox
-coverage
-coveralls
+six

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['six', 'cryptography>=2.0.3', 'pynacl>=0.2.3'],
+  install_requires = ['six>=1.11.0', 'cryptography>=2.0.3', 'pynacl>=0.2.3'],
   packages = find_packages(exclude=['tests']),
   scripts = []
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,6 @@ commands =
     coverage report -m --fail-under 100
 
 deps =
-    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/ci-requirements.txt
 
 install_command = pip install --pre {opts} {packages}


### PR DESCRIPTION
**Fixes issue #**: #69 

**Description of the changes being introduced by the pull request**:

The `requirements.txt` file can be used with pip to install dependencies needed to run `securesystemslib`, but it contains testing-related dependencies.   Edit the `requirements.tx` file and others as follows:

* Remove testing-related dependencies from requirements.txt
  requirements.txt should only contain dependencies required to run securesystemslib.

* Add `ci-requirements.txt` file for continuous integration/Travis

* Use `ci-requirements.txt` in tox.ini
  Travis is set up to use tox to install and initiate testing.  Set tox.ini to use ci-requirements.txt instead of 
  requirements.txt.  The latter can be used by users to install dependencies that are only needed to run 
  securesystemslib.

* Add `six` to `setup.py`
  The 'six' dependency is needed for Python 2+3 compatibility.

* Add missing dev dependencies
  six is needed for Python 2+3 compatibility
  tox, coveralls, coverage are needed for testing and continuous integration



**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


