### PR TITLE
Configure basic top-level logger

### DIFF
--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,0 +1,11 @@
+import logging
+
+# Configure a basic 'securesystemslib' top-level logger with a StreamHandler
+# (print to console) and the WARNING log level (print messages of type
+# warning, error or critical). This is similar to what 'logging.basicConfig'
+# would do with the root logger. All 'securesystemslib.*' loggers default to
+# this top-level logger and thus may be configured (e.g. formatted, silenced,
+# etc.) with it. It can be accessed via logging.getLogger('securesystemslib').
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+logger.addHandler(logging.StreamHandler())

--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -66,7 +66,7 @@ import securesystemslib.exceptions
 
 _SUPPORTED_ECDSA_SCHEMES = ['ecdsa-sha2-nistp256']
 
-logger = logging.getLogger('securesystemslib_ecdsa_keys')
+logger = logging.getLogger(__name__)
 
 
 def generate_public_and_private(scheme='ecdsa-sha2-nistp256'):

--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -25,11 +25,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import logging
-
 import six
 
-logger = logging.getLogger('securesystemslib.exceptions')
 
 
 class Error(Exception):

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import logging
 import hashlib
 
 import six
@@ -38,8 +37,6 @@ import six
 import securesystemslib.exceptions
 import securesystemslib.formats
 
-# Import securesystemslib logger to log warning messages.
-logger = logging.getLogger('securesystemslib.hash')
 
 DEFAULT_CHUNK_SIZE = 4096
 DEFAULT_HASH_ALGORITHM = 'sha256'

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -49,7 +49,7 @@ import securesystemslib.keys
 import six
 
 # See 'log.py' to learn how logging is handled in securesystemslib.
-logger = logging.getLogger('securesystemslib_interface')
+logger = logging.getLogger(__name__)
 
 try:
   from colorama import Fore

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -48,7 +48,6 @@ import securesystemslib.keys
 
 import six
 
-# See 'log.py' to learn how logging is handled in securesystemslib.
 logger = logging.getLogger(__name__)
 
 try:
@@ -73,7 +72,7 @@ SUPPORTED_KEY_TYPES = ['rsa', 'ed25519']
 
 def _prompt(message, result_type=str):
   """
-    Non-public function that prompts the user for input by logging 'message',
+    Non-public function that prompts the user for input by printing 'message',
     converting the input to 'result_type', and returning the value to the
     caller.
   """

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -102,7 +102,7 @@ RSA_SIGNATURE_SCHEMES = [
   'rsa-pkcs1v15-sha512',
 ]
 
-logger = logging.getLogger('securesystemslib_keys')
+logger = logging.getLogger(__name__)
 
 
 def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -39,7 +39,7 @@ import securesystemslib.formats
 
 import six
 
-logger = logging.getLogger('securesystemslib_util')
+logger = logging.getLogger(__name__)
 
 
 def get_file_details(filepath, hash_algorithms=['sha256']):

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import
 
 import inspect
 import json
-import logging
 import os
 import shutil
 import sys
@@ -48,9 +47,6 @@ import securesystemslib.gpg.functions
 import securesystemslib.gpg.util
 import securesystemslib.interface
 import securesystemslib.keys
-
-
-logger = logging.getLogger('securesystemslib_check_public_interfaces')
 
 
 

--- a/tests/test_ecdsa_keys.py
+++ b/tests/test_ecdsa_keys.py
@@ -27,14 +27,12 @@ from __future__ import unicode_literals
 
 import unittest
 import os
-import logging
 
 import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.ecdsa_keys
 import securesystemslib.rsa_keys
 
-logger = logging.getLogger('securesystemslib_test_ecdsa_keys')
 
 public, private = securesystemslib.ecdsa_keys.generate_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'

--- a/tests/test_ed25519_keys.py
+++ b/tests/test_ed25519_keys.py
@@ -27,13 +27,11 @@ from __future__ import unicode_literals
 
 import unittest
 import os
-import logging
 
 import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.ed25519_keys
 
-logger = logging.getLogger('securesystemslib.test_ed25519_keys')
 
 public, private = securesystemslib.ed25519_keys.generate_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ import logging
 
 import securesystemslib.exceptions
 
-logger = logging.getLogger('test_exceptions')
+logger = logging.getLogger(__name__)
 
 class TestExceptions(unittest.TestCase):
   def setUp(self):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -36,7 +36,7 @@ import securesystemslib.hash
 
 import six
 
-logger = logging.getLogger('securesystemslib.test_hash')
+logger = logging.getLogger(__name__)
 
 
 if not 'hashlib' in securesystemslib.hash.SUPPORTED_LIBRARIES:

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 if not 'hashlib' in securesystemslib.hash.SUPPORTED_LIBRARIES:
-  logger.warn('Not testing hashlib: could not be imported.')
+  logger.warning('Not testing hashlib: could not be imported.')
 
 
 class TestHash(unittest.TestCase):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -28,7 +28,6 @@ from __future__ import unicode_literals
 import os
 import time
 import datetime
-import logging
 import tempfile
 import json
 import shutil
@@ -48,8 +47,6 @@ import securesystemslib.hash
 import securesystemslib.interface as interface
 
 import six
-
-logger = logging.getLogger('securesystemslib_test_interface')
 
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -26,15 +26,11 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import unittest
-import logging
-
 
 import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.keys
 import securesystemslib.ecdsa_keys
-
-logger = logging.getLogger('securesystemslib_test_keys')
 
 KEYS = securesystemslib.keys
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError was raised!' + \

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import unittest
-import logging
 
 import securesystemslib.exceptions
 import securesystemslib.formats
@@ -34,7 +33,6 @@ import securesystemslib.keys
 import securesystemslib.rsa_keys
 
 from cryptography.hazmat.primitives import hashes
-logger = logging.getLogger('securesystemslib.test_rsa_keys')
 
 public_rsa, private_rsa = securesystemslib.rsa_keys.generate_rsa_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -27,12 +27,10 @@ from __future__ import unicode_literals
 
 import unittest
 import re
-import logging
 
 import securesystemslib.exceptions
 import securesystemslib.schema as SCHEMA
 
-logger = logging.getLogger('securesystemslib.test_schema')
 
 
 class TestSchema(unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -41,7 +41,7 @@ import securesystemslib.unittest_toolbox as unittest_toolbox
 
 import six
 
-logger = logging.getLogger('securesystemslib_test_util')
+logger = logging.getLogger(__name__)
 
 
 class TestUtil(unittest_toolbox.Modified_TestCase):


### PR DESCRIPTION
**Fixes issue #**:
Closes #210 
  
**Description of the changes being introduced by the pull request**:
As pointed out by @FlorianVeaux in #210, securesystemslib does not  correctly initialize its loggers. As a consequence the logging module logs a one-off "No handler could be found ..." warning when used for the first time (only on Python 2). 
The logging module then calls basicConfig, which attaches a basic StreamHandler to the root logger, to which securesystemslib's log messages are propagated.

This PR adds the configuration of a simple securesystemslib top-level logger, with an attached StreamHandler and log level WARNING, to which all other securesystemslib loggers default.
This removes the one-off warning, while providing a similar logging  behavior as before and clear instructions (see added comments) on  how to customize (format, silence, etc...) securesystemslib's logging.

The PR further:
- removes unused loggers
- establishes `__name__` logger naming convention
- replaces a deprecated logging method

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


