### PR TITLE
Expect bytes in create_ and verify_signature; do not serialize

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -662,7 +662,10 @@ def create_signature(key_dict, data):
       The public and private keys are strings in PEM format.
 
     data:
-      Data object used by create_signature() to generate the signature.
+      Data to be signed. This should be a bytes object; data should be
+      encoded/serialized before it is passed here.  The same value can be be
+      passed into securesystemslib.verify_signature() (along with the public
+      key) to later verify the signature.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'key_dict' is improperly
@@ -702,17 +705,11 @@ def create_signature(key_dict, data):
   keyid = key_dict['keyid']
   sig = None
 
-  # Convert 'data' to canonical JSON format so that repeatable signatures are
-  # generated across different platforms and Python key dictionaries.  The
-  # resulting 'data' is a string encoded in UTF-8 and compatible with the input
-  # expected by the cryptography functions called below.
-  data = securesystemslib.formats.encode_canonical(data)
-
   if keytype == 'rsa':
     if scheme == 'rsassa-pss-sha256':
       private = private.replace('\r\n', '\n')
-      sig, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(private,
-        data.encode('utf-8'), scheme)
+      sig, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(
+          private, data, scheme)
 
     else:
       raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
@@ -721,12 +718,12 @@ def create_signature(key_dict, data):
   elif keytype == 'ed25519':
     public = binascii.unhexlify(public.encode('utf-8'))
     private = binascii.unhexlify(private.encode('utf-8'))
-    sig, scheme = securesystemslib.ed25519_keys.create_signature(public,
-      private, data.encode('utf-8'), scheme)
+    sig, scheme = securesystemslib.ed25519_keys.create_signature(
+        public, private, data, scheme)
 
   elif keytype == 'ecdsa-sha2-nistp256':
-    sig, scheme = securesystemslib.ecdsa_keys.create_signature(public, private,
-      data.encode('utf-8'), scheme)
+    sig, scheme = securesystemslib.ecdsa_keys.create_signature(
+        public, private, data, scheme)
 
   # 'securesystemslib.formats.ANYKEY_SCHEMA' should have detected invalid key
   # types.  This is a defensive check against an invalid key type.
@@ -795,8 +792,10 @@ def verify_signature(key_dict, signature, data):
       Conformant to 'securesystemslib.formats.SIGNATURE_SCHEMA'.
 
     data:
-      Data object used by securesystemslib.rsa_key.create_signature() to
-      generate 'signature'.  'data' is needed here to verify the signature.
+      Data that the signature is expected to be over.  This should be a bytes
+      object; data should be encoded/serialized before it is passed here.)
+      This is the same value that can be passed into
+      securesystemslib.create_signature() in order to create the signature.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, raised if either 'key_dict' or
@@ -846,11 +845,6 @@ def verify_signature(key_dict, signature, data):
   scheme = key_dict['scheme']
   valid_signature = False
 
-  # Convert 'data' to canonical JSON format so that repeatable signatures are
-  # generated across different platforms and Python key dictionaries.  The
-  # resulting 'data' is a string encoded in UTF-8 and compatible with the input
-  # expected by the cryptography functions called below.
-  data = securesystemslib.formats.encode_canonical(data).encode('utf-8')
 
   if keytype == 'rsa':
     if scheme == 'rsassa-pss-sha256':

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -39,7 +39,8 @@ logger = logging.getLogger('securesystemslib_test_keys')
 KEYS = securesystemslib.keys
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError was raised!' + \
   '  Check object\'s format.'
-DATA = 'SOME DATA REQUIRING AUTHENTICITY.'
+DATA_STR = 'SOME DATA REQUIRING AUTHENTICITY.'
+DATA = securesystemslib.formats.encode_canonical(DATA_STR).encode('utf-8')
 
 
 
@@ -332,7 +333,8 @@ class TestKeys(unittest.TestCase):
     # 'rsa_signature'. Function should return 'False'.
 
     # Modifying 'DATA'.
-    _DATA = '1111' + DATA + '1111'
+    _DATA_STR = '1111' + DATA_STR + '1111'
+    _DATA = securesystemslib.formats.encode_canonical(_DATA_STR).encode('utf-8')
 
     # Verifying the 'signature' of modified '_DATA'.
     verified = KEYS.verify_signature(self.rsakey_dict, rsa_signature, _DATA)


### PR DESCRIPTION
This is related to #161.

Currently, ssl's `create_signature()` and `verify_signature()` assume they know too much about the data.  Rather than just taking bytes, these functions assume the data is compatible with `securesystemslib.formats.encode_canonical()`, which I don't think is appropriate (and is problematic for using other formats, like ASN.1/DER, which are not).

The caller knows what their data is and how to serialize it (including whether or not to canonicalize it in some fashion); ssl.keys is too low level to be doing this.  I talked this over with @lukpueh of in-toto, as the other major client of securesystemslib, and it serves in-toto's interests as well.

Updated testing.  Did not touch code style, even though I'd love to....



**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


