### PR TITLE
Bump version number (0.10.11 -> 0.11.0) and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## securesystemslib v0.11.0
+
+* Add `prompt` parameter to interface.import_rsa_privatekey_from_file() (pr #124).
+
+* Update dependencies
+
 ## securesystemslib v0.10.11
 
 * Replace deprecated `cryptography` methods.  signer() and verifier()

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst') as file_object:
 
 setup(
   name = 'securesystemslib',
-  version = '0.10.11',
+  version = '0.11.0',
   description = 'A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU',
   long_description = long_description,
   author = 'https://www.updateframework.com',


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request bumps the version (0.10.11 -> 0.11.0).

It is a backwards-incompatible change due to the [API change](https://github.com/secure-systems-lab/securesystemslib/pull/124) with `interface.import_rsa_privatekey_from_file(),` which now takes a `prompt` argument.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>