### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 changedir = tests


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

'cryptography' [version 2.0 officially dropped support for Python 3.3](https://pyup.io/changelogs/cryptography/#2.0).  Our Travis build is not affected by this backwards-incompatible change because we temporarily disabled Travis testing under Python 3.3.  See issue #71.

This pull request removes support for Python 3.3 by excluding it from `setup.py` and `tox.ini`.  The implementation of Issue #71 should exclude Python 3.3 from the Travis configuration file.  





**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


