### PR TITLE
Upgrade dependencies and fix warnings

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 --editable .
 
-cryptography==2.1.4
+cryptography==2.2.1
 pynacl==1.2.1
 six==1.11.0
 tox==2.9.1
-coveralls==1.2.0
+coveralls==1.3.0
 coverage==4.5.1
 colorama==0.3.9

--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -225,9 +225,7 @@ def create_signature(public_key, private_key, data, scheme='ecdsa-sha2-nistp256'
       private_key = load_pem_private_key(private_key.encode('utf-8'),
         password=None, backend=default_backend())
 
-      signer = private_key.signer(ec.ECDSA(hashes.SHA256()))
-      signer.update(data)
-      signature = signer.finalize()
+      signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
 
     except TypeError as e:
       raise securesystemslib.exceptions.CryptoError('Could not create'
@@ -307,21 +305,13 @@ def verify_signature(public_key, scheme, signature, data):
   else:
     logger.debug('Loaded a valid ECDSA public key.')
 
-  try:
-    verifier = ecdsa_key.verifier(signature, ec.ECDSA(hashes.SHA256()))
-    verifier.update(data)
-
-  except TypeError as e:
-    raise securesystemslib.exceptions.FormatError('Invalid signature or'
-      ' data: ' + str(e))
-
   # verify() raises an 'InvalidSignature' exception if 'signature'
   # is invalid.
   try:
-    verifier.verify()
+    ecdsa_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
     return True
 
-  except cryptography.exceptions.InvalidSignature:
+  except (TypeError, cryptography.exceptions.InvalidSignature):
     return False
 
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['six>=1.11.0', 'cryptography>=2.1.3', 'pynacl>=1.2.0', 'colorama>=0.3.9'],
+  install_requires = ['six>=1.11.0', 'cryptography>=2.2.1', 'pynacl>=1.2.0', 'colorama>=0.3.9'],
   packages = find_packages(exclude=['tests', 'debian']),
   scripts = []
 )

--- a/tests/test_ecdsa_keys.py
+++ b/tests/test_ecdsa_keys.py
@@ -153,11 +153,6 @@ class TestECDSA_keys(unittest.TestCase):
         'bad_signature', data)
 
     # Check for invalid signature and data.
-    # Mismatched data.
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-      securesystemslib.ecdsa_keys.verify_signature, public, scheme,
-      signature, '123')
-
     self.assertEqual(False, securesystemslib.ecdsa_keys.verify_signature(public,
         scheme, signature, b'123'))
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request upgrades `cryptography` (2.1.4 -> 2.2.1) and `coveralls` (1.2.0 -> 1.3.0).

`cryptography` deprecated the use of `verifier()` and `signer()`, so this pull request also removes these calls in favor of their replacements, `verify()` and `sign()`, respectively.

I failed to notice these deprecation warnings because deprecation warnings are silenced under Python 2.7, by default.  These warnings should now be visible under my testing environment now that I've enabled Deprecation Warnings under Python 2.7 via `export PYTHONWARNINGS=d.`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


