### PR TITLE
Fix a race condition in `process.run_duplicate_streams`

### DIFF
--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -129,12 +129,13 @@ def run(cmd, check=True, timeout=SUBPROCESS_TIMEOUT, **kwargs):
 def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
   """
   <Purpose>
-    Provide a function that executes a command in a subprocess and returns its
-    exit code and the contents of what it printed to its standard streams upon
-    termination.
+    Provide a function that executes a command in a subprocess and, upon
+    termination, returns its exit code and the contents of what was printed to
+    its standard streams.
 
-    NOTE: The function might behave unexpectedly with interactive commands.
-
+    * Might behave unexpectedly with interactive commands.
+    * Might not duplicate output in real time, if the command buffers it (see
+      e.g. `print("foo")` vs. `print("foo", flush=True)` in Python 3).
 
   <Arguments>
     cmd:
@@ -144,7 +145,7 @@ def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
 
     timeout: (default see settings.SUBPROCESS_TIMEOUT)
             If the timeout expires, the child process will be killed and waited
-            for and then subprocess.TimeoutExpired  will be raised.
+            for and then subprocess.TimeoutExpired will be raised.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError:

--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -190,8 +190,11 @@ def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
         contents to parent process standard streams, and build up return values
         for outer function.
         """
-        stdout_part = stdout_reader.read()
-        stderr_part = stderr_reader.read()
+        # Read until EOF but at most `io.DEFAULT_BUFFER_SIZE` bytes per call.
+        # Reading and writing in reasonably sized chunks prevents us from
+        # subverting a timeout, due to being busy for too long or indefinitely.
+        stdout_part = stdout_reader.read(io.DEFAULT_BUFFER_SIZE)
+        stderr_part = stderr_reader.read(io.DEFAULT_BUFFER_SIZE)
         sys.stdout.write(stdout_part)
         sys.stderr.write(stderr_part)
         sys.stdout.flush()


### PR DESCRIPTION
**Fixes issue #**:
in-toto/in-toto#282

**Description of the changes being introduced by the pull request**:
This PR fixes a race condition in a standard stream duplicating loop in `process.run_duplicate_streams`, where the subprocess would write to its standard streams after the last read in the parent process, and then terminate before another iteration would be started, and therefor leaving the last parts of the streams unread.

Also adds a note about buffered outputs in child process to the function's docstring.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


