### PR TITLE
Make check_match() errors more readable for ListOf objects

### DIFF
--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -523,7 +523,8 @@ class ListOf(Schema):
   def check_match(self, object):
     if not isinstance(object, (list, tuple)):
       raise securesystemslib.exceptions.FormatError(
-          'Expected ' + repr(self._list_name) + ' but got ' + repr(object))
+          'Expected object of type {} but got type {}'.format(
+            self._list_name, type(object).__name__))
 
 
     # Check if all the items in the 'object' list


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #194**:

**Description of the changes being introduced by the pull request**:

When the ListOf object's check_match() fails due to an incompatible object
having been passed, the salient information for the error message is the
type of the passed object and the type of the object against which the
check_match() method was called, therefore print those types in the error
message and not the string representation of the objects.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


