### PR TITLE
No (en|de)cryption of ed25519 private keys when empty password

### DIFF
--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -645,10 +645,12 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False):
         ' file \'' + Fore.RED + filepath + Fore.RESET + '\': ',
         confirm=False) or None
 
-    with open(filepath, 'rb') as file_object:
-      jsons = file_object.read()
-      return securesystemslib.keys.\
-             import_ed25519key_from_private_json(jsons, password=password)
+  # Finally, regardless of password, try decrypting the key, if necessary.
+  # Otherwise, load it straight from the disk.
+  with open(filepath, 'rb') as file_object:
+    json_str = file_object.read()
+    return securesystemslib.keys.\
+           import_ed25519key_from_private_json(json_str, password=password)
 
 
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -472,10 +472,18 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
         confirm=True)
 
   else:
-    logger.debug('The password has been specified.  Not prompting for one')
+    logger.debug('The password has been specified. Not prompting for one.')
 
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+
+  # Encrypt the private key if 'password' is set.
+  if len(password):
+    ed25519_key = securesystemslib.keys.encrypt_key(ed25519_key, password)
+
+  else:
+    logger.debug('An empty password was given. '
+                 'Not encrypting the private key.')
 
   # If the parent directory of filepath does not exist,
   # create it (and all its parent directories, if necessary).
@@ -507,8 +515,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
 
   # Raise 'securesystemslib.exceptions.CryptoError' if 'ed25519_key' cannot be
   # encrypted.
-  encrypted_key = securesystemslib.keys.encrypt_key(ed25519_key, password)
-  file_object.write(encrypted_key.encode('utf-8'))
+  file_object.write(ed25519_key.encode('utf-8'))
   file_object.move(filepath)
 
   return filepath

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -484,7 +484,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   else:
     logger.debug('An empty password was given. '
                  'Not encrypting the private key.')
-    ed25519_key = json.dumps(ed25519key)
+    ed25519_key = json.dumps(ed25519_key)
 
   # If the parent directory of filepath does not exist,
   # create it (and all its parent directories, if necessary).

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -643,7 +643,12 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False):
     # Hence, we treat an empty password here, as if no 'password' was passed.
     password = get_password('Enter a password for an encrypted RSA'
         ' file \'' + Fore.RED + filepath + Fore.RESET + '\': ',
-        confirm=False) or None
+        confirm=False)
+
+    # If user sets an empty string for the password, explicitly set the
+    # password to None, because some functions may expect this later.
+    if len(password) == 0: # pragma: no cover
+      password = None
 
   # Finally, regardless of password, try decrypting the key, if necessary.
   # Otherwise, load it straight from the disk.

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -484,6 +484,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   else:
     logger.debug('An empty password was given. '
                  'Not encrypting the private key.')
+    ed25519_key = json.dumps(ed25519key)
 
   # If the parent directory of filepath does not exist,
   # create it (and all its parent directories, if necessary).

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -477,15 +477,6 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # Does 'password' have the correct format?
   securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
 
-  # Encrypt the private key if 'password' is set.
-  if len(password):
-    ed25519_key = securesystemslib.keys.encrypt_key(ed25519_key, password)
-
-  else:
-    logger.debug('An empty password was given. '
-                 'Not encrypting the private key.')
-    ed25519_key = json.dumps(ed25519_key)
-
   # If the parent directory of filepath does not exist,
   # create it (and all its parent directories, if necessary).
   securesystemslib.util.ensure_parent_dir(filepath)
@@ -513,6 +504,15 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # Write the encrypted key string, conformant to
   # 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA', to '<filepath>'.
   file_object = securesystemslib.util.TempFile()
+
+  # Encrypt the private key if 'password' is set.
+  if len(password):
+    ed25519_key = securesystemslib.keys.encrypt_key(ed25519_key, password)
+
+  else:
+    logger.debug('An empty password was given. '
+                 'Not encrypting the private key.')
+    ed25519_key = json.dumps(ed25519_key)
 
   # Raise 'securesystemslib.exceptions.CryptoError' if 'ed25519_key' cannot be
   # encrypted.

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -645,41 +645,10 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False):
         ' file \'' + Fore.RED + filepath + Fore.RESET + '\': ',
         confirm=False) or None
 
-  # Store the encrypted contents of 'filepath' prior to calling the decryption
-  # routine.
-  encrypted_key = None
-
-  with open(filepath, 'rb') as file_object:
-    encrypted_key = file_object.read()
-
-  if password is not None:
-    # This check will not fail, because a mal-formatted passed password fails
-    # above and an entered password will always be a string (see get_password)
-    # However, we include it in case PASSWORD_SCHEMA or get_password changes.
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
-
-    # Decrypt the loaded key file, calling the 'cryptography' library to
-    # generate the derived encryption key from 'password'.  Raise
-    # 'securesystemslib.exceptions.CryptoError' if the decryption fails.
-    key_object = securesystemslib.keys.\
-                 decrypt_key(encrypted_key.decode('utf-8'), password)
-
-  else:
-    logger.debug('No password was given. Attempting to import an'
-        ' unencrypted file.')
-    key_object = json.loads(encrypted_key.decode('utf-8'))
-
-  # Raise an exception if an unexpected key type is imported.
-  if key_object['keytype'] != 'ed25519':
-    message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
-    raise securesystemslib.exceptions.FormatError(message)
-
-  # Add "keyid_hash_algorithms" so that equal ed25519 keys with
-  # different keyids can be associated using supported keyid_hash_algorithms.
-  key_object['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
-
-  return key_object
+    with open(filepath, 'rb') as file_object:
+      jsons = file_object.read()
+      return securesystemslib.keys.\
+             import_ed25519key_from_private_json(jsons, password=password)
 
 
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -59,6 +59,9 @@ from __future__ import unicode_literals
 # hexlified.
 import binascii
 
+# Required to load JSON files / strings.
+import json
+
 # NOTE:  'warnings' needed to temporarily suppress user warnings raised by
 # 'pynacl' (as of version 0.2.3).
 # http://docs.python.org/2/library/warnings.html#temporarily-suppressing-warnings

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -59,9 +59,6 @@ from __future__ import unicode_literals
 # hexlified.
 import binascii
 
-# Required to load JSON files / strings.
-import json
-
 # NOTE:  'warnings' needed to temporarily suppress user warnings raised by
 # 'pynacl' (as of version 0.2.3).
 # http://docs.python.org/2/library/warnings.html#temporarily-suppressing-warnings
@@ -1606,10 +1603,11 @@ def import_ed25519key_from_private_json(json_str, password=None):
     logger.debug('No password was given. Attempting to import an'
         ' unencrypted file.')
     try:
-      key_object = json.loads(json_str.decode('utf-8'))
+      key_object = \
+               securesystemslib.util.load_json_string(json_str.decode('utf-8'))
     # If the JSON could not be decoded, it is very likely, but not necessarily,
     # due to a non-empty password.
-    except ValueError:
+    except securesystemslib.exceptions.Error:
       raise securesystemslib.exceptions\
             .CryptoError('Malformed Ed25519 key JSON, '
                          'possibly due to encryption, '

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1605,7 +1605,15 @@ def import_ed25519key_from_private_json(json_str, password=None):
   else:
     logger.debug('No password was given. Attempting to import an'
         ' unencrypted file.')
-    key_object = json.loads(json_str.decode('utf-8'))
+    try:
+      key_object = json.loads(json_str.decode('utf-8'))
+    # If the JSON could not be decoded, it is very likely, but not necessarily,
+    # due to a non-empty password.
+    except ValueError:
+      raise securesystemslib.exceptions\
+            .CryptoError('Malformed Ed25519 key JSON, '
+                         'possibly due to encryption, '
+                         'but no password provided?')
 
   # Raise an exception if an unexpected key type is imported.
   if key_object['keytype'] != 'ed25519':

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1586,6 +1586,40 @@ def is_pem_private(pem, keytype='rsa'):
 
 
 
+def import_ed25519key_from_private_json(json_str, password=None):
+  if password is not None:
+    # This check will not fail, because a mal-formatted passed password fails
+    # above and an entered password will always be a string (see get_password)
+    # However, we include it in case PASSWORD_SCHEMA or get_password changes.
+    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+
+    # Decrypt the loaded key file, calling the 'cryptography' library to
+    # generate the derived encryption key from 'password'.  Raise
+    # 'securesystemslib.exceptions.CryptoError' if the decryption fails.
+    key_object = securesystemslib.keys.\
+                 decrypt_key(json_str.decode('utf-8'), password)
+
+  else:
+    logger.debug('No password was given. Attempting to import an'
+        ' unencrypted file.')
+    key_object = json.loads(json_str.decode('utf-8'))
+
+  # Raise an exception if an unexpected key type is imported.
+  if key_object['keytype'] != 'ed25519':
+    message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
+    raise securesystemslib.exceptions.FormatError(message)
+
+  # Add "keyid_hash_algorithms" so that equal ed25519 keys with
+  # different keyids can be associated using supported keyid_hash_algorithms.
+  key_object['keyid_hash_algorithms'] = \
+      securesystemslib.settings.HASH_ALGORITHMS
+
+  return key_object
+
+
+
+
+
 def import_ecdsakey_from_private_pem(pem, scheme='ecdsa-sha2-nistp256', password=None):
   """
   <Purpose>

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -124,14 +124,15 @@ class TestInterfaceFunctions(unittest.TestCase):
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
     # Try to import the unencrypted key file, by not passing a password
-    interface.import_rsa_privatekey_from_file(test_keypath_unencrypted)
+    imported_privkey = interface.import_rsa_privatekey_from_file(test_keypath_unencrypted)
     self.assertTrue(securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 
     # Try to import the unencrypted key file, by entering an empty password
     with mock.patch('securesystemslib.interface.get_password',
         return_value=''):
-      interface.import_rsa_privatekey_from_file(test_keypath_unencrypted,
-          prompt=True)
+      imported_privkey = \
+            interface.import_rsa_privatekey_from_file(test_keypath_unencrypted,
+                                                      prompt=True)
       self.assertTrue(
           securesystemslib.formats.RSAKEY_SCHEMA.matches(imported_privkey))
 


### PR DESCRIPTION
**Fixes issue #**:

Presently, the library is consistent about how it handles empty passwords with regards to RSA, Ed25519, and ECDSA. The functions for RSA handles empty passwords as a signal that private keys are not to be encrypted / decrypted, whereas the functions for Ed25519 and ECDSA currently "encrypts / decrypts" them with empty passwords.

**Description of the changes being introduced by the pull request**:

The functions for Ed25519 are now consistent with the RSA functions in the sense that empty passwords are a signal that private keys are not to be encrypted / decrypted.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


