### PR TITLE
Allow verifying signatures without gpg

### DIFF
--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -185,9 +185,6 @@ def verify_signature(signature_object, pubkey_info, content):
     securesystemslib.gpg.exceptions.KeyExpirationError:
             if the passed public key has expired
 
-    securesystemslib.exceptions.UnsupportedLibraryError:
-            If the gpg command is not available
-
   <Side Effects>
     None.
 
@@ -195,9 +192,6 @@ def verify_signature(signature_object, pubkey_info, content):
     True if signature verification passes, False otherwise.
 
   """
-  if not HAVE_GPG: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
-
   securesystemslib.formats.GPG_PUBKEY_SCHEMA.check_match(pubkey_info)
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -204,9 +204,6 @@ class TestPublicInterfaces(unittest.TestCase):
       securesystemslib.gpg.functions.create_signature('bar')
 
     with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
-      securesystemslib.gpg.functions.verify_signature(None, 'f00', 'bar')
-
-    with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
       securesystemslib.gpg.functions.export_pubkey('f00')
 
     with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Issue**:
A regression was introduced with https://github.com/secure-systems-lab/securesystemslib/pull/206
Before that it was possible to verify keys even if `gpg` was missing in the used environment.

gpg is not required for verifying but a safe-guard was added in the `verify_signature` method which now prevents that possibility.

**Description of the changes being introduced by the pull request**:

Removes the safe-guard introduced in #206 

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


