### PR TITLE
Support for RSA-PKCS1v15-HASH_ID scheme

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -103,8 +103,8 @@ HASH_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
 
 # A dict in {'sha256': '23432df87ab..', 'sha512': '34324abc34df..', ...} format.
 HASHDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = SCHEMA.AnyString(),
-  value_schema = HASH_SCHEMA)
+    key_schema = SCHEMA.AnyString(),
+    value_schema = HASH_SCHEMA)
 
 # A hexadecimal value in '23432df87ab..' format.
 HEX_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
@@ -132,10 +132,10 @@ URL_SCHEMA = SCHEMA.AnyString()
 
 # A dictionary holding version information.
 VERSION_SCHEMA = SCHEMA.Object(
-  object_name = 'VERSION_SCHEMA',
-  major = SCHEMA.Integer(lo=0),
-  minor = SCHEMA.Integer(lo=0),
-  fix = SCHEMA.Integer(lo=0))
+    object_name = 'VERSION_SCHEMA',
+    major = SCHEMA.Integer(lo=0),
+    minor = SCHEMA.Integer(lo=0),
+    fix = SCHEMA.Integer(lo=0))
 
 # An integer representing the numbered version of a metadata file.
 # Must be 1, or greater.
@@ -160,9 +160,9 @@ TEXT_SCHEMA = SCHEMA.AnyString()
 
 # Supported hash algorithms.
 HASHALGORITHMS_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
-  [SCHEMA.String('md5'), SCHEMA.String('sha1'),
-   SCHEMA.String('sha224'), SCHEMA.String('sha256'),
-   SCHEMA.String('sha384'), SCHEMA.String('sha512')]))
+    [SCHEMA.String('md5'), SCHEMA.String('sha1'),
+     SCHEMA.String('sha224'), SCHEMA.String('sha256'),
+     SCHEMA.String('sha384'), SCHEMA.String('sha512')]))
 
 # The contents of an encrypted TUF key.  Encrypted TUF keys are saved to files
 # in this format.
@@ -213,75 +213,77 @@ PASSWORDS_SCHEMA = SCHEMA.ListOf(PASSWORD_SCHEMA)
 # key identifier ('rsa', 233df889cb).  For RSA keys, the key value is a pair of
 # public and private keys in PEM Format stored as strings.
 KEYVAL_SCHEMA = SCHEMA.Object(
-  object_name = 'KEYVAL_SCHEMA',
-  public = SCHEMA.AnyString(),
-  private = SCHEMA.Optional(SCHEMA.AnyString()))
+    object_name = 'KEYVAL_SCHEMA',
+    public = SCHEMA.AnyString(),
+    private = SCHEMA.Optional(SCHEMA.AnyString()))
 
 # Public keys CAN have a private portion (for backwards compatibility) which
 # MUST be an empty string
 PUBLIC_KEYVAL_SCHEMA = SCHEMA.Object(
-  object_name = 'KEYVAL_SCHEMA',
-  public = SCHEMA.AnyString(),
-  private = SCHEMA.Optional(SCHEMA.String("")))
+    object_name = 'KEYVAL_SCHEMA',
+    public = SCHEMA.AnyString(),
+    private = SCHEMA.Optional(SCHEMA.String("")))
 
 # Supported TUF key types.
 KEYTYPE_SCHEMA = SCHEMA.OneOf(
-  [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
-   SCHEMA.String('ecdsa-sha2-nistp256')])
+    [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
+     SCHEMA.String('ecdsa-sha2-nistp256')])
 
 # A generic TUF key.  All TUF keys should be saved to metadata files in this
 # format.
 KEY_SCHEMA = SCHEMA.Object(
-  object_name = 'KEY_SCHEMA',
-  keytype = SCHEMA.AnyString(),
-  scheme = SCHEME_SCHEMA,
-  keyval = KEYVAL_SCHEMA,
-  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+    object_name = 'KEY_SCHEMA',
+    keytype = SCHEMA.AnyString(),
+    scheme = SCHEME_SCHEMA,
+    keyval = KEYVAL_SCHEMA,
+    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # Like KEY_SCHEMA, but requires keyval's private portion to be unset or empty,
 # and optionally includes the supported keyid hash algorithms used to generate
 # the key's keyid.
 PUBLIC_KEY_SCHEMA = SCHEMA.Object(
-  object_name = 'PUBLIC_KEY_SCHEMA',
-  keytype = SCHEMA.AnyString(),
-  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-  keyval = PUBLIC_KEYVAL_SCHEMA,
-  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+    object_name = 'PUBLIC_KEY_SCHEMA',
+    keytype = SCHEMA.AnyString(),
+    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+    keyval = PUBLIC_KEYVAL_SCHEMA,
+    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # A TUF key object.  This schema simplifies validation of keys that may be one
 # of the supported key types.  Supported key types: 'rsa', 'ed25519'.
 ANYKEY_SCHEMA = SCHEMA.Object(
-  object_name = 'ANYKEY_SCHEMA',
-  keytype = KEYTYPE_SCHEMA,
-  scheme = SCHEME_SCHEMA,
-  keyid = KEYID_SCHEMA,
-  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-  keyval = KEYVAL_SCHEMA,
-  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+    object_name = 'ANYKEY_SCHEMA',
+    keytype = KEYTYPE_SCHEMA,
+    scheme = SCHEME_SCHEMA,
+    keyid = KEYID_SCHEMA,
+    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+    keyval = KEYVAL_SCHEMA,
+    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # A list of TUF key objects.
 ANYKEYLIST_SCHEMA = SCHEMA.ListOf(ANYKEY_SCHEMA)
 
 # RSA signature schemes.
-RSA_SCHEME_SCHEMA = SCHEMA.OneOf([SCHEMA.String('rsassa-pss-sha256')])
+RSA_SCHEME_SCHEMA = SCHEMA.OneOf([
+  SCHEMA.String('rsassa-pss-sha256'),
+  SCHEMA.String('rsa-pkcs1v15-sha256')])
 
 # An RSA TUF key.
 RSAKEY_SCHEMA = SCHEMA.Object(
-  object_name = 'RSAKEY_SCHEMA',
-  keytype = SCHEMA.String('rsa'),
-  scheme = RSA_SCHEME_SCHEMA,
-  keyid = KEYID_SCHEMA,
-  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-  keyval = KEYVAL_SCHEMA)
+    object_name = 'RSAKEY_SCHEMA',
+    keytype = SCHEMA.String('rsa'),
+    scheme = RSA_SCHEME_SCHEMA,
+    keyid = KEYID_SCHEMA,
+    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+    keyval = KEYVAL_SCHEMA)
 
 # An ECDSA TUF key.
 ECDSAKEY_SCHEMA = SCHEMA.Object(
-  object_name = 'ECDSAKEY_SCHEMA',
-  keytype = SCHEMA.String('ecdsa-sha2-nistp256'),
-  scheme = ECDSA_SCHEME_SCHEMA,
-  keyid = KEYID_SCHEMA,
-  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-  keyval = KEYVAL_SCHEMA)
+    object_name = 'ECDSAKEY_SCHEMA',
+    keytype = SCHEMA.String('ecdsa-sha2-nistp256'),
+    scheme = ECDSA_SCHEME_SCHEMA,
+    keyid = KEYID_SCHEMA,
+    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+    keyval = KEYVAL_SCHEMA)
 
 # An ED25519 raw public key, which must be 32 bytes.
 ED25519PUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
@@ -298,8 +300,8 @@ ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
 # Required installation libraries expected by the repository tools and other
 # cryptography modules.
 REQUIRED_LIBRARIES_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
-  [SCHEMA.String('general'), SCHEMA.String('ed25519'), SCHEMA.String('rsa'),
-   SCHEMA.String('ecdsa-sha2-nistp256')]))
+    [SCHEMA.String('general'), SCHEMA.String('ed25519'), SCHEMA.String('rsa'),
+     SCHEMA.String('ecdsa-sha2-nistp256')]))
 
 # Ed25519 signature schemes.  The vanilla Ed25519 signature scheme is currently
 # supported.
@@ -307,22 +309,22 @@ ED25519_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String('ed25519')])
 
 # An ed25519 TUF key.
 ED25519KEY_SCHEMA = SCHEMA.Object(
-  object_name = 'ED25519KEY_SCHEMA',
-  keytype = SCHEMA.String('ed25519'),
-  scheme = ED25519_SIG_SCHEMA,
-  keyid = KEYID_SCHEMA,
-  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-  keyval = KEYVAL_SCHEMA)
+    object_name = 'ED25519KEY_SCHEMA',
+    keytype = SCHEMA.String('ed25519'),
+    scheme = ED25519_SIG_SCHEMA,
+    keyid = KEYID_SCHEMA,
+    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+    keyval = KEYVAL_SCHEMA)
 
 # Information about target files, like file length and file hash(es).  This
 # schema allows the storage of multiple hashes for the same file (e.g., sha256
 # and sha512 may be computed for the same file and stored).
 FILEINFO_SCHEMA = SCHEMA.Object(
-  object_name = 'FILEINFO_SCHEMA',
-  length = LENGTH_SCHEMA,
-  hashes = HASHDICT_SCHEMA,
-  version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
-  custom = SCHEMA.Optional(SCHEMA.Object()))
+    object_name = 'FILEINFO_SCHEMA',
+    length = LENGTH_SCHEMA,
+    hashes = HASHDICT_SCHEMA,
+    version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
+    custom = SCHEMA.Optional(SCHEMA.Object()))
 
 # Version information specified in "snapshot.json" for each role available on
 # the TUF repository.  The 'FILEINFO_SCHEMA' object was previously listed in
@@ -331,22 +333,22 @@ FILEINFO_SCHEMA = SCHEMA.Object(
 # "snapshot.json" also prevents rollback attacks for roles that clients have
 # not downloaded.
 VERSIONINFO_SCHEMA = SCHEMA.Object(
-  object_name = 'VERSIONINFO_SCHEMA',
-  version = METADATAVERSION_SCHEMA)
+    object_name = 'VERSIONINFO_SCHEMA',
+    version = METADATAVERSION_SCHEMA)
 
 # A dict holding the version information for a particular metadata role.  The
 # dict keys hold the relative file paths, and the dict values the corresponding
 # version numbers.
 VERSIONDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = RELPATH_SCHEMA,
-  value_schema = VERSIONINFO_SCHEMA)
+    key_schema = RELPATH_SCHEMA,
+    value_schema = VERSIONINFO_SCHEMA)
 
 # A dict holding the information for a particular target / file.  The dict keys
 # hold the relative file paths, and the dict values the corresponding file
 # information.
 FILEDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = RELPATH_SCHEMA,
-  value_schema = FILEINFO_SCHEMA)
+    key_schema = RELPATH_SCHEMA,
+    value_schema = FILEINFO_SCHEMA)
 
 # A single signature of an object.  Indicates the signature, and the KEYID of
 # the signing key.  I debated making the signature schema not contain the key
@@ -355,9 +357,9 @@ FILEDICT_SCHEMA = SCHEMA.DictOf(
 # That would be under the argument that a key should only be able to sign a
 # file once.
 SIGNATURE_SCHEMA = SCHEMA.Object(
-  object_name = 'SIGNATURE_SCHEMA',
-  keyid = KEYID_SCHEMA,
-  sig = HEX_SCHEMA)
+    object_name = 'SIGNATURE_SCHEMA',
+    keyid = KEYID_SCHEMA,
+    sig = HEX_SCHEMA)
 
 # List of SIGNATURE_SCHEMA.
 SIGNATURES_SCHEMA = SCHEMA.ListOf(SIGNATURE_SCHEMA)
@@ -368,30 +370,30 @@ SIGNATURES_SCHEMA = SCHEMA.ListOf(SIGNATURE_SCHEMA)
 # valid?  This SCHEMA holds this information.  See 'sig.py' for
 # more information.
 SIGNATURESTATUS_SCHEMA = SCHEMA.Object(
-  object_name = 'SIGNATURESTATUS_SCHEMA',
-  threshold = SCHEMA.Integer(),
-  good_sigs = KEYIDS_SCHEMA,
-  bad_sigs = KEYIDS_SCHEMA,
-  unknown_sigs = KEYIDS_SCHEMA,
-  untrusted_sigs = KEYIDS_SCHEMA)
+    object_name = 'SIGNATURESTATUS_SCHEMA',
+    threshold = SCHEMA.Integer(),
+    good_sigs = KEYIDS_SCHEMA,
+    bad_sigs = KEYIDS_SCHEMA,
+    unknown_sigs = KEYIDS_SCHEMA,
+    untrusted_sigs = KEYIDS_SCHEMA)
 
 # A signable object.  Holds the signing role and its associated signatures.
 SIGNABLE_SCHEMA = SCHEMA.Object(
-  object_name = 'SIGNABLE_SCHEMA',
-  signed = SCHEMA.Any(),
-  signatures = SCHEMA.ListOf(SIGNATURE_SCHEMA))
+    object_name = 'SIGNABLE_SCHEMA',
+    signed = SCHEMA.Any(),
+    signatures = SCHEMA.ListOf(SIGNATURE_SCHEMA))
 
 # A dict where the dict keys hold a keyid and the dict values a key object.
 KEYDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = KEYID_SCHEMA,
-  value_schema = KEY_SCHEMA)
+    key_schema = KEYID_SCHEMA,
+    value_schema = KEY_SCHEMA)
 
 # The format used by the key database to store keys.  The dict keys hold a key
 # identifier and the dict values any object.  The key database should store
 # key objects in the values (e.g., 'RSAKEY_SCHEMA', 'DSAKEY_SCHEMA').
 KEYDB_SCHEMA = SCHEMA.DictOf(
-  key_schema = KEYID_SCHEMA,
-  value_schema = SCHEMA.Any())
+    key_schema = KEYID_SCHEMA,
+    value_schema = SCHEMA.Any())
 
 # A path hash prefix is a hexadecimal string.
 PATH_HASH_PREFIX_SCHEMA = HEX_SCHEMA
@@ -402,27 +404,27 @@ PATH_HASH_PREFIXES_SCHEMA = SCHEMA.ListOf(PATH_HASH_PREFIX_SCHEMA)
 # Role object in {'keyids': [keydids..], 'name': 'ABC', 'threshold': 1,
 # 'paths':[filepaths..]} format.
 ROLE_SCHEMA = SCHEMA.Object(
-  object_name = 'ROLE_SCHEMA',
-  name = SCHEMA.Optional(ROLENAME_SCHEMA),
-  keyids = KEYIDS_SCHEMA,
-  threshold = THRESHOLD_SCHEMA,
-  backtrack = SCHEMA.Optional(BOOLEAN_SCHEMA),
-  paths = SCHEMA.Optional(RELPATHS_SCHEMA),
-  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
+    object_name = 'ROLE_SCHEMA',
+    name = SCHEMA.Optional(ROLENAME_SCHEMA),
+    keyids = KEYIDS_SCHEMA,
+    threshold = THRESHOLD_SCHEMA,
+    backtrack = SCHEMA.Optional(BOOLEAN_SCHEMA),
+    paths = SCHEMA.Optional(RELPATHS_SCHEMA),
+    path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.
 ROLEDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = ROLENAME_SCHEMA,
-  value_schema = ROLE_SCHEMA)
+    key_schema = ROLENAME_SCHEMA,
+    value_schema = ROLE_SCHEMA)
 
 # Like ROLEDICT_SCHEMA, except that ROLE_SCHEMA instances are stored in order.
 ROLELIST_SCHEMA = SCHEMA.ListOf(ROLE_SCHEMA)
 
 # The delegated roles of a Targets role (a parent).
 DELEGATIONS_SCHEMA = SCHEMA.Object(
-  keys = KEYDICT_SCHEMA,
-  roles = ROLELIST_SCHEMA)
+    keys = KEYDICT_SCHEMA,
+    roles = ROLELIST_SCHEMA)
 
 # The fileinfo format of targets specified in the repository and
 # developer tools.  The second element of this list holds custom data about the
@@ -430,60 +432,60 @@ DELEGATIONS_SCHEMA = SCHEMA.Object(
 CUSTOM_SCHEMA = SCHEMA.Object()
 
 PATH_FILEINFO_SCHEMA = SCHEMA.DictOf(
-  key_schema = RELPATH_SCHEMA,
-  value_schema = CUSTOM_SCHEMA)
+    key_schema = RELPATH_SCHEMA,
+    value_schema = CUSTOM_SCHEMA)
 
 # TUF roledb
 ROLEDB_SCHEMA = SCHEMA.Object(
-  object_name = 'ROLEDB_SCHEMA',
-  keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-  signing_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-  previous_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-  threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
-  previous_threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
-  version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
-  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA),
-  signatures = SCHEMA.Optional(SIGNATURES_SCHEMA),
-  paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
-  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-  delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
-  partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
+    object_name = 'ROLEDB_SCHEMA',
+    keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+    signing_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+    previous_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+    threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
+    previous_threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
+    version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
+    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA),
+    signatures = SCHEMA.Optional(SIGNATURES_SCHEMA),
+    paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
+    path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
+    delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
+    partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
 
 # Root role: indicates root keys and top-level roles.
 ROOT_SCHEMA = SCHEMA.Object(
-  object_name = 'ROOT_SCHEMA',
-  _type = SCHEMA.String('root'),
-  version = METADATAVERSION_SCHEMA,
-  consistent_snapshot = BOOLEAN_SCHEMA,
-  expires = ISO8601_DATETIME_SCHEMA,
-  keys = KEYDICT_SCHEMA,
-  roles = ROLEDICT_SCHEMA)
+    object_name = 'ROOT_SCHEMA',
+    _type = SCHEMA.String('root'),
+    version = METADATAVERSION_SCHEMA,
+    consistent_snapshot = BOOLEAN_SCHEMA,
+    expires = ISO8601_DATETIME_SCHEMA,
+    keys = KEYDICT_SCHEMA,
+    roles = ROLEDICT_SCHEMA)
 
 # Targets role: Indicates targets and delegates target paths to other roles.
 TARGETS_SCHEMA = SCHEMA.Object(
-  object_name = 'TARGETS_SCHEMA',
-  _type = SCHEMA.String('targets'),
-  version = METADATAVERSION_SCHEMA,
-  expires = ISO8601_DATETIME_SCHEMA,
-  targets = FILEDICT_SCHEMA,
-  delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA))
+    object_name = 'TARGETS_SCHEMA',
+    _type = SCHEMA.String('targets'),
+    version = METADATAVERSION_SCHEMA,
+    expires = ISO8601_DATETIME_SCHEMA,
+    targets = FILEDICT_SCHEMA,
+    delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA))
 
 # Snapshot role: indicates the latest versions of all metadata (except
 # timestamp).
 SNAPSHOT_SCHEMA = SCHEMA.Object(
-  object_name = 'SNAPSHOT_SCHEMA',
-  _type = SCHEMA.String('snapshot'),
-  version = METADATAVERSION_SCHEMA,
-  expires = ISO8601_DATETIME_SCHEMA,
-  meta = VERSIONDICT_SCHEMA)
+    object_name = 'SNAPSHOT_SCHEMA',
+    _type = SCHEMA.String('snapshot'),
+    version = METADATAVERSION_SCHEMA,
+    expires = ISO8601_DATETIME_SCHEMA,
+    meta = VERSIONDICT_SCHEMA)
 
 # Timestamp role: indicates the latest version of the snapshot file.
 TIMESTAMP_SCHEMA = SCHEMA.Object(
-  object_name = 'TIMESTAMP_SCHEMA',
-  _type = SCHEMA.String('timestamp'),
-  version = METADATAVERSION_SCHEMA,
-  expires = ISO8601_DATETIME_SCHEMA,
-  meta = FILEDICT_SCHEMA)
+    object_name = 'TIMESTAMP_SCHEMA',
+    _type = SCHEMA.String('timestamp'),
+    version = METADATAVERSION_SCHEMA,
+    expires = ISO8601_DATETIME_SCHEMA,
+    meta = FILEDICT_SCHEMA)
 
 # project.cfg file: stores information about the project in a json dictionary
 PROJECT_CFG_SCHEMA = SCHEMA.Object(
@@ -495,34 +497,34 @@ PROJECT_CFG_SCHEMA = SCHEMA.Object(
     prefix = PATH_SCHEMA,
     public_keys = KEYDICT_SCHEMA,
     threshold = SCHEMA.Integer(lo = 0, hi = 2)
-    )
+)
 
 # A schema containing information a repository mirror may require,
 # such as a url, the path of the directory metadata files, etc.
 MIRROR_SCHEMA = SCHEMA.Object(
-  object_name = 'MIRROR_SCHEMA',
-  url_prefix = URL_SCHEMA,
-  metadata_path = RELPATH_SCHEMA,
-  targets_path = RELPATH_SCHEMA,
-  confined_target_dirs = RELPATHS_SCHEMA,
-  custom = SCHEMA.Optional(SCHEMA.Object()))
+    object_name = 'MIRROR_SCHEMA',
+    url_prefix = URL_SCHEMA,
+    metadata_path = RELPATH_SCHEMA,
+    targets_path = RELPATH_SCHEMA,
+    confined_target_dirs = RELPATHS_SCHEMA,
+    custom = SCHEMA.Optional(SCHEMA.Object()))
 
 # A dictionary of mirrors where the dict keys hold the mirror's name and
 # and the dict values the mirror's data (i.e., 'MIRROR_SCHEMA').
 # The repository class of 'updater.py' accepts dictionaries
 # of this type provided by the TUF client.
 MIRRORDICT_SCHEMA = SCHEMA.DictOf(
-  key_schema = SCHEMA.AnyString(),
-  value_schema = MIRROR_SCHEMA)
+    key_schema = SCHEMA.AnyString(),
+    value_schema = MIRROR_SCHEMA)
 
 # A Mirrorlist: indicates all the live mirrors, and what documents they
 # serve.
 MIRRORLIST_SCHEMA = SCHEMA.Object(
-  object_name = 'MIRRORLIST_SCHEMA',
-  _type = SCHEMA.String('mirrors'),
-  version = METADATAVERSION_SCHEMA,
-  expires = ISO8601_DATETIME_SCHEMA,
-  mirrors = SCHEMA.ListOf(MIRROR_SCHEMA))
+    object_name = 'MIRRORLIST_SCHEMA',
+    _type = SCHEMA.String('mirrors'),
+    version = METADATAVERSION_SCHEMA,
+    expires = ISO8601_DATETIME_SCHEMA,
+    mirrors = SCHEMA.ListOf(MIRROR_SCHEMA))
 
 # Any of the role schemas (e.g., TIMESTAMP_SCHEMA, SNAPSHOT_SCHEMA, etc.)
 ANYROLE_SCHEMA = SCHEMA.OneOf([ROOT_SCHEMA, TARGETS_SCHEMA, SNAPSHOT_SCHEMA,
@@ -640,7 +642,7 @@ def format_base64(data):
 
   except (TypeError, binascii.Error) as e:
     raise securesystemslib.exceptions.FormatError('Invalid base64'
-      ' encoding: ' + str(e))
+                                                  ' encoding: ' + str(e))
 
 
 
@@ -680,7 +682,7 @@ def parse_base64(base64_string):
 
   except (TypeError, binascii.Error) as e:
     raise securesystemslib.exceptions.FormatError('Invalid base64'
-      ' encoding: ' + str(e))
+                                                  ' encoding: ' + str(e))
 
 
 

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -103,8 +103,8 @@ HASH_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
 
 # A dict in {'sha256': '23432df87ab..', 'sha512': '34324abc34df..', ...} format.
 HASHDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = SCHEMA.AnyString(),
-    value_schema = HASH_SCHEMA)
+  key_schema = SCHEMA.AnyString(),
+  value_schema = HASH_SCHEMA)
 
 # A hexadecimal value in '23432df87ab..' format.
 HEX_SCHEMA = SCHEMA.RegularExpression(r'[a-fA-F0-9]+')
@@ -132,10 +132,10 @@ URL_SCHEMA = SCHEMA.AnyString()
 
 # A dictionary holding version information.
 VERSION_SCHEMA = SCHEMA.Object(
-    object_name = 'VERSION_SCHEMA',
-    major = SCHEMA.Integer(lo=0),
-    minor = SCHEMA.Integer(lo=0),
-    fix = SCHEMA.Integer(lo=0))
+  object_name = 'VERSION_SCHEMA',
+  major = SCHEMA.Integer(lo=0),
+  minor = SCHEMA.Integer(lo=0),
+  fix = SCHEMA.Integer(lo=0))
 
 # An integer representing the numbered version of a metadata file.
 # Must be 1, or greater.
@@ -160,9 +160,9 @@ TEXT_SCHEMA = SCHEMA.AnyString()
 
 # Supported hash algorithms.
 HASHALGORITHMS_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
-    [SCHEMA.String('md5'), SCHEMA.String('sha1'),
-     SCHEMA.String('sha224'), SCHEMA.String('sha256'),
-     SCHEMA.String('sha384'), SCHEMA.String('sha512')]))
+  [SCHEMA.String('md5'), SCHEMA.String('sha1'),
+   SCHEMA.String('sha224'), SCHEMA.String('sha256'),
+   SCHEMA.String('sha384'), SCHEMA.String('sha512')]))
 
 # The contents of an encrypted TUF key.  Encrypted TUF keys are saved to files
 # in this format.
@@ -213,51 +213,51 @@ PASSWORDS_SCHEMA = SCHEMA.ListOf(PASSWORD_SCHEMA)
 # key identifier ('rsa', 233df889cb).  For RSA keys, the key value is a pair of
 # public and private keys in PEM Format stored as strings.
 KEYVAL_SCHEMA = SCHEMA.Object(
-    object_name = 'KEYVAL_SCHEMA',
-    public = SCHEMA.AnyString(),
-    private = SCHEMA.Optional(SCHEMA.AnyString()))
+  object_name = 'KEYVAL_SCHEMA',
+  public = SCHEMA.AnyString(),
+  private = SCHEMA.Optional(SCHEMA.AnyString()))
 
 # Public keys CAN have a private portion (for backwards compatibility) which
 # MUST be an empty string
 PUBLIC_KEYVAL_SCHEMA = SCHEMA.Object(
-    object_name = 'KEYVAL_SCHEMA',
-    public = SCHEMA.AnyString(),
-    private = SCHEMA.Optional(SCHEMA.String("")))
+  object_name = 'KEYVAL_SCHEMA',
+  public = SCHEMA.AnyString(),
+  private = SCHEMA.Optional(SCHEMA.String("")))
 
 # Supported TUF key types.
 KEYTYPE_SCHEMA = SCHEMA.OneOf(
-    [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
-     SCHEMA.String('ecdsa-sha2-nistp256')])
+  [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
+   SCHEMA.String('ecdsa-sha2-nistp256')])
 
 # A generic TUF key.  All TUF keys should be saved to metadata files in this
 # format.
 KEY_SCHEMA = SCHEMA.Object(
-    object_name = 'KEY_SCHEMA',
-    keytype = SCHEMA.AnyString(),
-    scheme = SCHEME_SCHEMA,
-    keyval = KEYVAL_SCHEMA,
-    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+  object_name = 'KEY_SCHEMA',
+  keytype = SCHEMA.AnyString(),
+  scheme = SCHEME_SCHEMA,
+  keyval = KEYVAL_SCHEMA,
+  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # Like KEY_SCHEMA, but requires keyval's private portion to be unset or empty,
 # and optionally includes the supported keyid hash algorithms used to generate
 # the key's keyid.
 PUBLIC_KEY_SCHEMA = SCHEMA.Object(
-    object_name = 'PUBLIC_KEY_SCHEMA',
-    keytype = SCHEMA.AnyString(),
-    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-    keyval = PUBLIC_KEYVAL_SCHEMA,
-    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+  object_name = 'PUBLIC_KEY_SCHEMA',
+  keytype = SCHEMA.AnyString(),
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+  keyval = PUBLIC_KEYVAL_SCHEMA,
+  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # A TUF key object.  This schema simplifies validation of keys that may be one
 # of the supported key types.  Supported key types: 'rsa', 'ed25519'.
 ANYKEY_SCHEMA = SCHEMA.Object(
-    object_name = 'ANYKEY_SCHEMA',
-    keytype = KEYTYPE_SCHEMA,
-    scheme = SCHEME_SCHEMA,
-    keyid = KEYID_SCHEMA,
-    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-    keyval = KEYVAL_SCHEMA,
-    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
+  object_name = 'ANYKEY_SCHEMA',
+  keytype = KEYTYPE_SCHEMA,
+  scheme = SCHEME_SCHEMA,
+  keyid = KEYID_SCHEMA,
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+  keyval = KEYVAL_SCHEMA,
+  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA))
 
 # A list of TUF key objects.
 ANYKEYLIST_SCHEMA = SCHEMA.ListOf(ANYKEY_SCHEMA)
@@ -267,23 +267,23 @@ RSA_SCHEME_SCHEMA = SCHEMA.OneOf([
   SCHEMA.RegularExpression(r'rsassa-pss-(md5|sha1|sha224|sha256|sha384|sha512)'),
   SCHEMA.RegularExpression(r'rsa-pkcs1v15-(md5|sha1|sha224|sha256|sha384|sha512)')])
 
-# An RSA TUF key.
+  # An RSA TUF key.
 RSAKEY_SCHEMA = SCHEMA.Object(
-    object_name = 'RSAKEY_SCHEMA',
-    keytype = SCHEMA.String('rsa'),
-    scheme = RSA_SCHEME_SCHEMA,
-    keyid = KEYID_SCHEMA,
-    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-    keyval = KEYVAL_SCHEMA)
+  object_name = 'RSAKEY_SCHEMA',
+  keytype = SCHEMA.String('rsa'),
+  scheme = RSA_SCHEME_SCHEMA,
+  keyid = KEYID_SCHEMA,
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+  keyval = KEYVAL_SCHEMA)
 
 # An ECDSA TUF key.
 ECDSAKEY_SCHEMA = SCHEMA.Object(
-    object_name = 'ECDSAKEY_SCHEMA',
-    keytype = SCHEMA.String('ecdsa-sha2-nistp256'),
-    scheme = ECDSA_SCHEME_SCHEMA,
-    keyid = KEYID_SCHEMA,
-    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-    keyval = KEYVAL_SCHEMA)
+  object_name = 'ECDSAKEY_SCHEMA',
+  keytype = SCHEMA.String('ecdsa-sha2-nistp256'),
+  scheme = ECDSA_SCHEME_SCHEMA,
+  keyid = KEYID_SCHEMA,
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+  keyval = KEYVAL_SCHEMA)
 
 # An ED25519 raw public key, which must be 32 bytes.
 ED25519PUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
@@ -300,8 +300,8 @@ ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
 # Required installation libraries expected by the repository tools and other
 # cryptography modules.
 REQUIRED_LIBRARIES_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
-    [SCHEMA.String('general'), SCHEMA.String('ed25519'), SCHEMA.String('rsa'),
-     SCHEMA.String('ecdsa-sha2-nistp256')]))
+  [SCHEMA.String('general'), SCHEMA.String('ed25519'), SCHEMA.String('rsa'),
+   SCHEMA.String('ecdsa-sha2-nistp256')]))
 
 # Ed25519 signature schemes.  The vanilla Ed25519 signature scheme is currently
 # supported.
@@ -309,22 +309,22 @@ ED25519_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String('ed25519')])
 
 # An ed25519 TUF key.
 ED25519KEY_SCHEMA = SCHEMA.Object(
-    object_name = 'ED25519KEY_SCHEMA',
-    keytype = SCHEMA.String('ed25519'),
-    scheme = ED25519_SIG_SCHEMA,
-    keyid = KEYID_SCHEMA,
-    keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
-    keyval = KEYVAL_SCHEMA)
+  object_name = 'ED25519KEY_SCHEMA',
+  keytype = SCHEMA.String('ed25519'),
+  scheme = ED25519_SIG_SCHEMA,
+  keyid = KEYID_SCHEMA,
+  keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
+  keyval = KEYVAL_SCHEMA)
 
 # Information about target files, like file length and file hash(es).  This
 # schema allows the storage of multiple hashes for the same file (e.g., sha256
 # and sha512 may be computed for the same file and stored).
 FILEINFO_SCHEMA = SCHEMA.Object(
-    object_name = 'FILEINFO_SCHEMA',
-    length = LENGTH_SCHEMA,
-    hashes = HASHDICT_SCHEMA,
-    version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
-    custom = SCHEMA.Optional(SCHEMA.Object()))
+  object_name = 'FILEINFO_SCHEMA',
+  length = LENGTH_SCHEMA,
+  hashes = HASHDICT_SCHEMA,
+  version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
+  custom = SCHEMA.Optional(SCHEMA.Object()))
 
 # Version information specified in "snapshot.json" for each role available on
 # the TUF repository.  The 'FILEINFO_SCHEMA' object was previously listed in
@@ -333,22 +333,22 @@ FILEINFO_SCHEMA = SCHEMA.Object(
 # "snapshot.json" also prevents rollback attacks for roles that clients have
 # not downloaded.
 VERSIONINFO_SCHEMA = SCHEMA.Object(
-    object_name = 'VERSIONINFO_SCHEMA',
-    version = METADATAVERSION_SCHEMA)
+  object_name = 'VERSIONINFO_SCHEMA',
+  version = METADATAVERSION_SCHEMA)
 
 # A dict holding the version information for a particular metadata role.  The
 # dict keys hold the relative file paths, and the dict values the corresponding
 # version numbers.
 VERSIONDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = RELPATH_SCHEMA,
-    value_schema = VERSIONINFO_SCHEMA)
+  key_schema = RELPATH_SCHEMA,
+  value_schema = VERSIONINFO_SCHEMA)
 
 # A dict holding the information for a particular target / file.  The dict keys
 # hold the relative file paths, and the dict values the corresponding file
 # information.
 FILEDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = RELPATH_SCHEMA,
-    value_schema = FILEINFO_SCHEMA)
+  key_schema = RELPATH_SCHEMA,
+  value_schema = FILEINFO_SCHEMA)
 
 # A single signature of an object.  Indicates the signature, and the KEYID of
 # the signing key.  I debated making the signature schema not contain the key
@@ -357,9 +357,9 @@ FILEDICT_SCHEMA = SCHEMA.DictOf(
 # That would be under the argument that a key should only be able to sign a
 # file once.
 SIGNATURE_SCHEMA = SCHEMA.Object(
-    object_name = 'SIGNATURE_SCHEMA',
-    keyid = KEYID_SCHEMA,
-    sig = HEX_SCHEMA)
+  object_name = 'SIGNATURE_SCHEMA',
+  keyid = KEYID_SCHEMA,
+  sig = HEX_SCHEMA)
 
 # List of SIGNATURE_SCHEMA.
 SIGNATURES_SCHEMA = SCHEMA.ListOf(SIGNATURE_SCHEMA)
@@ -370,30 +370,30 @@ SIGNATURES_SCHEMA = SCHEMA.ListOf(SIGNATURE_SCHEMA)
 # valid?  This SCHEMA holds this information.  See 'sig.py' for
 # more information.
 SIGNATURESTATUS_SCHEMA = SCHEMA.Object(
-    object_name = 'SIGNATURESTATUS_SCHEMA',
-    threshold = SCHEMA.Integer(),
-    good_sigs = KEYIDS_SCHEMA,
-    bad_sigs = KEYIDS_SCHEMA,
-    unknown_sigs = KEYIDS_SCHEMA,
-    untrusted_sigs = KEYIDS_SCHEMA)
+  object_name = 'SIGNATURESTATUS_SCHEMA',
+  threshold = SCHEMA.Integer(),
+  good_sigs = KEYIDS_SCHEMA,
+  bad_sigs = KEYIDS_SCHEMA,
+  unknown_sigs = KEYIDS_SCHEMA,
+  untrusted_sigs = KEYIDS_SCHEMA)
 
 # A signable object.  Holds the signing role and its associated signatures.
 SIGNABLE_SCHEMA = SCHEMA.Object(
-    object_name = 'SIGNABLE_SCHEMA',
-    signed = SCHEMA.Any(),
-    signatures = SCHEMA.ListOf(SIGNATURE_SCHEMA))
+  object_name = 'SIGNABLE_SCHEMA',
+  signed = SCHEMA.Any(),
+  signatures = SCHEMA.ListOf(SIGNATURE_SCHEMA))
 
 # A dict where the dict keys hold a keyid and the dict values a key object.
 KEYDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = KEYID_SCHEMA,
-    value_schema = KEY_SCHEMA)
+  key_schema = KEYID_SCHEMA,
+  value_schema = KEY_SCHEMA)
 
 # The format used by the key database to store keys.  The dict keys hold a key
 # identifier and the dict values any object.  The key database should store
 # key objects in the values (e.g., 'RSAKEY_SCHEMA', 'DSAKEY_SCHEMA').
 KEYDB_SCHEMA = SCHEMA.DictOf(
-    key_schema = KEYID_SCHEMA,
-    value_schema = SCHEMA.Any())
+  key_schema = KEYID_SCHEMA,
+  value_schema = SCHEMA.Any())
 
 # A path hash prefix is a hexadecimal string.
 PATH_HASH_PREFIX_SCHEMA = HEX_SCHEMA
@@ -404,27 +404,27 @@ PATH_HASH_PREFIXES_SCHEMA = SCHEMA.ListOf(PATH_HASH_PREFIX_SCHEMA)
 # Role object in {'keyids': [keydids..], 'name': 'ABC', 'threshold': 1,
 # 'paths':[filepaths..]} format.
 ROLE_SCHEMA = SCHEMA.Object(
-    object_name = 'ROLE_SCHEMA',
-    name = SCHEMA.Optional(ROLENAME_SCHEMA),
-    keyids = KEYIDS_SCHEMA,
-    threshold = THRESHOLD_SCHEMA,
-    backtrack = SCHEMA.Optional(BOOLEAN_SCHEMA),
-    paths = SCHEMA.Optional(RELPATHS_SCHEMA),
-    path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
+  object_name = 'ROLE_SCHEMA',
+  name = SCHEMA.Optional(ROLENAME_SCHEMA),
+  keyids = KEYIDS_SCHEMA,
+  threshold = THRESHOLD_SCHEMA,
+  backtrack = SCHEMA.Optional(BOOLEAN_SCHEMA),
+  paths = SCHEMA.Optional(RELPATHS_SCHEMA),
+  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.
 ROLEDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = ROLENAME_SCHEMA,
-    value_schema = ROLE_SCHEMA)
+  key_schema = ROLENAME_SCHEMA,
+  value_schema = ROLE_SCHEMA)
 
 # Like ROLEDICT_SCHEMA, except that ROLE_SCHEMA instances are stored in order.
 ROLELIST_SCHEMA = SCHEMA.ListOf(ROLE_SCHEMA)
 
 # The delegated roles of a Targets role (a parent).
 DELEGATIONS_SCHEMA = SCHEMA.Object(
-    keys = KEYDICT_SCHEMA,
-    roles = ROLELIST_SCHEMA)
+  keys = KEYDICT_SCHEMA,
+  roles = ROLELIST_SCHEMA)
 
 # The fileinfo format of targets specified in the repository and
 # developer tools.  The second element of this list holds custom data about the
@@ -432,60 +432,60 @@ DELEGATIONS_SCHEMA = SCHEMA.Object(
 CUSTOM_SCHEMA = SCHEMA.Object()
 
 PATH_FILEINFO_SCHEMA = SCHEMA.DictOf(
-    key_schema = RELPATH_SCHEMA,
-    value_schema = CUSTOM_SCHEMA)
+  key_schema = RELPATH_SCHEMA,
+  value_schema = CUSTOM_SCHEMA)
 
 # TUF roledb
 ROLEDB_SCHEMA = SCHEMA.Object(
-    object_name = 'ROLEDB_SCHEMA',
-    keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-    signing_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-    previous_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
-    threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
-    previous_threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
-    version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
-    expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA),
-    signatures = SCHEMA.Optional(SIGNATURES_SCHEMA),
-    paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
-    path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-    delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
-    partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
+  object_name = 'ROLEDB_SCHEMA',
+  keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+  signing_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+  previous_keyids = SCHEMA.Optional(KEYIDS_SCHEMA),
+  threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
+  previous_threshold = SCHEMA.Optional(THRESHOLD_SCHEMA),
+  version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
+  expires = SCHEMA.Optional(ISO8601_DATETIME_SCHEMA),
+  signatures = SCHEMA.Optional(SIGNATURES_SCHEMA),
+  paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
+  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
+  delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
+  partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
 
 # Root role: indicates root keys and top-level roles.
 ROOT_SCHEMA = SCHEMA.Object(
-    object_name = 'ROOT_SCHEMA',
-    _type = SCHEMA.String('root'),
-    version = METADATAVERSION_SCHEMA,
-    consistent_snapshot = BOOLEAN_SCHEMA,
-    expires = ISO8601_DATETIME_SCHEMA,
-    keys = KEYDICT_SCHEMA,
-    roles = ROLEDICT_SCHEMA)
+  object_name = 'ROOT_SCHEMA',
+  _type = SCHEMA.String('root'),
+  version = METADATAVERSION_SCHEMA,
+  consistent_snapshot = BOOLEAN_SCHEMA,
+  expires = ISO8601_DATETIME_SCHEMA,
+  keys = KEYDICT_SCHEMA,
+  roles = ROLEDICT_SCHEMA)
 
 # Targets role: Indicates targets and delegates target paths to other roles.
 TARGETS_SCHEMA = SCHEMA.Object(
-    object_name = 'TARGETS_SCHEMA',
-    _type = SCHEMA.String('targets'),
-    version = METADATAVERSION_SCHEMA,
-    expires = ISO8601_DATETIME_SCHEMA,
-    targets = FILEDICT_SCHEMA,
-    delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA))
+  object_name = 'TARGETS_SCHEMA',
+  _type = SCHEMA.String('targets'),
+  version = METADATAVERSION_SCHEMA,
+  expires = ISO8601_DATETIME_SCHEMA,
+  targets = FILEDICT_SCHEMA,
+  delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA))
 
 # Snapshot role: indicates the latest versions of all metadata (except
 # timestamp).
 SNAPSHOT_SCHEMA = SCHEMA.Object(
-    object_name = 'SNAPSHOT_SCHEMA',
-    _type = SCHEMA.String('snapshot'),
-    version = METADATAVERSION_SCHEMA,
-    expires = ISO8601_DATETIME_SCHEMA,
-    meta = VERSIONDICT_SCHEMA)
+  object_name = 'SNAPSHOT_SCHEMA',
+  _type = SCHEMA.String('snapshot'),
+  version = METADATAVERSION_SCHEMA,
+  expires = ISO8601_DATETIME_SCHEMA,
+  meta = VERSIONDICT_SCHEMA)
 
 # Timestamp role: indicates the latest version of the snapshot file.
 TIMESTAMP_SCHEMA = SCHEMA.Object(
-    object_name = 'TIMESTAMP_SCHEMA',
-    _type = SCHEMA.String('timestamp'),
-    version = METADATAVERSION_SCHEMA,
-    expires = ISO8601_DATETIME_SCHEMA,
-    meta = FILEDICT_SCHEMA)
+  object_name = 'TIMESTAMP_SCHEMA',
+  _type = SCHEMA.String('timestamp'),
+  version = METADATAVERSION_SCHEMA,
+  expires = ISO8601_DATETIME_SCHEMA,
+  meta = FILEDICT_SCHEMA)
 
 # project.cfg file: stores information about the project in a json dictionary
 PROJECT_CFG_SCHEMA = SCHEMA.Object(
@@ -497,34 +497,34 @@ PROJECT_CFG_SCHEMA = SCHEMA.Object(
     prefix = PATH_SCHEMA,
     public_keys = KEYDICT_SCHEMA,
     threshold = SCHEMA.Integer(lo = 0, hi = 2)
-)
+    )
 
 # A schema containing information a repository mirror may require,
 # such as a url, the path of the directory metadata files, etc.
 MIRROR_SCHEMA = SCHEMA.Object(
-    object_name = 'MIRROR_SCHEMA',
-    url_prefix = URL_SCHEMA,
-    metadata_path = RELPATH_SCHEMA,
-    targets_path = RELPATH_SCHEMA,
-    confined_target_dirs = RELPATHS_SCHEMA,
-    custom = SCHEMA.Optional(SCHEMA.Object()))
+  object_name = 'MIRROR_SCHEMA',
+  url_prefix = URL_SCHEMA,
+  metadata_path = RELPATH_SCHEMA,
+  targets_path = RELPATH_SCHEMA,
+  confined_target_dirs = RELPATHS_SCHEMA,
+  custom = SCHEMA.Optional(SCHEMA.Object()))
 
 # A dictionary of mirrors where the dict keys hold the mirror's name and
 # and the dict values the mirror's data (i.e., 'MIRROR_SCHEMA').
 # The repository class of 'updater.py' accepts dictionaries
 # of this type provided by the TUF client.
 MIRRORDICT_SCHEMA = SCHEMA.DictOf(
-    key_schema = SCHEMA.AnyString(),
-    value_schema = MIRROR_SCHEMA)
+  key_schema = SCHEMA.AnyString(),
+  value_schema = MIRROR_SCHEMA)
 
 # A Mirrorlist: indicates all the live mirrors, and what documents they
 # serve.
 MIRRORLIST_SCHEMA = SCHEMA.Object(
-    object_name = 'MIRRORLIST_SCHEMA',
-    _type = SCHEMA.String('mirrors'),
-    version = METADATAVERSION_SCHEMA,
-    expires = ISO8601_DATETIME_SCHEMA,
-    mirrors = SCHEMA.ListOf(MIRROR_SCHEMA))
+  object_name = 'MIRRORLIST_SCHEMA',
+  _type = SCHEMA.String('mirrors'),
+  version = METADATAVERSION_SCHEMA,
+  expires = ISO8601_DATETIME_SCHEMA,
+  mirrors = SCHEMA.ListOf(MIRROR_SCHEMA))
 
 # Any of the role schemas (e.g., TIMESTAMP_SCHEMA, SNAPSHOT_SCHEMA, etc.)
 ANYROLE_SCHEMA = SCHEMA.OneOf([ROOT_SCHEMA, TARGETS_SCHEMA, SNAPSHOT_SCHEMA,
@@ -642,7 +642,7 @@ def format_base64(data):
 
   except (TypeError, binascii.Error) as e:
     raise securesystemslib.exceptions.FormatError('Invalid base64'
-                                                  ' encoding: ' + str(e))
+      ' encoding: ' + str(e))
 
 
 
@@ -682,7 +682,7 @@ def parse_base64(base64_string):
 
   except (TypeError, binascii.Error) as e:
     raise securesystemslib.exceptions.FormatError('Invalid base64'
-                                                  ' encoding: ' + str(e))
+      ' encoding: ' + str(e))
 
 
 

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -264,8 +264,8 @@ ANYKEYLIST_SCHEMA = SCHEMA.ListOf(ANYKEY_SCHEMA)
 
 # RSA signature schemes.
 RSA_SCHEME_SCHEMA = SCHEMA.OneOf([
-  SCHEMA.String('rsassa-pss-sha256'),
-  SCHEMA.String('rsa-pkcs1v15-sha256')])
+  SCHEMA.RegularExpression(r'rsassa-pss-(md1|sha1|sha224|sha256|sha384|sha512)'),
+  SCHEMA.RegularExpression(r'rsa-pkcs1v15-(md1|sha1|sha224|sha256|sha384|sha512)')])
 
 # An RSA TUF key.
 RSAKEY_SCHEMA = SCHEMA.Object(

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -264,8 +264,8 @@ ANYKEYLIST_SCHEMA = SCHEMA.ListOf(ANYKEY_SCHEMA)
 
 # RSA signature schemes.
 RSA_SCHEME_SCHEMA = SCHEMA.OneOf([
-  SCHEMA.RegularExpression(r'rsassa-pss-(md1|sha1|sha224|sha256|sha384|sha512)'),
-  SCHEMA.RegularExpression(r'rsa-pkcs1v15-(md1|sha1|sha224|sha256|sha384|sha512)')])
+  SCHEMA.RegularExpression(r'rsassa-pss-(md5|sha1|sha224|sha256|sha384|sha512)'),
+  SCHEMA.RegularExpression(r'rsa-pkcs1v15-(md5|sha1|sha224|sha256|sha384|sha512)')])
 
 # An RSA TUF key.
 RSAKEY_SCHEMA = SCHEMA.Object(

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -267,7 +267,7 @@ RSA_SCHEME_SCHEMA = SCHEMA.OneOf([
   SCHEMA.RegularExpression(r'rsassa-pss-(md5|sha1|sha224|sha256|sha384|sha512)'),
   SCHEMA.RegularExpression(r'rsa-pkcs1v15-(md5|sha1|sha224|sha256|sha384|sha512)')])
 
-  # An RSA TUF key.
+# An RSA TUF key.
 RSAKEY_SCHEMA = SCHEMA.Object(
   object_name = 'RSAKEY_SCHEMA',
   keytype = SCHEMA.String('rsa'),

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -47,6 +47,82 @@ DEFAULT_HASH_LIBRARY = 'hashlib'
 SUPPORTED_LIBRARIES = ['hashlib']
 
 
+# If `pyca_crypto` is installed, add it to supported libraries
+try:
+  import cryptography.exceptions
+  import cryptography.hazmat.backends
+  import cryptography.hazmat.primitives.hashes
+  import binascii
+
+  # Dictionary of `pyca/cryptography` supported hash algorithms.
+  PYCA_DIGEST_OBJECTS_CACHE = {hash_algo.name: hash_algo
+                               for hash_algo in cryptography.hazmat.primitives.hashes.HashAlgorithm._abc_registry}
+
+  SUPPORTED_LIBRARIES.append('pyca_crypto')
+
+  class Pyca_Diggest_Wrapper(object):
+    """
+    <Purpose>
+      A wrapper around `cryptography.hazmat.primitives.hashes.Hash` which adds
+      additional methods to meet expected interface for digest objects:
+      
+        digest_object.digest_size
+        digest_object.hexdigest()
+        digest_object.update('data')
+        digest_object.digest()
+
+    <Properties>
+      algorithm:
+        Specific for `cryptography.hazmat.primitives.hashes.Hash` object, but
+        needed for `pyca_crypto_keys.py`
+
+      digest_size:
+        Returns original's object digest size.
+  
+    <Methods>
+      digest(self) -> bytes:
+        Calls original's object `finalize` method and returns digest as bytes.
+        NOTE: `cryptography.hazmat.primitives.hashes.Hash` allows calling
+        `finalize` method just once on the same instance, so everytime `digest`
+        methods is called, we replace internal object (`_digest_obj`).
+  
+      hexdigest(self) -> str:
+        Returns a string hex representation of digest.
+  
+      update(self, data) -> None:
+        Updates digest object data by calling the original's object `update`
+        method.
+    """
+
+    def __init__(self, digest_obj):
+      self._digest_obj = digest_obj
+
+    @property
+    def algorithm(self):
+      return self._digest_obj.algorithm
+
+    @property
+    def digest_size(self):
+      return self._digest_obj.algorithm.digest_size
+
+    def digest(self):
+      digest_obj_copy = self._digest_obj.copy()
+      digest = self._digest_obj.finalize()
+      self._digest_obj = digest_obj_copy
+      return digest
+
+    def hexdigest(self):
+      return binascii.hexlify(self.digest()).decode('utf-8')
+
+    def update(self, data):
+      self._digest_obj.update(data)
+
+except ImportError: #pragma: no cover
+  pass
+
+
+
+
 def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
   """
   <Purpose>
@@ -93,7 +169,11 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
     None.
 
   <Returns>
-    Digest object (e.g., hashlib.new(algorithm)).
+    Digest object
+
+    e.g.
+      hashlib.new(algorithm) or
+      Pyca_Diggest_Wrapper object
   """
 
   # Are the arguments properly formatted?  If not, raise
@@ -111,9 +191,17 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
       raise securesystemslib.exceptions.UnsupportedAlgorithmError(algorithm)
 
   # Was a pyca_crypto digest object requested and is it supported?
-  elif hash_library == 'pyca_crypto' and hash_library in SUPPORTED_LIBRARIES: #pragma: no cover
-    # TODO: Add support for pyca/cryptography's hashing routines.
-    pass
+  elif hash_library == 'pyca_crypto' and hash_library in SUPPORTED_LIBRARIES:
+    try:
+      global PYCA_DIGEST_OBJECTS_CACHE
+
+      hash_algorithm = PYCA_DIGEST_OBJECTS_CACHE[algorithm]()
+      return Pyca_Diggest_Wrapper(
+        cryptography.hazmat.primitives.hashes.Hash(hash_algorithm,
+        cryptography.hazmat.backends.default_backend()))
+    
+    except KeyError:
+      raise securesystemslib.exceptions.UnsupportedAlgorithmError(algorithm)
 
   # The requested hash library is not supported.
   else:
@@ -166,7 +254,11 @@ def digest_fileobject(file_object, algorithm=DEFAULT_HASH_ALGORITHM,
     None.
 
   <Returns>
-    Digest object (e.g., hashlib.new(algorithm)).
+    Digest object
+
+    e.g.
+      hashlib.new(algorithm) or
+      Pyca_Diggest_Wrapper object
   """
 
   # Are the arguments properly formatted?  If not, raise
@@ -254,7 +346,11 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
     None.
 
   <Returns>
-    Digest object (e.g., hashlib.new(algorithm)).
+    Digest object
+
+    e.g.
+      hashlib.new(algorithm) or
+      Pyca_Diggest_Wrapper object
   """
   # Are the arguments properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
@@ -274,3 +370,51 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
         file_object, algorithm, hash_library, normalize_line_endings)
 
   return digest_object
+
+
+
+
+
+def digest_from_rsa_scheme(scheme, hash_library=DEFAULT_HASH_LIBRARY):
+  """
+  <Purpose>
+    Get digest object from RSA scheme.
+
+  <Arguments>
+    scheme:
+      A string that indicates the signature scheme used to generate
+      'signature'. Currently supported RSA schemes are defined in 
+      `securesystemslib.keys.RSA_SIGNATURE_SCHEMES`
+
+    hash_library:
+      The crypto library to use for the given hash algorithm (e.g., 'hashlib').
+
+  <Exceptions>
+    securesystemslib.exceptions.FormatError, if the arguments are
+    improperly formatted.
+    
+    securesystemslib.exceptions.UnsupportedAlgorithmError, if an unsupported
+    hashing algorithm is specified, or digest could not be generated with given
+    the algorithm.
+    
+    securesystemslib.exceptions.UnsupportedLibraryError, if an unsupported
+    library was requested via 'hash_library'.
+    
+  <Side Effects>
+    None.
+
+  <Returns>
+    Digest object
+
+    e.g.
+      hashlib.new(algorithm) or
+      Pyca_Diggest_Wrapper object
+  """
+  # Are the arguments properly formatted?  If not, raise
+  # 'securesystemslib.exceptions.FormatError'.
+  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+
+  # Get hash algorithm from rsa scheme (hash algorithm id is specified after
+  # the last dash; e.g. rsassa-pss-sha256 -> sha256)
+  hash_algorithm = scheme.split('-')[-1]
+  return digest(hash_algorithm, hash_library)

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -121,7 +121,19 @@ _KEY_ID_HASH_ALGORITHM = 'sha256'
 # size 3072 provide security through 2031 and beyond.
 _DEFAULT_RSA_KEY_BITS = 3072
 
-_SUPPORTED_RSA_SIGNATURE_SCHEMES = ['rsassa-pss-sha256', 'rsa-pkcs1v15-sha256']
+
+RSA_SIGNATURE_SCHEMES = [
+  'rsassa-pss-md5',
+  'rsassa-pss-sha1',
+  'rsassa-pss-sha224',
+  'rsassa-pss-sha256',
+  'rsassa-pss-sha512',
+  'rsa-pkcs1v15-md5',
+  'rsa-pkcs1v15-sha1',
+  'rsa-pkcs1v15-sha224',
+  'rsa-pkcs1v15-sha256',
+  'rsa-pkcs1v15-sha512',
+]
 
 logger = logging.getLogger('securesystemslib_keys')
 
@@ -167,8 +179,8 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
       greater, and a multiple of 256.
 
     scheme:
-      The signature scheme used by the key.  It must be one of
-      ['rsassa-pss-sha256', 'rsa-pkcs1v15-sha256'].
+      The signature scheme used by the key.  It must be one from the list
+      `securesystemslib.keys.RSA_SIGNATURE_SCHEMES`.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'bits' is improperly or invalid
@@ -694,9 +706,9 @@ def create_signature(key_dict, data):
   # The key type of 'key_dict' must be either 'rsa' or 'ed25519'.
   securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_dict)
 
-  # Signing the 'data' object requires a private key.  'rsassa-pss-sha256',
-  # 'rsa-pkcs1v15-sha256', 'ed25519', and 'ecdsa-sha2-nistp256' are the only
-  # signing schemes currently supported.
+  # Signing the 'data' object requires a private key. Signing schemes that are
+  # currently supported are: 'ed25519', 'ecdsa-sha2-nistp256', and rsa schemes
+  # defined in `securesystemslib.keys.RSA_SIGNATURE_SCHEMES`.
   # RSASSA-PSS and RSA-PKCS1v15 keys and signatures can be generated and
   # verified by pyca_crypto_keys.py, and Ed25519 keys by PyNaCl and PyCA's
   # optimized, pure python implementation of Ed25519.
@@ -709,7 +721,7 @@ def create_signature(key_dict, data):
   sig = None
 
   if keytype == 'rsa':
-    if scheme in _SUPPORTED_RSA_SIGNATURE_SCHEMES:
+    if scheme in RSA_SIGNATURE_SCHEMES:
       private = private.replace('\r\n', '\n')
       sig, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(
           private, data, scheme)
@@ -850,7 +862,7 @@ def verify_signature(key_dict, signature, data):
 
 
   if keytype == 'rsa':
-    if scheme in _SUPPORTED_RSA_SIGNATURE_SCHEMES:
+    if scheme in RSA_SIGNATURE_SCHEMES:
       valid_signature = securesystemslib.pyca_crypto_keys.verify_rsa_signature(sig,
         scheme, public, data)
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -121,6 +121,8 @@ _KEY_ID_HASH_ALGORITHM = 'sha256'
 # size 3072 provide security through 2031 and beyond.
 _DEFAULT_RSA_KEY_BITS = 3072
 
+_SUPPORTED_RSA_SIGNATURE_SCHEMES = ['rsassa-pss-sha256', 'rsa-pkcs1v15-sha256']
+
 logger = logging.getLogger('securesystemslib_keys')
 
 
@@ -166,7 +168,7 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
 
     scheme:
       The signature scheme used by the key.  It must be one of
-      ['rsassa-pss-sha256'].
+      ['rsassa-pss-sha256', 'rsa-pkcs1v15-sha256'].
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'bits' is improperly or invalid
@@ -693,10 +695,11 @@ def create_signature(key_dict, data):
   securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_dict)
 
   # Signing the 'data' object requires a private key.  'rsassa-pss-sha256',
-  # 'ed25519', and 'ecdsa-sha2-nistp256' are the only signing schemes currently
-  # supported.  RSASSA-PSS keys and signatures can be generated and verified by
-  # pyca_crypto_keys.py, and Ed25519 keys by PyNaCl and PyCA's optimized, pure
-  # python implementation of Ed25519.
+  # 'rsa-pkcs1v15-sha256', 'ed25519', and 'ecdsa-sha2-nistp256' are the only
+  # signing schemes currently supported.
+  # RSASSA-PSS and RSA-PKCS1v15 keys and signatures can be generated and
+  # verified by pyca_crypto_keys.py, and Ed25519 keys by PyNaCl and PyCA's
+  # optimized, pure python implementation of Ed25519.
   signature = {}
   keytype = key_dict['keytype']
   scheme = key_dict['scheme']
@@ -706,7 +709,7 @@ def create_signature(key_dict, data):
   sig = None
 
   if keytype == 'rsa':
-    if scheme == 'rsassa-pss-sha256':
+    if scheme in _SUPPORTED_RSA_SIGNATURE_SCHEMES:
       private = private.replace('\r\n', '\n')
       sig, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(
           private, data, scheme)
@@ -847,7 +850,7 @@ def verify_signature(key_dict, signature, data):
 
 
   if keytype == 'rsa':
-    if scheme == 'rsassa-pss-sha256':
+    if scheme in _SUPPORTED_RSA_SIGNATURE_SCHEMES:
       valid_signature = securesystemslib.pyca_crypto_keys.verify_rsa_signature(sig,
         scheme, public, data)
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -127,11 +127,13 @@ RSA_SIGNATURE_SCHEMES = [
   'rsassa-pss-sha1',
   'rsassa-pss-sha224',
   'rsassa-pss-sha256',
+  'rsassa-pss-sha384',
   'rsassa-pss-sha512',
   'rsa-pkcs1v15-md5',
   'rsa-pkcs1v15-sha1',
   'rsa-pkcs1v15-sha224',
   'rsa-pkcs1v15-sha256',
+  'rsa-pkcs1v15-sha384',
   'rsa-pkcs1v15-sha512',
 ]
 

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -190,7 +190,7 @@ def _get_hash_function_from_scheme(scheme):
   """
   try:
     hash_id = scheme.split('-')[-1]
-    return _HASH_FUNCTIONS.get(hash_id)
+    return _HASH_FUNCTIONS[hash_id]
   except KeyError:
     raise securesystemslib.exceptions.UnsupportedAlgorithmError(
         'Unsupported hash algorithm is specified: ' + hash_id)

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -486,25 +486,34 @@ def create_rsa_encrypted_pem(private_key, passphrase):
     of the RSA key is encrypted using the best available encryption for a given
     key's backend. This is a curated (by cryptography.io) encryption choice and
     the algorithm may change over time.
+
     c.f. cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/
         #cryptography.hazmat.primitives.serialization.BestAvailableEncryption
+
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'
     >>> encrypted_pem = create_rsa_encrypted_pem(private, passphrase)
     >>> securesystemslib.formats.PEMRSA_SCHEMA.matches(encrypted_pem)
     True
+
   <Arguments>
     private_key:
       The private key string in PEM format.
+
     passphrase:
       The passphrase, or password, to encrypt the private part of the RSA
       key.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
         formatted.
+
     securesystemslib.exceptions.CryptoError, if the passed RSA key cannot be
         deserialized by pyca cryptography.
+
     ValueError, if 'private_key' is unset.
+
+
   <Returns>
     A string in PEM format (TraditionalOpenSSL), where the private RSA key is
     encrypted. Conforms to 'securesystemslib.formats.PEMRSA_SCHEMA'.
@@ -549,10 +558,15 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     Generate public and private RSA keys from an optionally encrypted PEM.  The
     public and private keys returned conform to
     'securesystemslib.formats.PEMRSA_SCHEMA' and have the form:
+
     '-----BEGIN RSA PUBLIC KEY----- ... -----END RSA PUBLIC KEY-----'
+
     and
+
     '-----BEGIN RSA PRIVATE KEY----- ...-----END RSA PRIVATE KEY-----'
+
     The public and private keys are returned as strings in PEM format.
+
     In case the private key part of 'pem' is encrypted  pyca/cryptography's
     load_pem_private_key() method is passed passphrase.  In the default case
     here, pyca/cryptography will decrypt with a PBKDF1+MD5
@@ -560,6 +574,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     Alternatively, key data may be encrypted with AES-CTR-Mode and the
     passphrase strengthened with PBKDF2+SHA256, although this method is used
     only with TUF encrypted key files.
+
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'
     >>> encrypted_pem = create_rsa_encrypted_pem(private, passphrase)
@@ -573,25 +588,32 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     True
     >>> private == returned_private
     True
+
   <Arguments>
     pem:
       A byte string in PEM format, where the private key can be encrypted.
       It has the form:
+
       '-----BEGIN RSA PRIVATE KEY-----\n
       Proc-Type: 4,ENCRYPTED\nDEK-Info: DES-EDE3-CBC ...'
+
     passphrase: (optional)
       The passphrase, or password, to decrypt the private part of the RSA
       key.  'passphrase' is not directly used as the encryption key, instead
       it is used to derive a stronger symmetric key.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
+
     securesystemslib.exceptions.CryptoError, if the public and private RSA keys
     cannot be generated from 'pem', or exported in PEM format.
+
   <Side Effects>
     pyca/cryptography's 'serialization.load_pem_private_key()' called to
     perform the actual conversion from an encrypted RSA private key to
     PEM format.
+
   <Returns>
     A (public, private) tuple containing the RSA keys in PEM format.
   """
@@ -660,15 +682,18 @@ def encrypt_key(key_object, password):
     object.  'key_object' is a TUF key (e.g., RSAKEY_SCHEMA,
     ED25519KEY_SCHEMA).  This function calls the pyca/cryptography library to
     perform the encryption and derive a suitable encryption key.
+
     Whereas an encrypted PEM file uses the Triple Data Encryption Algorithm
     (3DES), the Cipher-block chaining (CBC) mode of operation, and the Password
     Based Key Derivation Function 1 (PBKF1) + MD5 to strengthen 'password',
     encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
     PBKDF2-HMAC-SHA256 (100K iterations by default, but may be overriden in
     'settings.PBKDF2_ITERATIONS' by the user).
+
     http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
     http://en.wikipedia.org/wiki/CTR_mode#Counter_.28CTR.29
     https://en.wikipedia.org/wiki/PBKDF2
+
     >>> ed25519_key = {'keytype': 'ed25519', \
                        'scheme': 'ed25519', \
                        'keyid': \
@@ -681,24 +706,30 @@ def encrypt_key(key_object, password):
     >>> encrypted_key = encrypt_key(ed25519_key, passphrase)
     >>> securesystemslib.formats.ENCRYPTEDKEY_SCHEMA.matches(encrypted_key.encode('utf-8'))
     True
+
   <Arguments>
     key_object:
       The TUF key object that should contain the private portion of the ED25519
       key.
+
     password:
       The password, or passphrase, to encrypt the private part of the RSA
       key.  'password' is not used directly as the encryption key, a stronger
       encryption key is derived from it.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if any of the arguments are
     improperly formatted or 'key_object' does not contain the private portion
     of the key.
+
     securesystemslib.exceptions.CryptoError, if an Ed25519 key in encrypted TUF
     format cannot be created.
+
   <Side Effects>
     pyca/Cryptography cryptographic operations called to perform the actual
     encryption of 'key_object'.  'password' used to derive a suitable
     encryption key.
+
   <Returns>
     An encrypted string in 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA' format.
   """
@@ -746,12 +777,15 @@ def decrypt_key(encrypted_key, password):
     the original key object, a TUF key (e.g., RSAKEY_SCHEMA, ED25519KEY_SCHEMA).
     This function calls the appropriate cryptography module (i.e.,
     pyca_crypto_keys.py) to perform the decryption.
+
     Encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
     PBKDF2-HMAC-SHA256 (100K iterations be default, but may be overriden in
     'settings.py' by the user).
+
     http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
     http://en.wikipedia.org/wiki/CTR_mode#Counter_.28CTR.29
     https://en.wikipedia.org/wiki/PBKDF2
+
     >>> ed25519_key = {'keytype': 'ed25519', \
                        'scheme': 'ed25519', \
                        'keyid': \
@@ -767,27 +801,34 @@ def decrypt_key(encrypted_key, password):
     True
     >>> decrypted_key == ed25519_key
     True
+
   <Arguments>
     encrypted_key:
       An encrypted TUF key (additional data is also included, such as salt,
       number of password iterations used for the derived encryption key, etc)
       of the form 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA'.
       'encrypted_key' should have been generated with encrypted_key().
+
     password:
       The password, or passphrase, to encrypt the private part of the RSA
       key.  'password' is not used directly as the encryption key, a stronger
       encryption key is derived from it.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
+
     securesystemslib.exceptions.CryptoError, if a TUF key cannot be decrypted
     from 'encrypted_key'.
+
     securesystemslib.exceptions.Error, if a valid TUF key object is not found in
     'encrypted_key'.
+
   <Side Effects>
     The pyca/cryptography is library called to perform the actual decryption
     of 'encrypted_key'.  The key derivation data stored in 'encrypted_key' is
     used to re-derive the encryption/decryption key.
+
   <Returns>
     The decrypted key object in 'securesystemslib.formats.ANYKEY_SCHEMA' format.
   """
@@ -860,15 +901,19 @@ def _encrypt(key_data, derived_key_information):
   key size is 256 bits and AES's mode of operation is set to CTR (CounTeR Mode).
   The HMAC of the ciphertext is generated to ensure the ciphertext has not been
   modified.
+
   'key_data' is the JSON string representation of the key.  In the case
   of RSA keys, this format would be 'securesystemslib.formats.RSAKEY_SCHEMA':
+
   {'keytype': 'rsa',
    'keyval': {'public': '-----BEGIN RSA PUBLIC KEY----- ...',
               'private': '-----BEGIN RSA PRIVATE KEY----- ...'}}
+
   'derived_key_information' is a dictionary of the form:
     {'salt': '...',
      'derived_key': '...',
      'iterations': '...'}
+
   'securesystemslib.exceptions.CryptoError' raised if the encryption fails.
   """
 
@@ -927,6 +972,7 @@ def _encrypt(key_data, derived_key_information):
 def _decrypt(file_contents, password):
   """
   The corresponding decryption routine for _encrypt().
+
   'securesystemslib.exceptions.CryptoError' raised if the decryption fails.
   """
 

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -353,7 +353,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
 
       hash_func = _get_hash_function_from_scheme(scheme)
 
-      if scheme == 'rsassa-pss-sha256':
+      if scheme.startswith('rsassa-pss'):
         # Generate an RSSA-PSS signature.  Raise
         # 'securesystemslib.exceptions.CryptoError' for any of the expected
         # exceptions raised by pyca/cryptography.
@@ -361,7 +361,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
             data, padding.PSS(mgf=padding.MGF1(hash_func()),
                               salt_length=hash_func().digest_size), hash_func())
 
-      elif scheme == 'rsa-pkcs1v15-sha256':
+      elif scheme.startswith('rsa-pkcs1v15'):
         # Generate an RSSA-PSS signature.  Raise
         # 'securesystemslib.exceptions.CryptoError' for any of the expected
         # exceptions raised by pyca/cryptography.

--- a/securesystemslib/pyca_crypto_keys.py
+++ b/securesystemslib/pyca_crypto_keys.py
@@ -214,20 +214,20 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
   # and a 2048-bit minimum is enforced by
   # securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match().
   private_key = rsa.generate_private_key(public_exponent=65537, key_size=bits,
-                                         backend=default_backend())
+      backend=default_backend())
 
   # Extract the public & private halves of the RSA key and generate their
   # PEM-formatted representations.  Return the key pair as a (public, private)
   # tuple, where each RSA is a string in PEM format.
   private_pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
-                                          format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                          encryption_algorithm=serialization.NoEncryption())
+      format=serialization.PrivateFormat.TraditionalOpenSSL,
+      encryption_algorithm=serialization.NoEncryption())
 
   # Need to generate the public pem from the private key before serialization
   # to PEM.
   public_key = private_key.public_key()
   public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
-                                       format=serialization.PublicFormat.SubjectPublicKeyInfo)
+      format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
   return public_pem.decode('utf-8'), private_pem.decode('utf-8')
 
@@ -303,61 +303,61 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   # explicitly check that 'private_key' is not '', we can/should check for a
   # value and not compare identities with the 'is' keyword.  Up to this point
   # 'private_key' has variable size and can be an empty string.
-  if len(private_key):
-
-    try:
-      # 'private_key' (in PEM format) must first be converted to a
-      # pyca/cryptography private key object before a signature can be
-      # generated.
-      private_key_object = load_pem_private_key(private_key.encode('utf-8'),
-                                                password=None, backend=default_backend())
-
-      digest_obj = securesystemslib.hash.digest_from_rsa_scheme(scheme, 'pyca_crypto')
-
-      if scheme.startswith('rsassa-pss'):
-        # Generate an RSSA-PSS signature.  Raise
-        # 'securesystemslib.exceptions.CryptoError' for any of the expected
-        # exceptions raised by pyca/cryptography.
-        signature = private_key_object.sign(
-            data, padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-                              salt_length=digest_obj.algorithm.digest_size), digest_obj.algorithm)
-
-      elif scheme.startswith('rsa-pkcs1v15'):
-        # Generate an RSA-PKCS1v15 signature.  Raise
-        # 'securesystemslib.exceptions.CryptoError' for any of the expected
-        # exceptions raised by pyca/cryptography.
-        signature = private_key_object.sign(data, padding.PKCS1v15(), digest_obj.algorithm)
-
-      # The RSA_SCHEME_SCHEMA.check_match() above should have validated 'scheme'.
-      # This is a defensive check check..
-      else:  # pragma: no cover
-        raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
-                                                                    ' signature scheme is specified: ' + repr(scheme))
-
-    # If the PEM data could not be decrypted, or if its structure could not
-    # be decoded successfully.
-    except ValueError:
-      raise securesystemslib.exceptions.CryptoError('The private key'
-                                                    ' (in PEM format) could not be deserialized.')
-
-    # 'TypeError' is raised if a password was given and the private key was
-    # not encrypted, or if the key was encrypted but no password was
-    # supplied.  Note: A passphrase or password is not used when generating
-    # 'private_key', since it should not be encrypted.
-    except TypeError:
-      raise securesystemslib.exceptions.CryptoError('The private key was'
-                                                    ' unexpectedly encrypted.')
-
-    # 'cryptography.exceptions.UnsupportedAlgorithm' is raised if the
-    # serialized key is of a type that is not supported by the backend, or if
-    # the key is encrypted with a symmetric cipher that is not supported by
-    # the backend.
-    except cryptography.exceptions.UnsupportedAlgorithm:  # pragma: no cover
-      raise securesystemslib.exceptions.CryptoError('The private key is'
-                                                    ' encrypted with an unsupported algorithm.')
-
-  else:
+  if not len(private_key):
     raise ValueError('The required private key is unset.')
+
+  try:
+    # 'private_key' (in PEM format) must first be converted to a
+    # pyca/cryptography private key object before a signature can be
+    # generated.
+    private_key_object = load_pem_private_key(private_key.encode('utf-8'),
+        password=None, backend=default_backend())
+
+    digest_obj = securesystemslib.hash.digest_from_rsa_scheme(scheme,
+        'pyca_crypto')
+
+    if scheme.startswith('rsassa-pss'):
+      # Generate an RSSA-PSS signature.  Raise
+      # 'securesystemslib.exceptions.CryptoError' for any of the expected
+      # exceptions raised by pyca/cryptography.
+      signature = private_key_object.sign(
+          data, padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
+          salt_length=digest_obj.algorithm.digest_size), digest_obj.algorithm)
+
+    elif scheme.startswith('rsa-pkcs1v15'):
+      # Generate an RSA-PKCS1v15 signature.  Raise
+      # 'securesystemslib.exceptions.CryptoError' for any of the expected
+      # exceptions raised by pyca/cryptography.
+      signature = private_key_object.sign(data, padding.PKCS1v15(),
+          digest_obj.algorithm)
+
+    # The RSA_SCHEME_SCHEMA.check_match() above should have validated 'scheme'.
+    # This is a defensive check check..
+    else:  # pragma: no cover
+      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+          ' signature scheme is specified: ' + repr(scheme))
+
+  # If the PEM data could not be decrypted, or if its structure could not
+  # be decoded successfully.
+  except ValueError:
+    raise securesystemslib.exceptions.CryptoError('The private key'
+        ' (in PEM format) could not be deserialized.')
+
+  # 'TypeError' is raised if a password was given and the private key was
+  # not encrypted, or if the key was encrypted but no password was
+  # supplied.  Note: A passphrase or password is not used when generating
+  # 'private_key', since it should not be encrypted.
+  except TypeError:
+    raise securesystemslib.exceptions.CryptoError('The private key was'
+        ' unexpectedly encrypted.')
+
+  # 'cryptography.exceptions.UnsupportedAlgorithm' is raised if the
+  # serialized key is of a type that is not supported by the backend, or if
+  # the key is encrypted with a symmetric cipher that is not supported by
+  # the backend.
+  except cryptography.exceptions.UnsupportedAlgorithm:  # pragma: no cover
+    raise securesystemslib.exceptions.CryptoError('The private key is'
+        ' encrypted with an unsupported algorithm.')
 
   return signature, scheme
 
@@ -439,9 +439,11 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
 
   # Verify the RSASSA-PSS signature with pyca/cryptography.
   try:
-    public_key_object = serialization.load_pem_public_key(public_key.encode('utf-8'),
-                                                          backend=default_backend())
-    digest_obj = securesystemslib.hash.digest_from_rsa_scheme(signature_scheme, 'pyca_crypto')
+    public_key_object = serialization.load_pem_public_key(
+        public_key.encode('utf-8'), backend=default_backend())
+
+    digest_obj = securesystemslib.hash.digest_from_rsa_scheme(signature_scheme,
+        'pyca_crypto')
 
     # verify() raises 'cryptography.exceptions.InvalidSignature' if the
     # signature is invalid. 'salt_length' is set to the digest size of the
@@ -449,18 +451,19 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
     try:
       if signature_scheme.startswith('rsassa-pss'):
         public_key_object.verify(signature, data,
-                                 padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-                                             salt_length=digest_obj.algorithm.digest_size),
-                                 digest_obj.algorithm)
+            padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
+            salt_length=digest_obj.algorithm.digest_size),
+            digest_obj.algorithm)
 
       elif signature_scheme.startswith('rsa-pkcs1v15'):
-        public_key_object.verify(signature, data, padding.PKCS1v15(), digest_obj.algorithm)
+        public_key_object.verify(signature, data, padding.PKCS1v15(),
+            digest_obj.algorithm)
 
       # The RSA_SCHEME_SCHEMA.check_match() above should have validated 'scheme'.
       # This is a defensive check check..
       else:  # pragma: no cover
         raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
-                                                                    ' signature scheme is specified: ' + repr(scheme))
+            ' signature scheme is specified: ' + repr(scheme))
 
       return True
 
@@ -470,7 +473,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
   # Raised by load_pem_public_key().
   except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as e:
     raise securesystemslib.exceptions.CryptoError('The PEM could not be'
-                                                  ' decoded successfully, or contained an unsupported key type: ' + str(e))
+        ' decoded successfully, or contained an unsupported key type: ' + str(e))
 
 
 
@@ -483,34 +486,25 @@ def create_rsa_encrypted_pem(private_key, passphrase):
     of the RSA key is encrypted using the best available encryption for a given
     key's backend. This is a curated (by cryptography.io) encryption choice and
     the algorithm may change over time.
-
     c.f. cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/
         #cryptography.hazmat.primitives.serialization.BestAvailableEncryption
-
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'
     >>> encrypted_pem = create_rsa_encrypted_pem(private, passphrase)
     >>> securesystemslib.formats.PEMRSA_SCHEMA.matches(encrypted_pem)
     True
-
   <Arguments>
     private_key:
       The private key string in PEM format.
-
     passphrase:
       The passphrase, or password, to encrypt the private part of the RSA
       key.
-
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
         formatted.
-
     securesystemslib.exceptions.CryptoError, if the passed RSA key cannot be
         deserialized by pyca cryptography.
-
     ValueError, if 'private_key' is unset.
-
-
   <Returns>
     A string in PEM format (TraditionalOpenSSL), where the private RSA key is
     encrypted. Conforms to 'securesystemslib.formats.PEMRSA_SCHEMA'.
@@ -529,10 +523,10 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   if len(private_key):
     try:
       private_key = load_pem_private_key(private_key.encode('utf-8'),
-                                         password=None, backend=default_backend())
+          password=None, backend=default_backend())
     except ValueError:
       raise securesystemslib.exceptions.CryptoError('The private key'
-                                                    ' (in PEM format) could not be deserialized.')
+          ' (in PEM format) could not be deserialized.')
 
   else:
     raise ValueError('The required private key is unset.')
@@ -541,7 +535,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
       encoding=serialization.Encoding.PEM,
       format=serialization.PrivateFormat.TraditionalOpenSSL,
       encryption_algorithm=serialization.BestAvailableEncryption(
-          passphrase.encode('utf-8')))
+      passphrase.encode('utf-8')))
 
   return encrypted_pem.decode()
 
@@ -555,15 +549,10 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     Generate public and private RSA keys from an optionally encrypted PEM.  The
     public and private keys returned conform to
     'securesystemslib.formats.PEMRSA_SCHEMA' and have the form:
-
     '-----BEGIN RSA PUBLIC KEY----- ... -----END RSA PUBLIC KEY-----'
-
     and
-
     '-----BEGIN RSA PRIVATE KEY----- ...-----END RSA PRIVATE KEY-----'
-
     The public and private keys are returned as strings in PEM format.
-
     In case the private key part of 'pem' is encrypted  pyca/cryptography's
     load_pem_private_key() method is passed passphrase.  In the default case
     here, pyca/cryptography will decrypt with a PBKDF1+MD5
@@ -571,7 +560,6 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     Alternatively, key data may be encrypted with AES-CTR-Mode and the
     passphrase strengthened with PBKDF2+SHA256, although this method is used
     only with TUF encrypted key files.
-
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'
     >>> encrypted_pem = create_rsa_encrypted_pem(private, passphrase)
@@ -585,32 +573,25 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     True
     >>> private == returned_private
     True
-
   <Arguments>
     pem:
       A byte string in PEM format, where the private key can be encrypted.
       It has the form:
-
       '-----BEGIN RSA PRIVATE KEY-----\n
       Proc-Type: 4,ENCRYPTED\nDEK-Info: DES-EDE3-CBC ...'
-
     passphrase: (optional)
       The passphrase, or password, to decrypt the private part of the RSA
       key.  'passphrase' is not directly used as the encryption key, instead
       it is used to derive a stronger symmetric key.
-
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
-
     securesystemslib.exceptions.CryptoError, if the public and private RSA keys
     cannot be generated from 'pem', or exported in PEM format.
-
   <Side Effects>
     pyca/cryptography's 'serialization.load_pem_private_key()' called to
     perform the actual conversion from an encrypted RSA private key to
     PEM format.
-
   <Returns>
     A (public, private) tuple containing the RSA keys in PEM format.
   """
@@ -632,7 +613,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
   # key.
   try:
     private_key = load_pem_private_key(pem.encode('utf-8'),
-                                       passphrase, backend=default_backend())
+        passphrase, backend=default_backend())
 
   # pyca/cryptography's expected exceptions for 'load_pem_private_key()':
   # ValueError: If the PEM data could not be decrypted.
@@ -646,7 +627,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     # exception message.  Avoid propogating pyca/cryptography's exception trace
     # to avoid revealing sensitive error.
     raise securesystemslib.exceptions.CryptoError('RSA (public, private) tuple'
-                                                  ' cannot be generated from the encrypted PEM string: ' + str(e))
+      ' cannot be generated from the encrypted PEM string: ' + str(e))
 
   # Export the public and private halves of the pyca/cryptography RSA key
   # object.  The (public, private) tuple returned contains the public and
@@ -655,14 +636,14 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
   # PEM-formatted representations.  Return the key pair as a (public, private)
   # tuple, where each RSA is a string in PEM format.
   private_pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
-                                          format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                          encryption_algorithm=serialization.NoEncryption())
+      format=serialization.PrivateFormat.TraditionalOpenSSL,
+      encryption_algorithm=serialization.NoEncryption())
 
   # Need to generate the public key from the private one before serializing
   # to PEM format.
   public_key = private_key.public_key()
   public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
-                                       format=serialization.PublicFormat.SubjectPublicKeyInfo)
+      format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
   return public_pem.decode(), private_pem.decode()
 
@@ -679,18 +660,15 @@ def encrypt_key(key_object, password):
     object.  'key_object' is a TUF key (e.g., RSAKEY_SCHEMA,
     ED25519KEY_SCHEMA).  This function calls the pyca/cryptography library to
     perform the encryption and derive a suitable encryption key.
-
     Whereas an encrypted PEM file uses the Triple Data Encryption Algorithm
     (3DES), the Cipher-block chaining (CBC) mode of operation, and the Password
     Based Key Derivation Function 1 (PBKF1) + MD5 to strengthen 'password',
     encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
     PBKDF2-HMAC-SHA256 (100K iterations by default, but may be overriden in
     'settings.PBKDF2_ITERATIONS' by the user).
-
     http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
     http://en.wikipedia.org/wiki/CTR_mode#Counter_.28CTR.29
     https://en.wikipedia.org/wiki/PBKDF2
-
     >>> ed25519_key = {'keytype': 'ed25519', \
                        'scheme': 'ed25519', \
                        'keyid': \
@@ -703,30 +681,24 @@ def encrypt_key(key_object, password):
     >>> encrypted_key = encrypt_key(ed25519_key, passphrase)
     >>> securesystemslib.formats.ENCRYPTEDKEY_SCHEMA.matches(encrypted_key.encode('utf-8'))
     True
-
   <Arguments>
     key_object:
       The TUF key object that should contain the private portion of the ED25519
       key.
-
     password:
       The password, or passphrase, to encrypt the private part of the RSA
       key.  'password' is not used directly as the encryption key, a stronger
       encryption key is derived from it.
-
   <Exceptions>
     securesystemslib.exceptions.FormatError, if any of the arguments are
     improperly formatted or 'key_object' does not contain the private portion
     of the key.
-
     securesystemslib.exceptions.CryptoError, if an Ed25519 key in encrypted TUF
     format cannot be created.
-
   <Side Effects>
     pyca/Cryptography cryptographic operations called to perform the actual
     encryption of 'key_object'.  'password' used to derive a suitable
     encryption key.
-
   <Returns>
     An encrypted string in 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA' format.
   """
@@ -743,7 +715,7 @@ def encrypt_key(key_object, password):
   # Ensure the private portion of the key is included in 'key_object'.
   if 'private' not in key_object['keyval'] or not key_object['keyval']['private']:
     raise securesystemslib.exceptions.FormatError('Key object does not contain'
-                                                  ' a private part.')
+      ' a private part.')
 
   # Derive a key (i.e., an appropriate encryption key and not the
   # user's password) from the given 'password'.  Strengthen 'password' with
@@ -774,15 +746,12 @@ def decrypt_key(encrypted_key, password):
     the original key object, a TUF key (e.g., RSAKEY_SCHEMA, ED25519KEY_SCHEMA).
     This function calls the appropriate cryptography module (i.e.,
     pyca_crypto_keys.py) to perform the decryption.
-
     Encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
     PBKDF2-HMAC-SHA256 (100K iterations be default, but may be overriden in
     'settings.py' by the user).
-
     http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
     http://en.wikipedia.org/wiki/CTR_mode#Counter_.28CTR.29
     https://en.wikipedia.org/wiki/PBKDF2
-
     >>> ed25519_key = {'keytype': 'ed25519', \
                        'scheme': 'ed25519', \
                        'keyid': \
@@ -798,34 +767,27 @@ def decrypt_key(encrypted_key, password):
     True
     >>> decrypted_key == ed25519_key
     True
-
   <Arguments>
     encrypted_key:
       An encrypted TUF key (additional data is also included, such as salt,
       number of password iterations used for the derived encryption key, etc)
       of the form 'securesystemslib.formats.ENCRYPTEDKEY_SCHEMA'.
       'encrypted_key' should have been generated with encrypted_key().
-
     password:
       The password, or passphrase, to encrypt the private part of the RSA
       key.  'password' is not used directly as the encryption key, a stronger
       encryption key is derived from it.
-
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
-
     securesystemslib.exceptions.CryptoError, if a TUF key cannot be decrypted
     from 'encrypted_key'.
-
     securesystemslib.exceptions.Error, if a valid TUF key object is not found in
     'encrypted_key'.
-
   <Side Effects>
     The pyca/cryptography is library called to perform the actual decryption
     of 'encrypted_key'.  The key derivation data stored in 'encrypted_key' is
     used to re-derive the encryption/decryption key.
-
   <Returns>
     The decrypted key object in 'securesystemslib.formats.ANYKEY_SCHEMA' format.
   """
@@ -881,7 +843,7 @@ def _generate_derived_key(password, salt=None, iterations=None):
   # Derive an AES key with PBKDF2.  The  'length' is the desired key length of
   # the derived key.
   pbkdf_object = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt,
-                            iterations=iterations, backend=backend)
+       iterations=iterations, backend=backend)
 
   derived_key = pbkdf_object.derive(password.encode('utf-8'))
 
@@ -898,19 +860,15 @@ def _encrypt(key_data, derived_key_information):
   key size is 256 bits and AES's mode of operation is set to CTR (CounTeR Mode).
   The HMAC of the ciphertext is generated to ensure the ciphertext has not been
   modified.
-
   'key_data' is the JSON string representation of the key.  In the case
   of RSA keys, this format would be 'securesystemslib.formats.RSAKEY_SCHEMA':
-
   {'keytype': 'rsa',
    'keyval': {'public': '-----BEGIN RSA PUBLIC KEY----- ...',
               'private': '-----BEGIN RSA PRIVATE KEY----- ...'}}
-
   'derived_key_information' is a dictionary of the form:
     {'salt': '...',
      'derived_key': '...',
      'iterations': '...'}
-
   'securesystemslib.exceptions.CryptoError' raised if the encryption fails.
   """
 
@@ -929,7 +887,7 @@ def _encrypt(key_data, derived_key_information):
   # generated IV.
   symmetric_key = derived_key_information['derived_key']
   encryptor = Cipher(algorithms.AES(symmetric_key), modes.CTR(iv),
-                     backend=default_backend()).encryptor()
+      backend=default_backend()).encryptor()
 
   # Encrypt the plaintext and get the associated ciphertext.
   # Do we need to check for any exceptions?
@@ -941,8 +899,8 @@ def _encrypt(key_data, derived_key_information):
   symmetric_key = derived_key_information['derived_key']
   salt = derived_key_information['salt']
   hmac_object = \
-      cryptography.hazmat.primitives.hmac.HMAC(symmetric_key, hashes.SHA256(),
-                                               backend=default_backend())
+    cryptography.hazmat.primitives.hmac.HMAC(symmetric_key, hashes.SHA256(),
+        backend=default_backend())
   hmac_object.update(ciphertext)
   hmac_value = binascii.hexlify(hmac_object.finalize())
 
@@ -969,7 +927,6 @@ def _encrypt(key_data, derived_key_information):
 def _decrypt(file_contents, password):
   """
   The corresponding decryption routine for _encrypt().
-
   'securesystemslib.exceptions.CryptoError' raised if the decryption fails.
   """
 
@@ -981,7 +938,7 @@ def _decrypt(file_contents, password):
   # 'file_contents' does not contains the expected data layout.
   try:
     salt, iterations, hmac, iv, ciphertext = \
-        file_contents.split(_ENCRYPTION_DELIMITER)
+      file_contents.split(_ENCRYPTION_DELIMITER)
 
   except ValueError:
     raise securesystemslib.exceptions.CryptoError('Invalid encrypted file.')
@@ -997,15 +954,15 @@ def _decrypt(file_contents, password):
   # Discard the old "salt" and "iterations" values, as we only need the old
   # derived key.
   junk_old_salt, junk_old_iterations, symmetric_key = \
-      _generate_derived_key(password, salt, iterations)
+    _generate_derived_key(password, salt, iterations)
 
   # Verify the hmac to ensure the ciphertext is valid and has not been altered.
   # See the encryption routine for why we use the encrypt-then-MAC approach.
   # The decryption routine may verify a ciphertext without having to perform
   # a decryption operation.
   generated_hmac_object = \
-      cryptography.hazmat.primitives.hmac.HMAC(symmetric_key, hashes.SHA256(),
-                                               backend=default_backend())
+    cryptography.hazmat.primitives.hmac.HMAC(symmetric_key, hashes.SHA256(),
+        backend=default_backend())
   generated_hmac_object.update(ciphertext)
   generated_hmac = binascii.hexlify(generated_hmac_object.finalize())
 
@@ -1015,7 +972,7 @@ def _decrypt(file_contents, password):
 
   # Construct a Cipher object, with the key and iv.
   decryptor = Cipher(algorithms.AES(symmetric_key), modes.CTR(iv),
-                     backend=default_backend()).decryptor()
+      backend=default_backend()).decryptor()
 
   # Decryption gets us the authenticated plaintext.
   plaintext = decryptor.update(ciphertext) + decryptor.finalize()

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -128,6 +128,9 @@ class TestFormats(unittest.TestCase):
           'rsassa-pss-sha256'),
 
       'RSA_SCHEME_SCHEMA_RSASSA_PSS_5': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-sha384'),
+
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS_6': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
           'rsassa-pss-sha512'),
 
       'RSA_SCHEME_SCHEMA_PKCS1v15': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
@@ -142,7 +145,10 @@ class TestFormats(unittest.TestCase):
       'RSA_SCHEME_SCHEMA_PKCS1v15_4': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
           'rsa-pkcs1v15-sha256'),
 
-      'RSA_SCHEME_SCHEMA_PKCS1v15_4': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+      'RSA_SCHEME_SCHEMA_PKCS1v15_5': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-sha384'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15_6': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
           'rsa-pkcs1v15-sha512'),
 
       'KEY_SCHEMA': (securesystemslib.formats.KEY_SCHEMA,

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -116,7 +116,7 @@ class TestFormats(unittest.TestCase):
           {'public': 'pubkey', 'private': ''}),
 
       'RSA_SCHEME_SCHEMA_RSASSA_PSS': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
-          'rsassa-pss-md1'),
+          'rsassa-pss-md5'),
 
       'RSA_SCHEME_SCHEMA_RSASSA_PSS_2': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
           'rsassa-pss-sha1'),
@@ -131,7 +131,7 @@ class TestFormats(unittest.TestCase):
           'rsassa-pss-sha512'),
 
       'RSA_SCHEME_SCHEMA_PKCS1v15': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
-          'rsa-pkcs1v15-md1'),
+          'rsa-pkcs1v15-md5'),
 
       'RSA_SCHEME_SCHEMA_PKCS1v15_2': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
           'rsa-pkcs1v15-sha1'),

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -115,6 +115,36 @@ class TestFormats(unittest.TestCase):
       'PUBLIC_KEYVAL_SCHEMA2': (securesystemslib.formats.PUBLIC_KEYVAL_SCHEMA,
           {'public': 'pubkey', 'private': ''}),
 
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-md1'),
+
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS_2': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-sha1'),
+
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS_3': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-sha224'),
+
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS_4': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-sha256'),
+
+      'RSA_SCHEME_SCHEMA_RSASSA_PSS_5': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsassa-pss-sha512'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-md1'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15_2': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-sha1'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15_3': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-sha224'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15_4': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-sha256'),
+
+      'RSA_SCHEME_SCHEMA_PKCS1v15_4': (securesystemslib.formats.RSA_SCHEME_SCHEMA,
+          'rsa-pkcs1v15-sha512'),
+
       'KEY_SCHEMA': (securesystemslib.formats.KEY_SCHEMA,
           {'keytype': 'rsa',
            'scheme': 'rsassa-pss-sha256',

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -46,8 +46,8 @@ if not 'hashlib' in securesystemslib.hash.SUPPORTED_LIBRARIES:
 class TestHash(unittest.TestCase):
 
   def _run_with_all_hash_libraries(self, test_func):
-    if 'hashlib' in securesystemslib.hash.SUPPORTED_LIBRARIES:
-      test_func('hashlib')
+    for lib in securesystemslib.hash.SUPPORTED_LIBRARIES:
+      test_func(lib)
 
 
   def test_md5_update(self):
@@ -181,7 +181,7 @@ class TestHash(unittest.TestCase):
 
   def _do_unsupported_algorithm(self, library):
     self.assertRaises(securesystemslib.exceptions.UnsupportedAlgorithmError,
-        securesystemslib.hash.digest, 'bogus')
+        securesystemslib.hash.digest, 'bogus', library)
 
 
   def test_digest_size(self):
@@ -263,6 +263,25 @@ class TestHash(unittest.TestCase):
       # Note: we don't seek because the update_file_obj call is supposed
       # to always seek to the beginning.
       self.assertEqual(digest_object_truth.digest(), digest_object.digest())
+
+
+  def test_digest_from_rsa_scheme(self):
+    self._run_with_all_hash_libraries(self._do_get_digest_from_rsa_valid_schemes)
+    self._run_with_all_hash_libraries(self._do_get_digest_from_rsa_non_valid_schemes)
+
+
+  def _do_get_digest_from_rsa_valid_schemes(self, library):
+    algorithm = 'sha256'
+    scheme = 'rsassa-pss-sha256'
+    expected_digest_cls = type(securesystemslib.hash.digest(algorithm, library))
+
+    self.assertIsInstance(securesystemslib.hash.digest_from_rsa_scheme(scheme, library),
+      expected_digest_cls)
+
+  def _do_get_digest_from_rsa_non_valid_schemes(self, library):
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+      securesystemslib.hash.digest_from_rsa_scheme, 'rsassa-pss-sha123', library)
+
 
 
   def test_unsupported_digest_algorithm_and_library(self):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -350,8 +350,7 @@ class TestKeys(unittest.TestCase):
     self.assertFalse(verified,
         'Returned \'True\' on an incorrect signature.')
 
-    # Modifying 'rsakey_dict' to pass an incorrect scheme since only
-    # 'rsassa-pss-sha256' is accepted.
+    # Modifying 'rsakey_dict' to pass an incorrect scheme.
     valid_scheme = self.rsakey_dict['scheme']
     self.rsakey_dict['scheme'] = 'Biff'
 

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -30,27 +30,14 @@ import logging
 
 import securesystemslib.exceptions
 import securesystemslib.formats
+import securesystemslib.keys
 import securesystemslib.pyca_crypto_keys
 
 from cryptography.hazmat.primitives import hashes
-
 logger = logging.getLogger('securesystemslib.test_pyca_crypto_keys')
 
 public_rsa, private_rsa = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'
-
-RSA_SIGNATURE_SCHEMES = [
-  'rsassa-pss-md5',
-  'rsassa-pss-sha1',
-  'rsassa-pss-sha224',
-  'rsassa-pss-sha256',
-  'rsassa-pss-sha512',
-  'rsa-pkcs1v15-md5',
-  'rsa-pkcs1v15-sha1',
-  'rsa-pkcs1v15-sha224',
-  'rsa-pkcs1v15-sha256',
-  'rsa-pkcs1v15-sha512',
-]
 
 
 class TestPyca_crypto_keys(unittest.TestCase):
@@ -75,40 +62,12 @@ class TestPyca_crypto_keys(unittest.TestCase):
         securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private, '2048')
 
 
-
-  def test_get_hash_function_from_scheme(self):
-    self.assertEqual(
-      hashes.MD5, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-md5')
-    )
-    self.assertEqual(
-      hashes.SHA1, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha1')
-    )
-    self.assertEqual(
-      hashes.SHA224, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha224')
-    )
-    self.assertEqual(
-      hashes.SHA256, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha256')
-    )
-    self.assertEqual(
-      hashes.SHA384, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha384')
-    )
-    self.assertEqual(
-      hashes.SHA512, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha512')
-    )
-
-    self.assertRaises(
-      securesystemslib.exceptions.UnsupportedAlgorithmError,
-      securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme, 'rsassa-pss-sha100'
-    )
-
-
-
   def test_create_rsa_signature(self):
     global private_rsa
     global public_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
 
-    for rsa_scheme in RSA_SIGNATURE_SCHEMES:
+    for rsa_scheme in securesystemslib.keys.RSA_SIGNATURE_SCHEMES:
       signature, scheme = \
         securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data, rsa_scheme)
 
@@ -156,7 +115,7 @@ class TestPyca_crypto_keys(unittest.TestCase):
     global private_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
 
-    for rsa_scheme in RSA_SIGNATURE_SCHEMES:
+    for rsa_scheme in securesystemslib.keys.RSA_SIGNATURE_SCHEMES:
       signature, scheme = \
         securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data, rsa_scheme)
 

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -39,6 +39,19 @@ logger = logging.getLogger('securesystemslib.test_pyca_crypto_keys')
 public_rsa, private_rsa = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'
 
+RSA_SIGNATURE_SCHEMES = [
+  'rsassa-pss-md5',
+  'rsassa-pss-sha1',
+  'rsassa-pss-sha224',
+  'rsassa-pss-sha256',
+  'rsassa-pss-sha512',
+  'rsa-pkcs1v15-md5',
+  'rsa-pkcs1v15-sha1',
+  'rsa-pkcs1v15-sha224',
+  'rsa-pkcs1v15-sha256',
+  'rsa-pkcs1v15-sha512',
+]
+
 
 class TestPyca_crypto_keys(unittest.TestCase):
   def setUp(self):
@@ -94,97 +107,102 @@ class TestPyca_crypto_keys(unittest.TestCase):
     global private_rsa
     global public_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, scheme = securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data)
 
-    # Verify format of returned values.
-    self.assertNotEqual(None, signature)
-    self.assertEqual(None,
-        securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme),
-        FORMAT_ERROR_MSG)
-    self.assertEqual('rsassa-pss-sha256', scheme)
+    for rsa_scheme in RSA_SIGNATURE_SCHEMES:
+      signature, scheme = \
+        securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data, rsa_scheme)
 
-    # Check for improperly formatted arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, 123, data)
+      # Verify format of returned values.
+      self.assertNotEqual(None, signature)
+      self.assertEqual(None,
+          securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme),
+          FORMAT_ERROR_MSG)
+      self.assertEqual(rsa_scheme, scheme)
 
-    # Check for an unset private key.
-    self.assertRaises(ValueError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, '', data)
+      # Check for improperly formatted arguments.
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, 123, data)
 
-    # Check for an invalid PEM.
-    self.assertRaises(securesystemslib.exceptions.CryptoError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, '123', data)
+      # Check for an unset private key.
+      self.assertRaises(ValueError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, '', data)
 
-    # Check for invalid 'data'.
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, '')
+      # Check for an invalid PEM.
+      self.assertRaises(securesystemslib.exceptions.CryptoError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, '123', data)
 
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, 123)
+      # Check for invalid 'data'.
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, '')
 
-    # Check for a missing private key.
-    self.assertRaises(securesystemslib.exceptions.CryptoError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, public_rsa, data)
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, private_rsa, 123)
 
-    # Check for a TypeError by attempting to create a signature with an
-    # encrypted key.
-    encrypted_pem = securesystemslib.pyca_crypto_keys.create_rsa_encrypted_pem(
-        private_rsa, 'pw')
-    self.assertRaises(securesystemslib.exceptions.CryptoError,
-        securesystemslib.pyca_crypto_keys.create_rsa_signature, encrypted_pem,
-        data)
+      # Check for a missing private key.
+      self.assertRaises(securesystemslib.exceptions.CryptoError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, public_rsa, data)
+
+      # Check for a TypeError by attempting to create a signature with an
+      # encrypted key.
+      encrypted_pem = securesystemslib.pyca_crypto_keys.create_rsa_encrypted_pem(
+          private_rsa, 'pw')
+      self.assertRaises(securesystemslib.exceptions.CryptoError,
+          securesystemslib.pyca_crypto_keys.create_rsa_signature, encrypted_pem,
+          data)
 
 
   def test_verify_rsa_signature(self):
     global public_rsa
     global private_rsa
     data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
-    signature, scheme = \
-      securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data)
 
-    valid_signature = \
-      securesystemslib.pyca_crypto_keys.verify_rsa_signature(signature,
-        scheme, public_rsa, data)
-    self.assertEqual(True, valid_signature)
+    for rsa_scheme in RSA_SIGNATURE_SCHEMES:
+      signature, scheme = \
+        securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa, data, rsa_scheme)
 
-    # Check for an invalid public key.
-    self.assertRaises(securesystemslib.exceptions.CryptoError,
-      securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature, scheme,
-      private_rsa, data)
-
-    # Check for improperly formatted arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
-        123, public_rsa, data)
-
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
-        scheme, 123, data)
-
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature, 123, scheme,
-        public_rsa, data)
-
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature,
-        signature, 'invalid_scheme', public_rsa, data)
-
-    # Check for invalid 'signature' and 'data' arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature,
-        signature, scheme, public_rsa, 123)
-
-    self.assertEqual(False,
+      valid_signature = \
         securesystemslib.pyca_crypto_keys.verify_rsa_signature(signature,
-        scheme, public_rsa, b'mismatched data'))
+          scheme, public_rsa, data)
+      self.assertEqual(True, valid_signature)
 
-    mismatched_signature, scheme = \
-      securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa,
-      b'mismatched data')
+      # Check for an invalid public key.
+      self.assertRaises(securesystemslib.exceptions.CryptoError,
+        securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature, scheme,
+        private_rsa, data)
 
-    self.assertEqual(False,
-        securesystemslib.pyca_crypto_keys.verify_rsa_signature(mismatched_signature,
-        scheme, public_rsa, data))
+      # Check for improperly formatted arguments.
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
+          123, public_rsa, data)
+
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature, signature,
+          scheme, 123, data)
+
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature, 123, scheme,
+          public_rsa, data)
+
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature,
+          signature, 'invalid_scheme', public_rsa, data)
+
+      # Check for invalid 'signature' and 'data' arguments.
+      self.assertRaises(securesystemslib.exceptions.FormatError,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature,
+          signature, scheme, public_rsa, 123)
+
+      self.assertEqual(False,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature(signature,
+          scheme, public_rsa, b'mismatched data'))
+
+      mismatched_signature, scheme = \
+        securesystemslib.pyca_crypto_keys.create_rsa_signature(private_rsa,
+        b'mismatched data')
+
+      self.assertEqual(False,
+          securesystemslib.pyca_crypto_keys.verify_rsa_signature(mismatched_signature,
+          scheme, public_rsa, data))
 
 
   def test_create_rsa_encrypted_pem(self):

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -32,6 +32,8 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.pyca_crypto_keys
 
+from cryptography.hazmat.primitives import hashes
+
 logger = logging.getLogger('securesystemslib.test_pyca_crypto_keys')
 
 public_rsa, private_rsa = securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private()
@@ -58,6 +60,33 @@ class TestPyca_crypto_keys(unittest.TestCase):
 
     self.assertRaises(securesystemslib.exceptions.FormatError,
         securesystemslib.pyca_crypto_keys.generate_rsa_public_and_private, '2048')
+
+
+
+  def test_get_hash_function_from_scheme(self):
+    self.assertEqual(
+      hashes.MD5, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-md5')
+    )
+    self.assertEqual(
+      hashes.SHA1, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha1')
+    )
+    self.assertEqual(
+      hashes.SHA224, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha224')
+    )
+    self.assertEqual(
+      hashes.SHA256, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha256')
+    )
+    self.assertEqual(
+      hashes.SHA384, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha384')
+    )
+    self.assertEqual(
+      hashes.SHA512, securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme('rsassa-pss-sha512')
+    )
+
+    self.assertRaises(
+      securesystemslib.exceptions.UnsupportedAlgorithmError,
+      securesystemslib.pyca_crypto_keys._get_hash_function_from_scheme, 'rsassa-pss-sha100'
+    )
 
 
 


### PR DESCRIPTION
Add support for `RSA-PKCS1v15` signatures, as well as other supported openssl hash algorithms.

**Description of the changes being introduced by the pull request**:

Allow passing one of the following schemes, when generating keys and creating/verifying signatures:

- `rsassa-pss-HASH_ID`
- `rsa-pkcs1v15-HASH_ID`

Where `HASH_ID` is one of: `md5`, `sha1`, `sha224`, `sha256`, `sha384` and `sha512`.

`HASH_ID` is picked from a _scheme_, so changes are backwards compatible.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


