### PR TITLE
Add MANIFEST.in to include files in source distro

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include README.rst
+include LICENSE
+
+# Add tests and test data
+recursive-include tests *.py
+recursive-include tests/data *
+
+# Add test config files to show how to run tests
+include tests/.coveragerc
+include tox.ini
+include .travis.yml
+include *requirements.txt


### PR DESCRIPTION
**Fixes issue #**:
#166 

**Description of the changes being introduced by the pull request**:
MANIFEST.in is used to specify files (patterns) to be added to the source distribution (e.g. on `python setup.py sdist`) in addition to files that are added by default.

This PR configures MANIFEST.in to add files that are important/helpful for downstream packagers, i.e. readme, license, tests and test data and config.

Kudos to @koobs for bringing this to our attention.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


