### PR TITLE
Add default timeout setting helper to process module

### DIFF
--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -37,19 +37,22 @@ else: # pragma: no cover
   import subprocess
 
 import securesystemslib.formats
-
+import securesystemslib.settings
 
 DEVNULL = subprocess.DEVNULL
 PIPE = subprocess.PIPE
-# NOTE: If changed programatically, please do via this process module, e.g.
-# securesystemslib.process.SUBPROCESS_TIMEOUT = <seconds>
-from securesystemslib.settings import SUBPROCESS_TIMEOUT
-
 
 log = logging.getLogger(__name__)
 
+def _default_timeout():
+  """Helper to use securesystemslib.settings.SUBPROCESS_TIMEOUT as default
+  argument, and still be able to modify it after the function definitions are
+  evaluated. """
+  return securesystemslib.settings.SUBPROCESS_TIMEOUT
 
-def run(cmd, check=True, timeout=SUBPROCESS_TIMEOUT, **kwargs):
+
+
+def run(cmd, check=True, timeout=_default_timeout(), **kwargs):
   """
   <Purpose>
     Provide wrapper for `subprocess.run` (see
@@ -126,7 +129,7 @@ def run(cmd, check=True, timeout=SUBPROCESS_TIMEOUT, **kwargs):
 
 
 
-def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
+def run_duplicate_streams(cmd, timeout=_default_timeout()):
   """
   <Purpose>
     Provide a function that executes a command in a subprocess and, upon

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -23,6 +23,7 @@ import shlex
 import io
 import sys
 import securesystemslib.process
+import securesystemslib.settings
 
 
 class Test_Process(unittest.TestCase):
@@ -120,6 +121,20 @@ class Test_Process(unittest.TestCase):
       securesystemslib.process.run_duplicate_streams("python --version",
           timeout=-1)
 
+
+  def test__default_timeout(self):
+    """Test default timeout modification. """
+    # Backup timeout and check that it is what's returned by _default_timeout()
+    timeout_old = securesystemslib.settings.SUBPROCESS_TIMEOUT
+    self.assertEqual(securesystemslib.process._default_timeout(), timeout_old)
+
+    # Modify timeout and check that _default_timeout() returns the same value
+    timeout_new = timeout_old + 1
+    securesystemslib.settings.SUBPROCESS_TIMEOUT = timeout_new
+    self.assertEqual(securesystemslib.process._default_timeout(), timeout_new)
+
+    # Restore original timeout
+    securesystemslib.settings.SUBPROCESS_TIMEOUT = timeout_old
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
Add helper to use `settings.SUBPROCESS_TIMEOUT` as default argument in `process.run*` functions, and still be able to modify the setting in the settingsmodule after the function definitions are evaluated, i.e. after the process module is imported for the first time.

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


