### PR TITLE
Update installation instructions to mention 'crypto' and 'pynacl'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,10 @@ securesystemslib supports public-key and general-purpose cryptography, such as
 <https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm>`_,
 `Ed25519 <http://ed25519.cr.yp.to/>`_, `RSA
 <https://en.wikipedia.org/wiki/RSA_%28cryptosystem%29>`_, SHA256, SHA512, etc.
-Cryptographic operations are performed by the `cryptography
+Most of the cryptographic operations are performed by the `cryptography
 <https://cryptography.io/en/latest/>`_ and `PyNaCl
-<https://github.com/pyca/pynacl>`_ libraries.
+<https://github.com/pyca/pynacl>`_ libraries, but verification of Ed25519
+signatures can be done in pure Python.
 
 The `cryptography` library is used to generate keys and signatures with the
 ECDSA and RSA algorithms, and perform general-purpose cryptography such as

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,16 @@ Installation
     $ pip install securesystemslib
 
 
+The default installation only supports Ed25519 keys and signatures (in pure
+Python).  Support for RSA, ECDSA, and E25519 via the `cryptography` and
+`PyNaCl` libraries is available by installing the `crypto` and `pynacl` extras:
+
+::
+
+    $ pip install securesystemslib[crypto]
+    $ pip install securesystemslib[pynacl]
+
+
 Create RSA Keys
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request edits the README to update the installation instructions.  Pull request #149 made the `cryptography` and `pynacl` optional dependencies.  Users should be instructed to execute `pip install securesystems[crypto]` and `pip install securesystemslib[pynacl]` if they wish to use RSA, ECDSA, and the other C extensions.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>