### PR TITLE
Bump version 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## securesystemslib v0.12.2
+
+* Remove unnecessary `python-dateutil==2.8.0` version pinning to not cause
+  downstream dependency conflicts (#192)
+
 ## securesystemslib v0.12.1
 
 * Fix stream duplication race conditions in subprocess interface (#186)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst') as file_object:
 
 setup(
   name = 'securesystemslib',
-  version = '0.12.1',
+  version = '0.12.2',
   description = 'A library that provides cryptographic and general-purpose'
       ' routines for Secure Systems Lab projects at NYU',
   long_description = long_description,


### PR DESCRIPTION
Make patch release to remove unnecessary `python-dateutil==2.8.0` version pinning to not cause downstream dependency conflicts (#192).