### PR TITLE
Use KEYID as default filename: Fix issue#573

### DIFF
--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -382,7 +382,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
     The 'filepath' of the written key.
   """
 
-  # Generate a new Ed25519 key object and encrypt it.
+  # Generate a new Ed25519 key object.
   ed25519_key = securesystemslib.keys.generate_ed25519_key()
 
   if not filepath:
@@ -585,21 +585,26 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
 
 
 
-def generate_and_write_ecdsa_keypair(filepath, password=None):
+def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   """
   <Purpose>
-    Generate an ECDSA key file, create an encrypted key (using 'password' as
-    the pass phrase), and store it in 'filepath'.  The public key portion of
-    the generated ECDSA key is stored in <'filepath'>.pub.  The 'cryptography'
-    library currently supported.  The private key is encrypted according to
-    'cryptography's approach: "Encrypt using the best available encryption for
-    a given key's backend. This is a curated encryption choice and the
-    algorithm may change over time."
+    Generate an ECDSA keypair, where the encrypted key (using 'password' as the
+    passphrase) is saved to <'filepath'>.  The public key portion of the
+    generated ECDSA key is saved to <'filepath'>.pub.  If the filepath is not
+    given, the KEYID is used as the filename and the keypair saved to the
+    current working directory.
+
+    The 'cryptography' library currently supported.  The private key is
+    encrypted according to 'cryptography's approach: "Encrypt using the best
+    available encryption for a given key's backend. This is a curated
+    encryption choice and the algorithm may change over time."
 
   <Arguments>
     filepath:
       The public and private key files are saved to <filepath>.pub and
-      <filepath>, respectively.
+      <filepath>, respectively.  If the filepath is not given, the public and
+      private keys are saved to the current working directory as <KEYID>.pub
+      and <KEYID>.  KEYID is the generated key's KEYID.
 
     password:
       The password, or passphrase, to encrypt the private portion of the
@@ -616,8 +621,19 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
     Writes key files to '<filepath>' and '<filepath>.pub'.
 
   <Returns>
-    None.
+    The 'filepath' of the written key.
   """
+
+  # Generate a new ECDSA key object.  The 'cryptography' library is currently
+  # supported and performs the actual cryptographic operations.
+  ecdsa_key = securesystemslib.keys.generate_ecdsa_key()
+
+  if not filepath:
+    filepath = os.path.join(os.getcwd(), ecdsa_key['keyid'])
+
+  else:
+    logger.debug('The filepath has been specified.  Not using the key\'s'
+        ' KEYID as the default filepath.')
 
   # Does 'filepath' have the correct format?
   # Ensure the arguments have the appropriate number of objects and object
@@ -635,25 +651,11 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
         ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
         confirm=False)
 
+  else:
+    logger.debug('The password has been specified.  Not prompting for one')
+
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
-
-  # Generate a new ECDSA key object and encrypt it.  The 'cryptography' library
-  # is currently supported and performs the actual cryptographic routine.
-  # Raise 'securesystemslib.exceptions.CryptoError' if 'ed25519_key' cannot be
-  # encrypted.
-  ecdsa_key = securesystemslib.keys.generate_ecdsa_key()
-  encrypted_key = securesystemslib.keys.encrypt_key(ecdsa_key, password)
-
-  # ECDSA public key file contents in metadata format (i.e., does not include
-  # the keyid portion).
-  keytype = ecdsa_key['keytype']
-  keyval = ecdsa_key['keyval']
-  scheme = ecdsa_key['scheme']
-
-  ecdsakey_metadata_format = \
-    securesystemslib.keys.format_keyval_to_metadata(keytype, scheme,
-        keyval, private=False)
 
   # Write the public key, conformant to 'securesystemslib.formats.KEY_SCHEMA',
   # to '<filepath>.pub'.
@@ -662,6 +664,15 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
   # Create a tempororary file, write the contents of the public key, and move
   # to final destination.
   file_object = securesystemslib.util.TempFile()
+
+  # Generate the ECDSA public key file contents in metadata format (i.e., does
+  # not include the keyid portion).
+  keytype = ecdsa_key['keytype']
+  keyval = ecdsa_key['keyval']
+  scheme = ecdsa_key['scheme']
+  ecdsakey_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
+      keytype, scheme, keyval, private=False)
+
   file_object.write(json.dumps(ecdsakey_metadata_format).encode('utf-8'))
 
   # The temporary file is closed after the final move.
@@ -670,9 +681,13 @@ def generate_and_write_ecdsa_keypair(filepath, password=None):
   # Write the encrypted key string, conformant to
   # 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA', to '<filepath>'.
   file_object = securesystemslib.util.TempFile()
+  # Raise 'securesystemslib.exceptions.CryptoError' if 'ecdsa_key' cannot be
+  # encrypted.
+  encrypted_key = securesystemslib.keys.encrypt_key(ecdsa_key, password)
   file_object.write(encrypted_key.encode('utf-8'))
   file_object.move(filepath)
 
+  return filepath
 
 
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -170,11 +170,12 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the encrypted RSA'
-        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' key (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   else:
@@ -261,11 +262,12 @@ def import_rsa_privatekey_from_file(filepath, password=None,
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the encrypted RSA'
-        ' file (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' file (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   # Does 'password' have the correct format?
@@ -401,11 +403,12 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the Ed25519'
-        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' key (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   else:
@@ -546,11 +549,12 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the encrypted Ed25519'
-        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' key (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   # Does 'password' have the correct format?
@@ -644,11 +648,12 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   # If the caller does not provide a password argument, prompt for one.
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the ECDSA'
-        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' key (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   else:
@@ -786,11 +791,12 @@ def import_ecdsa_privatekey_from_file(filepath, password=None):
   # when creating encrypted key files (i.e., improve usability).
   if password is None: # pragma: no cover
 
-    # Make sure the prompt for the password specifies the relative path of
-    # 'filepath', to prevent unnessary leakage of a sensitive key path.
-    relative_path = os.path.basename(filepath)
+    # It is safe to specify the full path of 'filepath' in the prompt and not
+    # worry about leaking sensitive information about the key's location.
+    # However, care should be taken when including the full path in exceptions
+    # and log files.
     password = _get_password('Enter a password for the encrypted ECDSA'
-        ' key (' + Fore.RED + relative_path + Fore.RESET + '): ',
+        ' key (' + Fore.RED + filepath + Fore.RESET + '): ',
         confirm=False)
 
   # Does 'password' have the correct format?

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -420,7 +420,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
 
-  # Create a tempororary file, write the contents of the public key, and move
+  # Create a temporary file, write the contents of the public key, and move
   # to final destination.
   file_object = securesystemslib.util.TempFile()
 
@@ -668,7 +668,7 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
 
-  # Create a tempororary file, write the contents of the public key, and move
+  # Create a temporary file, write the contents of the public key, and move
   # to final destination.
   file_object = securesystemslib.util.TempFile()
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -191,16 +191,15 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   else:
     logger.debug('An empty password was given.  Not encrypting the private key.')
 
-  # Write public key (i.e., 'public', which is in PEM format) to
-  # '<filepath>.pub'.  If the parent directory of filepath does not exist,
+  # If the parent directory of filepath does not exist,
   # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
 
-  # Create a tempororary file, write the contents of the public key, and move
-  # to final destination.
+  # Write the public key (i.e., 'public', which is in PEM format) to
+  # '<filepath>.pub'.  (1) Create a temporary file, (2) write the contents of
+  # the public key, and (3) move to final destination.
   file_object = securesystemslib.util.TempFile()
   file_object.write(public.encode('utf-8'))
-
   # The temporary file is closed after the final move.
   file_object.move(filepath + '.pub')
 
@@ -417,8 +416,8 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
 
-  # Write the public key, conformant to 'securesystemslib.formats.KEY_SCHEMA',
-  # to '<filepath>.pub'.
+  # If the parent directory of filepath does not exist,
+  # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
 
   # Create a tempororary file, write the contents of the public key, and move
@@ -435,6 +434,9 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
 
   file_object.write(json.dumps(ed25519key_metadata_format).encode('utf-8'))
 
+  # Write the public key (i.e., 'public', which is in PEM format) to
+  # '<filepath>.pub'.  (1) Create a temporary file, (2) write the contents of
+  # the public key, and (3) move to final destination.
   # The temporary file is closed after the final move.
   file_object.move(filepath + '.pub')
 
@@ -662,8 +664,8 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
 
-  # Write the public key, conformant to 'securesystemslib.formats.KEY_SCHEMA',
-  # to '<filepath>.pub'.
+  # If the parent directory of filepath does not exist,
+  # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
 
   # Create a tempororary file, write the contents of the public key, and move
@@ -680,7 +682,9 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
 
   file_object.write(json.dumps(ecdsakey_metadata_format).encode('utf-8'))
 
-  # The temporary file is closed after the final move.
+  # Write the public key (i.e., 'public', which is in PEM format) to
+  # '<filepath>.pub'.  (1) Create a temporary file, (2) write the contents of
+  # the public key, and (3) move to final destination.
   file_object.move(filepath + '.pub')
 
   # Write the encrypted key string, conformant to

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -600,7 +600,7 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
     given, the KEYID is used as the filename and the keypair saved to the
     current working directory.
 
-    The 'cryptography' library currently supported.  The private key is
+    The 'cryptography' library is currently supported.  The private key is
     encrypted according to 'cryptography's approach: "Encrypt using the best
     available encryption for a given key's backend. This is a curated
     encryption choice and the algorithm may change over time."

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -147,8 +147,6 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   """
 
   # Does 'bits' have the correct format?
-  # This check ensures arguments have the appropriate number of
-  # objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match(bits)
 
@@ -642,8 +640,6 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
         ' KEYID as the default filepath.')
 
   # Does 'filepath' have the correct format?
-  # Ensure the arguments have the appropriate number of objects and object
-  # types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -192,6 +192,12 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
   # securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match().
   public, private = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private(bits)
 
+  # When loading in PEM keys, extract_pem() is called, which strips any
+  # leading or trailing new line characters. Do the same here before generating
+  # the keyid.
+  public =  extract_pem(public, private_pem=False)
+  private = extract_pem(private, private_pem=True)
+
   # Generate the keyid of the RSA key.  Note: The private key material is
   # not included in the generation of the 'keyid' identifier.
   key_value = {'public': public,

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -226,7 +226,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
   public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
       format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
-  return public_pem.decode(), private_pem.decode()
+  return public_pem.decode('utf-8'), private_pem.decode('utf-8')
 
 
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -249,7 +249,7 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Test for a default filepath.  If 'filepath' is not given, the key's
     # KEYID is used as the filename.  The key is saved to the current working
     # directory.
-    default_keypath = interface.generate_and_write_rsa_keypair(password='pw')
+    default_keypath = interface.generate_and_write_ed25519_keypair(password='pw')
     self.assertTrue(os.path.exists(default_keypath))
     self.assertTrue(os.path.exists(default_keypath + '.pub'))
     os.remove(default_keypath)
@@ -380,9 +380,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
     test_keypath = os.path.join(temporary_directory, 'ecdsa_key')
 
-    interface.generate_and_write_ecdsa_keypair(test_keypath, password='pw')
+    returned_path = interface.generate_and_write_ecdsa_keypair(test_keypath, password='pw')
     self.assertTrue(os.path.exists(test_keypath))
     self.assertTrue(os.path.exists(test_keypath + '.pub'))
+    self.assertEqual(returned_path, test_keypath)
 
     # Ensure the generated key files are importable.
     imported_pubkey = \
@@ -393,6 +394,14 @@ class TestInterfaceFunctions(unittest.TestCase):
       interface.import_ecdsa_privatekey_from_file(test_keypath, 'pw')
     self.assertTrue(securesystemslib.formats.ECDSAKEY_SCHEMA.matches(imported_privkey))
 
+    # Test for a default filepath.  If 'filepath' is not given, the key's
+    # KEYID is used as the filename.  The key is saved to the current working
+    # directory.
+    default_keypath = interface.generate_and_write_ecdsa_keypair(password='pw')
+    self.assertTrue(os.path.exists(default_keypath))
+    self.assertTrue(os.path.exists(default_keypath + '.pub'))
+    os.remove(default_keypath)
+    os.remove(default_keypath + '.pub')
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -231,9 +231,11 @@ class TestInterfaceFunctions(unittest.TestCase):
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
     test_keypath = os.path.join(temporary_directory, 'ed25519_key')
 
-    interface.generate_and_write_ed25519_keypair(test_keypath, password='pw')
+    returned_path = interface.generate_and_write_ed25519_keypair(
+        test_keypath, password='pw')
     self.assertTrue(os.path.exists(test_keypath))
     self.assertTrue(os.path.exists(test_keypath + '.pub'))
+    self.assertEqual(returned_path, test_keypath)
 
     # Ensure the generated key files are importable.
     imported_pubkey = \
@@ -244,6 +246,14 @@ class TestInterfaceFunctions(unittest.TestCase):
       interface.import_ed25519_privatekey_from_file(test_keypath, 'pw')
     self.assertTrue(securesystemslib.formats.ED25519KEY_SCHEMA.matches(imported_privkey))
 
+    # Test for a default filepath.  If 'filepath' is not given, the key's
+    # KEYID is used as the filename.  The key is saved to the current working
+    # directory.
+    default_keypath = interface.generate_and_write_rsa_keypair(password='pw')
+    self.assertTrue(os.path.exists(default_keypath))
+    self.assertTrue(os.path.exists(default_keypath + '.pub'))
+    os.remove(default_keypath)
+    os.remove(default_keypath + '.pub')
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,
@@ -364,7 +374,7 @@ class TestInterfaceFunctions(unittest.TestCase):
 
 
 
-  def test_generate_and_write_ed25519_keypair(self):
+  def test_generate_and_write_ecdsa_keypair(self):
 
     # Test normal case.
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -135,6 +135,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     default_keypath = interface.generate_and_write_rsa_keypair(password='pw')
     self.assertTrue(os.path.exists(default_keypath))
     self.assertTrue(os.path.exists(default_keypath + '.pub'))
+
+    written_key = interface.import_rsa_publickey_from_file(default_keypath + '.pub')
+    self.assertEqual(written_key['keyid'], os.path.basename(default_keypath))
+
     os.remove(default_keypath)
     os.remove(default_keypath + '.pub')
 
@@ -252,8 +256,13 @@ class TestInterfaceFunctions(unittest.TestCase):
     default_keypath = interface.generate_and_write_ed25519_keypair(password='pw')
     self.assertTrue(os.path.exists(default_keypath))
     self.assertTrue(os.path.exists(default_keypath + '.pub'))
+
+    written_key = interface.import_ed25519_publickey_from_file(default_keypath + '.pub')
+    self.assertEqual(written_key['keyid'], os.path.basename(default_keypath))
+
     os.remove(default_keypath)
     os.remove(default_keypath + '.pub')
+
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,
@@ -400,6 +409,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     default_keypath = interface.generate_and_write_ecdsa_keypair(password='pw')
     self.assertTrue(os.path.exists(default_keypath))
     self.assertTrue(os.path.exists(default_keypath + '.pub'))
+
+    written_key = interface.import_ecdsa_publickey_from_file(default_keypath + '.pub')
+    self.assertEqual(written_key['keyid'], os.path.basename(default_keypath))
+
     os.remove(default_keypath)
     os.remove(default_keypath + '.pub')
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -93,9 +93,11 @@ class TestInterfaceFunctions(unittest.TestCase):
     test_keypath_unencrypted = os.path.join(temporary_directory,
         'rsa_key_unencrypted')
 
-    interface.generate_and_write_rsa_keypair(test_keypath, password='pw')
+    returned_path = interface.generate_and_write_rsa_keypair(test_keypath,
+        password='pw')
     self.assertTrue(os.path.exists(test_keypath))
     self.assertTrue(os.path.exists(test_keypath + '.pub'))
+    self.assertEqual(returned_path, test_keypath)
 
     # If an empty string is given for 'password', the private key file
     # is written to disk unencrypted.
@@ -127,6 +129,14 @@ class TestInterfaceFunctions(unittest.TestCase):
     self.assertTrue(os.path.exists(test_keypath))
     self.assertTrue(os.path.exists(test_keypath + '.pub'))
 
+    # Test for a default filepath.  If 'filepath' is not given, the key's
+    # KEYID is used as the filename.  The key is saved to the current working
+    # directory.
+    default_keypath = interface.generate_and_write_rsa_keypair(password='pw')
+    self.assertTrue(os.path.exists(default_keypath))
+    self.assertTrue(os.path.exists(default_keypath + '.pub'))
+    os.remove(default_keypath)
+    os.remove(default_keypath + '.pub')
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,


### PR DESCRIPTION
**Fixes issue #**:

Addresses https://github.com/theupdateframework/tuf/issues/573.

**Description of the changes being introduced by the pull request**:

This pull request modifies the `generate_and_write_XXX_keypair()` functions to use the KEYID of generated keys as the default filename (if the 'filepath' argument is not given).

For example:

<img width="1179" alt="screen shot 2018-01-11 at 4 44 35 pm" src="https://user-images.githubusercontent.com/3520883/34849187-867aa124-f6ef-11e7-95ba-5adddd8ae28b.png">

Note: This pull request also modifies `generate_rsa_key()` so that leading and trailing newline characters in PEMs are stripped and matches the format of imported PEM keys (which are always stripped of leading and trailing new line characters.  This change is made so that consistent keyids are generated.  The other generate_ecdsa_key() function already follows this behavior. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>
