### PR TITLE
Move colorama to install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,9 @@ setup(
     'Topic :: Software Development'
   ],
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"',
-      'python-dateutil==2.8.0'],
-  extras_require = {'crypto': ['cryptography>=2.2.2', 'colorama>=0.3.9'],
+      'python-dateutil==2.8.0', 'colorama>=0.3.9'],
+  extras_require = {
+      'crypto': ['cryptography>=2.2.2'],
       'pynacl': ['pynacl>1.2.0']},
   packages = find_packages(exclude=['tests', 'debian']),
   scripts = []


### PR DESCRIPTION
**Fixes issue #**:
closes #153 

**Description of the changes being introduced by the pull request**:
`colorama` was added to colorize output generated by some functions in `securesystemslib.interface`.

Prior to this PR `colorama` was listed as extra requirement in setup.py under `extras_require["crypto"]` alongside `cryptography`.

However, `securesystemslib.interface` does not properly handle an installation without `colorama`, as e.g. `secureystemslib.keys` does for an installation without `cryptography` (or `pynacl`), thus it cannot be an extra requirement.

Moreover, `colorama` does not require C extensions, which would be a good reason to keep it out of the standard installation.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


