### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## securesystemslib v0.11.1
+
+* Convert `\r\n` newline characters to `\n`, so that the same KEYID is
+  generated for key data regardless of the newline style used (pr #146).
+
 ## securesystemslib v0.11.0
 
 * Add `prompt` parameter to interface.import_rsa_privatekey_from_file() (pr #124).

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst') as file_object:
 
 setup(
   name = 'securesystemslib',
-  version = '0.11.0',
+  version = '0.11.1',
   description = 'A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU',
   long_description = long_description,
   author = 'https://www.updateframework.com',


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request bumps the release version (0.11.0 -> 0.11.1).  This release is made to address unit tests failures in TUF that are caused by PEM data that contain `\r\n` characters, but which are treated as `\n` in MacOS/Linux and thus generate different KEYIDs for the otherwise same PEM.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>