### PR TITLE
Unpin python-dateutil dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,6 @@ coverage==4.5.1
 colorama==0.3.9
 mock==2.0.0; python_version < '3.3'
 subprocess32==3.5.4; python_version < '3'
-python-dateutil==2.8.0
+python-dateutil
 
 --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cryptography
 pynacl
 six
 colorama
-python-dateutil==2.8.0
+python-dateutil
 subprocess32; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     'Topic :: Software Development'
   ],
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"',
-      'python-dateutil==2.8.0', 'colorama>=0.3.9'],
+      'python-dateutil>=2.8.0', 'colorama>=0.3.9'],
   extras_require = {
       'crypto': ['cryptography>=2.2.2'],
       'pynacl': ['pynacl>1.2.0']},


### PR DESCRIPTION
There is no reason to strictly pin python-dateutil to 2.8.0. On the contrary, pinning dependencies is prone to introduce dependency conflicts (especially in downstream releases).

This was most likely a copy-paste mistake related to the practice of pinning dependencies in dev-requirements.txt.

This is a quick fix for python-dateutil. A more comprehensive dependency handling revision may be performed with https://github.com/secure-systems-lab/securesystemslib/issues/182.
