### PR TITLE
Add gpg test data to sdist via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,13 @@
 include README.rst
 include LICENSE
 
-# Add tests and test data
-recursive-include tests *.py
-recursive-include tests/data *
-
 # Add test config files to show how to run tests
-include tests/.coveragerc
 include tox.ini
 include .travis.yml
 include *requirements.txt
+
+# Include all files under the tests directory (including test data)
+graft tests
+
+# Exclude all files anywhere in the source tree matching any of these patterns
+global-exclude *.py[cod] .DS_Store .coverage */htmlcov/* */__pycache__/*


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
* Add gpg test data to sdist via MANIFEST.in (in future releases)
* This PR also changes the inclusion strategy for test data to use black- instead of whitelisting, to avoid source releases with missing files in the future. This seems to be the recommended practice for MANIFEST.in

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


