### PR TITLE
Convert Windows-style newline (\r\n) characters to Unix-style (\n)

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -198,9 +198,11 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
   public =  extract_pem(public, private_pem=False)
   private = extract_pem(private, private_pem=True)
 
-  # Generate the keyid of the RSA key.  Note: The private key material is
-  # not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public,
+  # Generate the keyid of the RSA key.  Note: The private key material is not
+  # included in the generation of the 'keyid' identifier.  Convert any '\r\n'
+  # (e.g., Windows) newline characters to '\n' so that a consistent keyid is
+  # generated.
+  key_value = {'public': public.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -278,7 +280,9 @@ def generate_ecdsa_key(scheme='ecdsa-sha2-nistp256'):
   # Generate the keyid of the Ed25519 key.  'key_value' corresponds to the
   # 'keyval' entry of the 'Ed25519KEY_SCHEMA' dictionary.  The private key
   # information is not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public,
+  # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
+  # consistent keyid is generated.
+  key_value = {'public': public.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -695,6 +699,7 @@ def create_signature(key_dict, data):
 
   if keytype == 'rsa':
     if scheme == 'rsassa-pss-sha256':
+      private = private.replace('\r\n', '\n')
       sig, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(private,
         data.encode('utf-8'), scheme)
 
@@ -963,7 +968,9 @@ def import_rsakey_from_private_pem(pem, scheme='rsassa-pss-sha256', password=Non
   # Generate the keyid of the RSA key.  'key_value' corresponds to the
   # 'keyval' entry of the 'RSAKEY_SCHEMA' dictionary.  The private key
   # information is not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public,
+  # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
+  # consistent keyid is generated.
+  key_value = {'public': public.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -1050,7 +1057,9 @@ def import_rsakey_from_public_pem(pem, scheme='rsassa-pss-sha256'):
   # Generate the keyid of the RSA key.  'key_value' corresponds to the
   # 'keyval' entry of the 'RSAKEY_SCHEMA' dictionary.  The private key
   # information is not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public_pem,
+  # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
+  # consistent keyid is generated.
+  key_value = {'public': public_pem.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -1127,13 +1136,14 @@ def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
   rsakey_dict = {}
   keytype = 'rsa'
 
-  # Generate the keyid of the RSA key.  'key_value' corresponds to the
-  # 'keyval' entry of the 'RSAKEY_SCHEMA' dictionary.  The private key
-  # information is not included in the generation of the 'keyid' identifier.
-  # If a PEM is found to contain a private key, the generated rsakey object
-  # should be returned above.  The following key object is for the case of a
-  # PEM with only a public key.
-  key_value = {'public': public_pem,
+  # Generate the keyid of the RSA key.  'key_value' corresponds to the 'keyval'
+  # entry of the 'RSAKEY_SCHEMA' dictionary.  The private key information is
+  # not included in the generation of the 'keyid' identifier.  If a PEM is
+  # found to contain a private key, the generated rsakey object should be
+  # returned above.  The following key object is for the case of a PEM with
+  # only a public key.  Convert any '\r\n' (e.g., Windows) newline characters
+  # to '\n' so that a consistent keyid is generated.
+  key_value = {'public': public_pem.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -1654,7 +1664,9 @@ def import_ecdsakey_from_private_pem(pem, scheme='ecdsa-sha2-nistp256', password
   # Generate the keyid of the ECDSA key.  'key_value' corresponds to the
   # 'keyval' entry of the 'ECDSAKEY_SCHEMA' dictionary.  The private key
   # information is not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public,
+  # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
+  # consistent keyid is generated.
+  key_value = {'public': public.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -1751,7 +1763,9 @@ def import_ecdsakey_from_public_pem(pem, scheme='ecdsa-sha2-nistp256'):
   # Generate the keyid of the ECDSA key.  'key_value' corresponds to the
   # 'keyval' entry of the 'ECDSAKEY_SCHEMA' dictionary.  The private key
   # information is not included in the generation of the 'keyid' identifier.
-  key_value = {'public': public_pem,
+  # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
+  # consistent keyid is generated.
+  key_value = {'public': public_pem.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 
@@ -1832,8 +1846,9 @@ def import_ecdsakey_from_pem(pem, scheme='ecdsa-sha2-nistp256'):
   # information is not included in the generation of the 'keyid' identifier.
   # If a PEM is found to contain a private key, the generated rsakey object
   # should be returned above.  The following key object is for the case of a
-  # PEM with only a public key.
-  key_value = {'public': public_pem,
+  # PEM with only a public key.  Convert any '\r\n' (e.g., Windows) newline
+  # characters to '\n' so that a consistent keyid is generated.
+  key_value = {'public': public_pem.replace('\r\n', '\n'),
                'private': ''}
   keyid = _get_keyid(keytype, scheme, key_value)
 


### PR DESCRIPTION
**Fixes issue #**:

Address https://github.com/theupdateframework/tuf/issues/709 and https://github.com/theupdateframework/tuf/issues/690.

**Description of the changes being introduced by the pull request**:

This pull request converts `\r\n` newline characters (in keys data) to `\n` so that consistent keyids are generated for public keys that differ only in the style of newline characters.

For instance, an RSA PEM string that is generated in Windows might contain `\r\n`  characters.  These newline characters would need to be read/written in a consistent manner so that the keyid of the PEM string matches the one generated on MacOS/Linux (which might treat load these newline characters as `\n`.

Before generating the keyid of public key data (e.g., RSA PEM string), this pull request applies `replace('\r\n', '\n)` to the string.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>