### PR TITLE
Do not log a warning if colorama is not installed

### DIFF
--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -56,7 +56,7 @@ try:
   TERM_RED = Fore.RED
   TERM_RESET = Fore.RESET
 except ImportError:
-  logger.warning("Failed to find colorama module, terminal output won't be colored")
+  logger.debug("Failed to find colorama module, terminal output won't be colored")
   TERM_RED = ''
   TERM_RESET = ''
 


### PR DESCRIPTION
**Fixes issue #**:
https://github.com/secure-systems-lab/securesystemslib/issues/210

**Description of the changes being introduced by the pull request**:
Remove the warning

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


More details available on the issue #210

**Additional notes**:
This PR doesn't fix the issue that the `logger` has not been initialized correctly. (Shows only on Python2 with `No handler could be found ...`). This would require a bit more knowledge of the library and an easy workaround for library users is to use `logging.raiseExceptions = False`
