### PR TITLE
Handle missing native dependencies in securesystemslib.gpg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOXENV=py27
     - python: "2.7"
       env: TOXENV=purepy27
+      before_install:
+        - sudo apt-get remove -y --allow-remove-essential gnupg gnupg2
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"
@@ -18,6 +20,8 @@ matrix:
       env: TOXENV=py38
     - python: "3.8"
       env: TOXENV=purepy38
+      before_install:
+        - sudo apt-get remove -y  --allow-remove-essential gnupg gnupg2
 
 install:
   - pip install -U tox coveralls

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -31,6 +31,10 @@ GPG_COMMAND = "gpg2"
 GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 
+HAVE_GPG = True
+NO_GPG_MSG = "GPG support requires a GPG command, {} version {} or newer is" \
+  " fully supported.".format(GPG_COMMAND, FULLY_SUPPORTED_MIN_VERSION)
+
 try:
   proc = process.run(GPG_VERSION_COMMAND, stdout=process.PIPE,
     stderr=process.PIPE)
@@ -38,6 +42,13 @@ try:
 except OSError: # pragma: no cover
   GPG_COMMAND = "gpg"
   GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
+
+  try:
+    proc = process.run(GPG_VERSION_COMMAND, stdout=process.PIPE,
+      stderr=process.PIPE)
+
+  except OSError:
+    HAVE_GPG = False
 
 GPG_SIGN_COMMAND = GPG_COMMAND + \
                    " --detach-sign --digest-algo SHA256 {keyarg} {homearg}"

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -18,10 +18,12 @@
 import logging
 import time
 
+import securesystemslib.exceptions
 import securesystemslib.gpg.common
 import securesystemslib.gpg.exceptions
 from securesystemslib.gpg.constants import (GPG_EXPORT_PUBKEY_COMMAND,
-    GPG_SIGN_COMMAND, SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION, SHA256)
+    GPG_SIGN_COMMAND, SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION, SHA256,
+    HAVE_GPG, NO_GPG_MSG)
 
 import securesystemslib.process
 import securesystemslib.formats
@@ -66,6 +68,9 @@ def create_signature(content, keyid=None, homedir=None):
     OSError:
             If the gpg command is not present or non-executable.
 
+    securesystemslib.exceptions.UnsupportedLibraryError:
+            If the gpg command is not available
+
     securesystemslib.gpg.exceptions.CommandError:
             If the gpg command returned a non-zero exit code
 
@@ -81,6 +86,9 @@ def create_signature(content, keyid=None, homedir=None):
     securesystemslib.formats.GPG_SIGNATURE_SCHEMA.
 
   """
+  if not HAVE_GPG: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
+
   keyarg = ""
   if keyid:
     securesystemslib.formats.KEYID_SCHEMA.check_match(keyid)
@@ -177,6 +185,9 @@ def verify_signature(signature_object, pubkey_info, content):
     securesystemslib.gpg.exceptions.KeyExpirationError:
             if the passed public key has expired
 
+    securesystemslib.exceptions.UnsupportedLibraryError:
+            If the gpg command is not available
+
   <Side Effects>
     None.
 
@@ -184,6 +195,9 @@ def verify_signature(signature_object, pubkey_info, content):
     True if signature verification passes, False otherwise.
 
   """
+  if not HAVE_GPG: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
+
   securesystemslib.formats.GPG_PUBKEY_SCHEMA.check_match(pubkey_info)
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
 
@@ -233,6 +247,9 @@ def export_pubkey(keyid, homedir=None):
     ValueError:
             if the keyid does not match the required format.
 
+    securesystemslib.exceptions.UnsupportedLibraryError:
+            If the gpg command is not available.
+
     securesystemslib.gpg.execeptions.KeyNotFoundError:
             if no key or subkey was found for that keyid.
 
@@ -245,6 +262,9 @@ def export_pubkey(keyid, homedir=None):
     securesystemslib.formats.GPG_PUBKEY_SCHEMA.
 
   """
+  if not HAVE_GPG: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
+
   if not securesystemslib.formats.KEYID_SCHEMA.matches(keyid):
     # FIXME: probably needs smarter parsing of what a valid keyid is so as to
     # not export more than one pubkey packet.

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -24,6 +24,7 @@ from distutils.version import StrictVersion # pylint: disable=no-name-in-module,
 import cryptography.hazmat.backends as backends
 import cryptography.hazmat.primitives.hashes as hashing
 
+import securesystemslib.exceptions
 import securesystemslib.gpg.exceptions
 import securesystemslib.process
 import securesystemslib.gpg.constants
@@ -294,10 +295,18 @@ def get_version():
 
     The executed base command is defined in constants.GPG_VERSION_COMMAND.
 
+  <Exceptions>
+    securesystemslib.exceptions.UnsupportedLibraryError:
+            If the gpg command is not available
+
   <Returns>
     Version number string, e.g. "2.1.22"
 
   """
+  if not securesystemslib.gpg.constants.HAVE_GPG: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(
+        securesystemslib.gpg.constants.NO_GPG_MSG)
+
   command = securesystemslib.gpg.constants.GPG_VERSION_COMMAND
   process = securesystemslib.process.run(command,
       stdout=securesystemslib.process.PIPE,

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -21,8 +21,13 @@ import logging
 
 from distutils.version import StrictVersion # pylint: disable=no-name-in-module,import-error
 
-import cryptography.hazmat.backends as backends
-import cryptography.hazmat.primitives.hashes as hashing
+CRYPTO = True
+NO_CRYPTO_MSG = 'gpg.utils requires the cryptography library'
+try:
+  import cryptography.hazmat.backends as backends
+  import cryptography.hazmat.primitives.hashes as hashing
+except ImportError:
+  CRYPTO = False
 
 import securesystemslib.exceptions
 import securesystemslib.gpg.exceptions
@@ -74,7 +79,8 @@ def hash_object(headers, algorithm, content):
     content: the signed content
 
   <Exceptions>
-    None
+    securesystemslib.exceptions.UnsupportedLibraryError if:
+      the cryptography module is unavailable
 
   <Side Effects>
     None
@@ -82,6 +88,9 @@ def hash_object(headers, algorithm, content):
   <Returns>
     The RFC4880-compliant hashed buffer
   """
+  if not CRYPTO: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+
   # As per RFC4880 Section 5.2.4., we need to hash the content,
   # signature headers and add a very opinionated trailing header
   hasher = hashing.Hash(algorithm, backend=backends.default_backend())
@@ -210,7 +219,8 @@ def compute_keyid(pubkey_packet_data):
     pubkey_packet_data: the public-key packet buffer
 
   <Exceptions>
-    None
+    securesystemslib.exceptions.UnsupportedLibraryError if:
+      the cryptography module is unavailable
 
   <Side Effects>
     None
@@ -218,11 +228,15 @@ def compute_keyid(pubkey_packet_data):
   <Returns>
     The RFC4880-compliant hashed buffer
   """
+  if not CRYPTO: # pragma: no cover
+    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+
   hasher = hashing.Hash(hashing.SHA1(), backend=backends.default_backend())
   hasher.update(b'\x99')
   hasher.update(struct.pack(">H", len(pubkey_packet_data)))
   hasher.update(bytes(pubkey_packet_data))
   return binascii.hexlify(hasher.finalize()).decode("ascii")
+
 
 def parse_subpacket_header(data):
   """ Parse out subpacket header as per RFC4880 5.2.3.1. Signature Subpacket

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -31,30 +31,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import os
 import sys
 import unittest
-import subprocess
-
-def check_usable_gpg():
-  """Set `TEST_SKIP_GPG` environment variable if neither gpg2 nor gpg is
-  available. """
-  os.environ["TEST_SKIP_GPG"] = "1"
-  for gpg in ["gpg2", "gpg"]:
-    try:
-      subprocess.check_call([gpg, "--version"])
-
-    except OSError:
-      pass
-
-    else:
-      # If one of the two exists, we can unset the skip envvar and ...
-      os.environ.pop("TEST_SKIP_GPG", None)
-      # ... abort the availability check.:
-      break
 
 if __name__ == '__main__':
-  check_usable_gpg()
   suite = unittest.TestLoader().discover("tests", top_level_dir=".")
   all_tests_passed = unittest.TextTestRunner(
       verbosity=1, buffer=True).run(suite).wasSuccessful()

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -43,6 +43,9 @@ import unittest
 
 
 import securesystemslib.exceptions
+import securesystemslib.gpg.constants
+import securesystemslib.gpg.functions
+import securesystemslib.gpg.util
 import securesystemslib.interface
 import securesystemslib.keys
 
@@ -193,6 +196,21 @@ class TestPublicInterfaces(unittest.TestCase):
     invalid = securesystemslib.ed25519_keys.verify_signature(
         pub, 'ed25519', bsig, data)
     self.assertEqual(False, invalid)
+
+  def test_gpg_cmds(self):
+    """Ensure functions calling GPG commands throw an appropriate error"""
+
+    with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.gpg.functions.create_signature('bar')
+
+    with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.gpg.functions.verify_signature(None, 'f00', 'bar')
+
+    with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.gpg.functions.export_pubkey('f00')
+
+    with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.gpg.util.get_version()
 
 
 if __name__ == '__main__':

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -51,14 +51,14 @@ from securesystemslib.gpg.common import (parse_pubkey_payload,
     _get_verified_subkeys, parse_signature_packet)
 from securesystemslib.gpg.constants import (SHA1, SHA256, SHA512,
     GPG_EXPORT_PUBKEY_COMMAND, PACKET_TYPE_PRIMARY_KEY, PACKET_TYPE_USER_ID,
-    PACKET_TYPE_USER_ATTR, PACKET_TYPE_SUB_KEY)
+    PACKET_TYPE_USER_ATTR, PACKET_TYPE_SUB_KEY, HAVE_GPG)
 from securesystemslib.gpg.exceptions import (PacketParsingError,
     PacketVersionNotSupportedError, SignatureAlgorithmNotSupportedError,
     KeyNotFoundError, CommandError, KeyExpirationError)
 from securesystemslib.formats import GPG_PUBKEY_SCHEMA
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestUtil(unittest.TestCase):
   """Test util functions. """
   def test_version_utils_return_types(self):
@@ -171,7 +171,7 @@ class TestUtil(unittest.TestCase):
       self.assertEqual(result, expected[idx])
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestCommon(unittest.TestCase):
   """Test common functions of the securesystemslib.gpg module. """
   @classmethod
@@ -471,7 +471,7 @@ class TestCommon(unittest.TestCase):
           "'{}' not in '{}'".format(expected_error_str, str(ctx.exception)))
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestGPGRSA(unittest.TestCase):
   """Test signature creation, verification and key export from the gpg
   module"""
@@ -625,7 +625,7 @@ class TestGPGRSA(unittest.TestCase):
         "\ngot:      {}".format(expected, ctx.exception))
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestGPGDSA(unittest.TestCase):
   """ Test signature creation, verification and key export from the gpg
   module """
@@ -710,7 +710,7 @@ class TestGPGDSA(unittest.TestCase):
 
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestGPGEdDSA(unittest.TestCase):
   """ Test signature creation, verification and key export from the gpg
   module """


### PR DESCRIPTION
**Fixes issue #**: 
#179 

**Description of the changes being introduced by the pull request**:
* Handle missing `gpg[2]` command in all functions that would call it and raise `UnsupportedLibraryError`
* Wrap native module imports in `securesystemslib.gpg` in `try/except` logic so that the modules can always be imported cleanly
* Handle missing native module dependencies in `securesystemslib.gpg` by raising `UnsupportedLibraryError` when a function requiring a native module dependency is called
* Test the `securesystemslib.gpg` interfaces requiring `gpg[2]` or native module dependencies from our pure python test environment

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


