### PR TITLE
Fix hash and hex schema regex pattern

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -99,7 +99,7 @@ ISO8601_DATETIME_SCHEMA = SCHEMA.RegularExpression(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{
 UNIX_TIMESTAMP_SCHEMA = SCHEMA.Integer(lo=0, hi=2147483647)
 
 # A hexadecimal value in '23432df87ab..' format.
-HASH_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
+HASH_SCHEMA = SCHEMA.RegularExpression(r'^[a-fA-F0-9]+$')
 
 # A dict in {'sha256': '23432df87ab..', 'sha512': '34324abc34df..', ...} format.
 HASHDICT_SCHEMA = SCHEMA.DictOf(
@@ -107,7 +107,7 @@ HASHDICT_SCHEMA = SCHEMA.DictOf(
   value_schema = HASH_SCHEMA)
 
 # A hexadecimal value in '23432df87ab..' format.
-HEX_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
+HEX_SCHEMA = SCHEMA.RegularExpression(r'^[a-fA-F0-9]+$')
 
 # A key identifier (e.g., a hexadecimal value identifying an RSA key).
 KEYID_SCHEMA = HASH_SCHEMA


### PR DESCRIPTION
The regex patterns used to match `HASH_SCHEMA` and `HEX_SCHEMA` are incomplete - they're not strict about matching only what's in the character class. This PR adds a fix for that.

[This](
https://github.com/adityasaky/in-toto/commit/aa579917a029f7f1253404d96dbf063549e7bb46) is a commit on a branch which loads an in-toto metadata file which has key IDs with invalid characters. However, the validation which uses `HASH_SCHEMA` (indirectly) passes.