### PR TITLE
Fix publishing of coverage results to coveralls.io (+ misc test config updates)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,3 +12,5 @@ exclude_lines =
 
 omit =
   */securesystemslib/_vendor/*
+  */tests/*
+  */site-packages/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,10 @@
 [run]
 branch = True
 
+omit =
+  */securesystemslib/_vendor/*
+  */tests/*
+  */site-packages/*
 
 [report]
 exclude_lines =
@@ -9,8 +13,3 @@ exclude_lines =
   def _prompt
   def __str__
   if __name__ == .__main__.:
-
-omit =
-  */securesystemslib/_vendor/*
-  */tests/*
-  */site-packages/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,4 @@ script:
   - tox
 
 after_success:
-  - cd tests
   - coveralls
-  - cd -
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,26 @@
+dist: xenial
 language: python
-dist: trusty
-sudo: false
 cache: pip
-python: 3.6
 
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=py36
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
 
-before_script:
-  - pip install -U pip wheel tox
+install:
+  - pip install -U tox coveralls
 
-script: tox
+script:
+  - tox
 
 after_success:
   - cd tests
   - coveralls
   - cd -
 
-branches:
-  only:
-    - master

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,8 +1,8 @@
 cryptography
 pynacl
-tox
-coverage
-coveralls
 six
 colorama
 mock; python_version < '3.3'
+# Pin to versions supported by `coveralls` (see .travis.yml)
+# https://github.com/coveralls-clients/coveralls-python/releases/tag/1.8.1
+coverage<5.0

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -36,13 +36,6 @@ import unittest
 import glob
 import random
 
-# 'unittest2' required for testing under Python < 2.7.
-if sys.version_info >= (2, 7):
-  import unittest
-
-else:
-  import unittest2 as unittest
-
 # Generate a list of pathnames that match a pattern (i.e., that begin with
 # 'test_' and end with '.py'.  A shell-style wildcard is used with glob() to
 # match desired filenames.  All the tests matching the pattern will be loaded

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -20,7 +20,7 @@
 
 <Purpose>
   Run all the unit tests from every .py file beginning with "test_" in
-  'tuf/tests'.  Use --random to run the tests in random order.
+  'securesystemslib/tests'.
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -33,29 +33,9 @@ from __future__ import unicode_literals
 
 import sys
 import unittest
-import glob
-import random
-
-# Generate a list of pathnames that match a pattern (i.e., that begin with
-# 'test_' and end with '.py'.  A shell-style wildcard is used with glob() to
-# match desired filenames.  All the tests matching the pattern will be loaded
-# and run in a test suite.
-tests_list = glob.glob('test_*.py')
-
-# Remove '.py' from each filename to allow loadTestsFromNames() (called below)
-# to properly load the file as a module.
-tests_without_extension = []
-for test in tests_list:
-  test = test[:-3]
-  tests_without_extension.append(test)
-
-# Randomize the order in which the tests run.  Randomization might catch errors
-# with unit tests that do not properly clean up or restore monkey-patched
-# modules.
-random.shuffle(tests_without_extension)
 
 if __name__ == '__main__':
-  suite = unittest.TestLoader().loadTestsFromNames(tests_without_extension)
+  suite = unittest.TestLoader().discover("tests", top_level_dir=".")
   all_tests_passed = unittest.TextTestRunner(verbosity=1).run(suite).wasSuccessful()
   if not all_tests_passed:
     sys.exit(1)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -34,13 +34,7 @@ import json
 import shutil
 import stat
 import sys
-
-# 'unittest2' required for testing under Python < 2.7.
-if sys.version_info >= (2, 7):
-  import unittest
-
-else:
-  import unittest2 as unittest
+import unittest
 
 # Use external backport 'mock' on versions under 3.3
 if sys.version_info >= (3, 3):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = py27, py34, py35, py36
+skipsdist = True
 
 [testenv]
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,12 @@ envlist = py27, py34, py35, py36
 skipsdist = True
 
 [testenv]
-
-commands =
-    coverage run tests/aggregate_tests.py
-    coverage report -m --fail-under 100
+install_command =
+    pip install --pre {opts} {packages}
 
 deps =
     -r{toxinidir}/ci-requirements.txt
 
-install_command = pip install --pre {opts} {packages}
+commands =
+    coverage run tests/aggregate_tests.py
+    coverage report -m --fail-under 100

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,9 @@
 envlist = py27, py34, py35, py36
 
 [testenv]
-changedir = tests
 
 commands =
-    coverage run --source securesystemslib aggregate_tests.py
+    coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 100
 
 deps =


### PR DESCRIPTION
**Fixes issue #**:
Motivated by https://github.com/theupdateframework/tuf/pull/890
i.a. closes #71 

**Description of the changes being introduced by the pull request**:

- Fixes generation and publishing of coverage results on coveralls.io
- Simplifies test aggregation script
- Updates travis.yml to use most recent dist and to define a build matrix for tox builds as per corresponding best practices
- Removes obsolete unittest2 import
- Cleans up ci-requirements.txt

See commit messages for details.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


