### PR TITLE
Pass scheme to import_rsakey_from_private_pem

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1148,7 +1148,7 @@ def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
 
   elif is_pem_private(pem):
     # Return an rsakey object (RSAKEY_SCHEMA) with the private key included.
-    return import_rsakey_from_private_pem(pem, password=None)
+    return import_rsakey_from_private_pem(pem, scheme, password=None)
 
   else:
     raise securesystemslib.exceptions.FormatError('PEM contains neither a'


### PR DESCRIPTION
**Fixes issue #**:

Pass scheme argument to `import_rsakey_from_private_pem` when calling `import_rsakey_from_pem`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


