### PR TITLE
Edit License classifier entry in setup.py to 'OSI Approved :: MIT'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
   classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
-    'License :: Freely Distributable',
+    'License :: OSI Approved :: MIT License',
     'Natural Language :: English',
     'Operating System :: POSIX',
     'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request edits `setup.py` to fix the license classifier (Freely Distributable -> MIT).  This change might possibly remove the "unknown" label indicated by pyup.io, which looks for an OSI specified license.

<img width="1107" alt="screen shot 2018-06-01 at 1 44 36 pm" src="https://user-images.githubusercontent.com/3520883/40855270-2ba030da-65a2-11e8-9e30-46a26c82dd5b.png">
 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>