### PR TITLE
Revise prompts

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -4,3 +4,4 @@ tox
 coverage
 coveralls
 six
+colorama

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ six==1.11.0
 tox==2.9.1
 coveralls==1.2.0
 coverage==4.4.2
+colorama==0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cryptography
 pynacl
 six
+colorama

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -48,6 +48,8 @@ import securesystemslib.keys
 
 import six
 
+from colorama import Fore
+
 # See 'log.py' to learn how logging is handled in securesystemslib.
 logger = logging.getLogger('securesystemslib_interface')
 
@@ -152,8 +154,13 @@ def generate_and_write_rsa_keypair(filepath, bits=DEFAULT_RSA_KEY_BITS,
 
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
-    message = 'Enter a password for the RSA key file: '
-    password = _get_password(message, confirm=True)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the encrypted RSA'
+        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
@@ -239,8 +246,13 @@ def import_rsa_privatekey_from_file(filepath, password=None,
   # Password confirmation disabled here, which should ideally happen only
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
-    message = 'Enter a password for the encrypted RSA file: '
-    password = _get_password(message, confirm=False)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the encrypted RSA'
+        ' file (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
@@ -358,8 +370,13 @@ def generate_and_write_ed25519_keypair(filepath, password=None):
 
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
-    message = 'Enter a password for the Ed25519 key: '
-    password = _get_password(message, confirm=True)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the Ed25519'
+        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
@@ -497,8 +514,13 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
   # Password confirmation disabled here, which should ideally happen only
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
-    message = 'Enter a password for the encrypted Ed25519 key: '
-    password = _get_password(message, confirm=False)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the encrypted Ed25519'
+        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
@@ -574,8 +596,13 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
 
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
-    message = 'Enter a password for the ECDSA key: '
-    password = _get_password(message, confirm=True)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the ECDSA'
+        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
@@ -712,8 +739,13 @@ def import_ecdsa_privatekey_from_file(filepath, password=None):
   # Password confirmation disabled here, which should ideally happen only
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
-    message = 'Enter a password for the encrypted ECDSA key: '
-    password = _get_password(message, confirm=False)
+
+    # Make sure the prompt for the password specifies the relative path of
+    # 'filepath', to prevent unnessary leakage of a sensitive key path.
+    relative_path = os.path.relpath(filepath)
+    password = _get_password('Enter a password for the encrypted ECDSA'
+        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        confirm=False)
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -157,7 +157,7 @@ def generate_and_write_rsa_keypair(filepath, bits=DEFAULT_RSA_KEY_BITS,
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the encrypted RSA'
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
@@ -249,7 +249,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the encrypted RSA'
         ' file (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
@@ -373,7 +373,7 @@ def generate_and_write_ed25519_keypair(filepath, password=None):
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the Ed25519'
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
@@ -517,7 +517,7 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the encrypted Ed25519'
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
@@ -599,7 +599,7 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the ECDSA'
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
@@ -742,7 +742,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None):
 
     # Make sure the prompt for the password specifies the relative path of
     # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.relpath(filepath)
+    relative_path = os.path.basename(filepath)
     password = _get_password('Enter a password for the encrypted ECDSA'
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['six>=1.11.0', 'cryptography>=2.1.3', 'pynacl>=1.2.0', 'colorama>=0.3.9],
+  install_requires = ['six>=1.11.0', 'cryptography>=2.1.3', 'pynacl>=1.2.0', 'colorama>=0.3.9'],
   packages = find_packages(exclude=['tests']),
   scripts = []
 )

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['six>=1.11.0', 'cryptography>=2.1.3', 'pynacl>=1.2.0'],
+  install_requires = ['six>=1.11.0', 'cryptography>=2.1.3', 'pynacl>=1.2.0', 'colorama>=0.3.9],
   packages = find_packages(exclude=['tests']),
   scripts = []
 )


### PR DESCRIPTION
**Fixes issue #**:

Addresses https://github.com/theupdateframework/tuf/issues/568.

**Description of the changes being introduced by the pull request**:

This pull request makes sure that a prompt for a key file specifies its basename.  The basename is
also colorized to improve readability.

Note: The `colorama` dependency should be available in debian installations via `python-colorama`.

<img width="855" alt="screen shot 2018-01-05 at 5 19 32 pm" src="https://user-images.githubusercontent.com/3520883/34631199-51114ab2-f23d-11e7-9d03-c2b8fccbdf7b.png">


\cc @trishankatdatadog @lukpueh @SantiagoTorres

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>

  