### PR TITLE
Bump version to 0.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## securesystemslib v0.10.11
+
+* Replace deprecated `cryptography` methods.  signer() and verifier()
+  should be replaced with sign() and verify(), respectively.
+
+* Update dependencies.
+
 ## securesystemslib v0.10.10
 
 * Add get_password() to API.

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst') as file_object:
 
 setup(
   name = 'securesystemslib',
-  version = '0.10.10',
+  version = '0.10.11',
   description = 'A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU',
   long_description = long_description,
   author = 'https://www.updateframework.com',


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request bumps the version number 0.10.10 -> 0.10.11 prior to the new release (minor changes).  0.10.11 replaces deprecated `cryptography` methods, `signer()` and `verifier()`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz>