### PR TITLE
Support pure python Ed25519

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -71,7 +71,7 @@ import logging
 try:
   import securesystemslib.pyca_crypto_keys
 
-except ImportError:
+except ImportError: #pragma: no cover
   pass
 
 # Import the PyNaCl library, if available.  It is recommended this library be
@@ -101,7 +101,7 @@ import securesystemslib.ed25519_keys
 try:
   import securesystemslib.ecdsa_keys
 
-except ImportError:
+except ImportError: #pragma: no cover
   pass
 
 import securesystemslib.exceptions

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -68,7 +68,11 @@ import logging
 # Try to import the pyca/Cryptography module (pyca_crypto_keys.py), which is
 # used for general-purpose cryptography and generation of RSA keys and
 # signatures.
-import securesystemslib.pyca_crypto_keys
+try:
+  import securesystemslib.pyca_crypto_keys
+
+except ImportError:
+  pass
 
 # Import the PyNaCl library, if available.  It is recommended this library be
 # used over the pure python implementation of ed25519, due to its speedier
@@ -82,17 +86,24 @@ with warnings.catch_warnings():
   try:
     import nacl
     import nacl.signing
+    USE_PYNACL = True
 
   # PyNaCl's 'cffi' dependency may raise an 'IOError' exception when importing
   # 'nacl.signing'.
   except (ImportError, IOError): # pragma: no cover
+    USE_PYNACL = False
     pass
 
 # The optimized version of the Ed25519 library provided by default is imported
 # regardless of the availability of PyNaCl.
 import securesystemslib.ed25519_keys
 
-import securesystemslib.ecdsa_keys
+try:
+  import securesystemslib.ecdsa_keys
+
+except ImportError:
+  pass
+
 import securesystemslib.exceptions
 
 # Digest objects needed to generate hashes.
@@ -854,7 +865,7 @@ def verify_signature(key_dict, signature, data):
     if scheme == 'ed25519':
       public = binascii.unhexlify(public.encode('utf-8'))
       valid_signature = securesystemslib.ed25519_keys.verify_signature(public,
-          scheme, sig, data, use_pynacl=True)
+          scheme, sig, data, use_pynacl=USE_PYNACL)
 
     else:
       raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ with open('README.rst') as file_object:
 setup(
   name = 'securesystemslib',
   version = '0.11.1',
-  description = 'A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU',
+  description = 'A library that provides cryptographic and general-purpose'
+      ' routines for Secure Systems Lab projects at NYU',
   long_description = long_description,
   author = 'https://www.updateframework.com',
   author_email = 'theupdateframework@googlegroups.com',
@@ -95,7 +96,9 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['six>=1.11.0', 'cryptography>=2.2.2', 'pynacl>=1.2.0', 'colorama>=0.3.9'],
+  install_requires = ['six>=1.11.0'],
+  extras_require = {'crypto': ['cryptography>=2.2.2', 'colorama>=0.3.9'],
+      'pynacl': ['pynacl>1.2.0']},
   packages = find_packages(exclude=['tests', 'debian']),
   scripts = []
 )


### PR DESCRIPTION
**Fixes issue #**:

Addresses https://github.com/theupdateframework/tuf/issues/727.

**Description of the changes being introduced by the pull request**:

This pull request makes `cryptography`, `colorama`, and `pynacl` optional dependencies.  A default installation of securesystemslib (and TUF) is expected to work in pure Python and verify Ed25519 signatures.  Users who wish to fully support RSA, ECDSA, and the repo tools must install the optional dependencies.

`pip install securesystemslib['crypto']` and
`pip install securesystemslib['pynacl']`). 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>