### PR TITLE
Add extra metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,9 @@ setup(
   version = '0.14.0',
   description = 'A library that provides cryptographic and general-purpose'
       ' routines for Secure Systems Lab projects at NYU',
+  license = 'MIT',
   long_description = long_description,
+  long_description_content_type = 'text/x-rst',
   author = 'https://www.updateframework.com',
   author_email = 'theupdateframework@googlegroups.com',
   url = 'https://github.com/secure-systems-lab/securesystemslib',
@@ -91,6 +93,8 @@ setup(
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'


### PR DESCRIPTION
Add the license and the content type of long_description. Add extra
supported versions of Python to the Classifiers list.

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
* Add missing license field to metadata in setup.py
* Add long_description_content_type field to metadata in setup.py
* Add additional items to the classifiers list for supported Python versions

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


