### PR TITLE
Add prompt argument to import RSA private key function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,8 @@ Import RSA Keys
     # Import an existing private key.  If your private key is encrypted,
     # which it should be, you either have to pass a 'password' or enter one
     # on the prompt.
+    >>> private_rsa_key1 = import_rsa_privatekey_from_file("rsa_key1", password='some passphrase")
+    OR:
     >>> private_rsa_key1 = import_rsa_privatekey_from_file("rsa_key1", prompt=True)
     Enter a password for the encrypted RSA key:
 

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,10 @@ Import RSA Keys
     # Import an existing public key.
     >>> public_rsa_key1 = import_rsa_publickey_from_file("rsa_key1.pub")
 
-    # Import an existing private key.  Importing a private key requires a
-    # password, whereas importing a public key does not.
-    >>> private_rsa_key1 = import_rsa_privatekey_from_file("rsa_key1")
+    # Import an existing private key.  If your private key is encrypted,
+    # which it should be, you either have to pass a 'password' or enter one
+    # on the prompt.
+    >>> private_rsa_key1 = import_rsa_privatekey_from_file("rsa_key1", prompt=True)
     Enter a password for the encrypted RSA key:
 
 **import_rsa_privatekey_from_file()** raises a

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -5,3 +5,4 @@ coverage
 coveralls
 six
 colorama
+mock; python_version < '3.3'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ tox==2.9.1
 coveralls==1.2.0
 coverage==4.5.1
 colorama==0.3.9
+mock==2.0.0; python_version < '3.3'

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -237,11 +237,20 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
 
 
 def import_rsa_privatekey_from_file(filepath, password=None,
-    scheme='rsassa-pss-sha256'):
+    scheme='rsassa-pss-sha256', prompt=False):
   """
   <Purpose>
-    Import the encrypted PEM file in 'filepath', decrypt it, and return the key
-    object in 'securesystemslib.formats.RSAKEY_SCHEMA' format.
+    Import the PEM file in 'filepath' containing the private key.
+
+    If password is passed use passed password for decryption.
+    If prompt is True use entered password for decryption.
+    If no password is passed or entered, or if the entered password is an empty
+    string, omit decryption.
+
+    Passing and prompting for a passowrd is not possible.
+
+    The returned key is an object in the
+    'securesystemslib.formats.RSAKEY_SCHEMA' format.
 
   <Arguments>
     filepath:
@@ -254,18 +263,35 @@ def import_rsa_privatekey_from_file(filepath, password=None,
     scheme:
       The signature scheme used by the imported key.
 
+    prompt:
+      If True the user is prompted for a passphrase to decrypt 'filepath'.
+      Default is False.
+
   <Exceptions>
+    ValueError, if 'password' is passed and 'prompt' is True.
+
+    ValueError, if 'password' is passed and it is an empty string.
+
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
 
-    securesystemslib.exceptions.CryptoError, if 'filepath' is not a valid
-    encrypted key file.
+    securesystemslib.exceptions.FormatError, if the entered password is
+    improperly formatted.
+
+    IOError, if 'filepath' can't be loaded.
+
+    securesystemslib.exceptions.CryptoError, if a password is available
+    and 'filepath' is not a valid key file encrypted using that password.
+
+    securesystemslib.exceptions.CryptoError, if no password is available
+    and 'filepath' is not a valid non-encrypted key file.
 
   <Side Effects>
-    The contents of 'filepath' is read, decrypted, and the key stored.
+    The contents of 'filepath' are read, optionally decrypted, and returned.
 
   <Returns>
     An RSA key object, conformant to 'securesystemslib.formats.RSAKEY_SCHEMA'.
+
   """
 
   # Does 'filepath' have the correct format?
@@ -277,37 +303,51 @@ def import_rsa_privatekey_from_file(filepath, password=None,
   # Is 'scheme' properly formatted?
   securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
-  # If the caller does not provide a password argument, prompt for one.
-  # Password confirmation disabled here, which should ideally happen only
-  # when creating encrypted key files (i.e., improve usability).
-  if password is None: # pragma: no cover
+  if password and prompt:
+    raise ValueError("Passing 'password' and 'prompt' True is not allowed.")
 
+  # If 'password' was passed check format and that it is not empty.
+  if password is not None:
+    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+
+    # TODO: PASSWORD_SCHEMA should be securesystemslib.schema.AnyString(min=1)
+    if not len(password):
+      raise ValueError('Password must be 1 or more charcters')
+
+  elif prompt: # pragma: no cover
+    # Password confirmation disabled here, which should ideally happen only
+    # when creating encrypted key files (i.e., improve usability).
     # It is safe to specify the full path of 'filepath' in the prompt and not
     # worry about leaking sensitive information about the key's location.
     # However, care should be taken when including the full path in exceptions
     # and log files.
-    password = get_password('Enter a password for the encrypted RSA'
-        ' file (' + Fore.RED + filepath + Fore.RESET + '): ',
-        confirm=False)
+    # NOTE: A user who gets prompted for a password, can only signal that the
+    # key is not encrypted by entering no password in the prompt, as opposed
+    # to a programmer who can call the function with or without a 'password'.
+    # Hence, we treat an empty password here, as if no 'password' was passed.
+    password = get_password('Enter a password for an encrypted RSA'
+        ' file \'' + Fore.RED + filepath + Fore.RESET + '\': ',
+        confirm=False) or None
 
-  # Does 'password' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  if password is not None:
+    # This check will not fail, because a mal-formatted passed password fails
+    # above and an entered password will always be a string (see get_password)
+    # However, we include it in case PASSWORD_SCHEMA or get_password changes.
+    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
 
-  # Read the contents of 'filepath' that should be an encrypted PEM.
+  else:
+    logger.debug('No password was given. Attempting to import an'
+        ' unencrypted file.')
+
+  # Read the contents of 'filepath' that should be a PEM formatted private key.
   with open(filepath, 'rb') as file_object:
-    pem = file_object.read().decode('utf-8')
+    pem_key = file_object.read().decode('utf-8')
 
   # Convert 'pem_key' to 'securesystemslib.formats.RSAKEY_SCHEMA' format.
   # Raise 'securesystemslib.exceptions.CryptoError' if 'pem_key' is invalid.
-  if len(password):
-    rsa_key = securesystemslib.keys.import_rsakey_from_private_pem(pem,
-        scheme, password)
-
-  else:
-    logger.debug('An empty password was given.  Attempting to import an'
-        ' unencrypted file.')
-    rsa_key = securesystemslib.keys.import_rsakey_from_private_pem(pem,
-    scheme, password=None)
+  # If 'password' is None decryption will be omitted.
+  rsa_key = securesystemslib.keys.import_rsakey_from_private_pem(pem_key,
+      scheme, password)
 
   return rsa_key
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -314,7 +314,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
     if not len(password):
       raise ValueError('Password must be 1 or more charcters')
 
-  elif prompt: # pragma: no cover
+  elif prompt:
     # Password confirmation disabled here, which should ideally happen only
     # when creating encrypted key files (i.e., improve usability).
     # It is safe to specify the full path of 'filepath' in the prompt and not

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -247,7 +247,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
     If no password is passed or entered, or if the entered password is an empty
     string, omit decryption.
 
-    Passing and prompting for a passowrd is not possible.
+    Passing and prompting for a password is not possible.
 
     The returned key is an object in the
     'securesystemslib.formats.RSAKEY_SCHEMA' format.

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -14,7 +14,7 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  Provide an interface to the cryptography funtions available in
+  Provide an interface to the cryptography functions available in
   securesystemslib.  The interface can be used with the Python interpreter in
   interactive mode, or imported directly into a Python module.  See
   'securesystemslib/README' for the complete guide to using 'interface.py'.
@@ -244,10 +244,10 @@ def import_rsa_privatekey_from_file(filepath, password=None,
 
     If password is passed use passed password for decryption.
     If prompt is True use entered password for decryption.
-    If no password is passed or entered, or if the entered password is an empty
-    string, omit decryption.
-
-    Passing and prompting for a password is not possible.
+    If no password is passed and either prompt is False or if the password
+    entered at the prompt is an empty string, omit decryption, treating the
+    key as if it is not encrypted.
+    If password is passed and prompt is True, an error is raised. (See below.)
 
     The returned key is an object in the
     'securesystemslib.formats.RSAKEY_SCHEMA' format.

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -312,7 +312,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
 
     # TODO: PASSWORD_SCHEMA should be securesystemslib.schema.AnyString(min=1)
     if not len(password):
-      raise ValueError('Password must be 1 or more charcters')
+      raise ValueError('Password must be 1 or more characters')
 
   elif prompt:
     # Password confirmation disabled here, which should ideally happen only

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -116,9 +116,8 @@ class TestInterfaceFunctions(unittest.TestCase):
       'pw')
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
-    # Try to import the unencrypted key file.
-    imported_privkey = interface.import_rsa_privatekey_from_file(test_keypath_unencrypted,
-      '')
+    # Try to import the unencrypted key file, by not passing a password
+    interface.import_rsa_privatekey_from_file(test_keypath_unencrypted)
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
     # Custom 'bits' argument.
@@ -167,7 +166,7 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Load one of the pre-generated key files from
     # 'securesystemslib/tests/repository_data'.  'password' unlocks the
     # pre-generated key files.
-    key_filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 
+    key_filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),
         'data', 'keystore', 'rsa_key')
     self.assertTrue(os.path.exists(key_filepath))
 
@@ -176,10 +175,22 @@ class TestInterfaceFunctions(unittest.TestCase):
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_rsa_key))
 
 
-    # Test improperly formatted argument.
+    # Test improperly formatted 'filepath' argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,
         interface.import_rsa_privatekey_from_file, 3, 'pw')
 
+    # Test improperly formatted 'password' argument.
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      interface.import_rsa_privatekey_from_file(key_filepath, 123)
+
+    # Test unallowed empty 'password'
+    with self.assertRaises(ValueError):
+      interface.import_rsa_privatekey_from_file(key_filepath, '')
+
+    # Test unallowed passing 'prompt' and 'password'
+    with self.assertRaises(ValueError):
+      interface.import_rsa_privatekey_from_file(key_filepath,
+          password='pw', prompt=True)
 
     # Test invalid argument.
     # Non-existent key file.

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -42,6 +42,13 @@ if sys.version_info >= (2, 7):
 else:
   import unittest2 as unittest
 
+# Use external backport 'mock' on versions under 3.3
+if sys.version_info >= (3, 3):
+  import unittest.mock as mock
+
+else:
+  import mock
+
 import securesystemslib.formats
 import securesystemslib.formats
 import securesystemslib.hash
@@ -120,6 +127,14 @@ class TestInterfaceFunctions(unittest.TestCase):
     interface.import_rsa_privatekey_from_file(test_keypath_unencrypted)
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
+    # Try to import the unencrypted key file, by entering an empty password
+    with mock.patch('securesystemslib.interface.get_password',
+        return_value=''):
+      interface.import_rsa_privatekey_from_file(test_keypath_unencrypted,
+          prompt=True)
+      self.assertTrue(
+          securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
+
     # Fail importing unencrypted key passing a password
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
       interface.import_rsa_privatekey_from_file(test_keypath_unencrypted, 'pw')
@@ -182,6 +197,13 @@ class TestInterfaceFunctions(unittest.TestCase):
         key_filepath, 'password')
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_rsa_key))
 
+    # Test load encrypted key prompt for password
+    with mock.patch('securesystemslib.interface.get_password',
+        return_value='password'):
+      imported_rsa_key = interface.import_rsa_privatekey_from_file(
+          key_filepath, prompt=True)
+      self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(
+          imported_rsa_key))
 
     # Test improperly formatted 'filepath' argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -120,6 +120,14 @@ class TestInterfaceFunctions(unittest.TestCase):
     interface.import_rsa_privatekey_from_file(test_keypath_unencrypted)
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
+    # Fail importing unencrypted key passing a password
+    with self.assertRaises(securesystemslib.exceptions.CryptoError):
+      interface.import_rsa_privatekey_from_file(test_keypath_unencrypted, 'pw')
+
+    # Fail importing encrypted key passing no password
+    with self.assertRaises(securesystemslib.exceptions.CryptoError):
+      interface.import_rsa_privatekey_from_file(test_keypath)
+
     # Custom 'bits' argument.
     os.remove(test_keypath)
     os.remove(test_keypath + '.pub')


### PR DESCRIPTION
**Fixes issue #**:
Fixes RSA part of #122 

**Description of the changes being introduced by the pull request**:
Add an optional boolean `prompt` argument to `interface.import_rsa_privatekey_from_file` and change the behavior of the function like so:

- If `password` is passed use passed `password` for decryption.
- If `prompt` is `True` use entered password for decryption.
- If no password is passed or entered, or if the entered password is an empty string, omit decryption.
- Passing and prompting for a password is not possible.


This PR further:
- adds `mock` as dev/ci requirement for supported Python versions <3.3, i.e. 2.7, to mock password prompts, and
- adopts and adds related unit tests.

See commit messages, code comments or secure-systems-lab/securesystemslib#122 for more details.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


