### PR TITLE
Add blake hashing algorithms to HASHALGORITHMS_SCHEMA

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -149,7 +149,8 @@ TEXT_SCHEMA = SCHEMA.AnyString()
 HASHALGORITHMS_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
   [SCHEMA.String('md5'), SCHEMA.String('sha1'),
    SCHEMA.String('sha224'), SCHEMA.String('sha256'),
-   SCHEMA.String('sha384'), SCHEMA.String('sha512')]))
+   SCHEMA.String('sha384'), SCHEMA.String('sha512'),
+   SCHEMA.String('blake2s'), SCHEMA.String('blake2b')]))
 
 # The contents of an encrypted key.  Encrypted keys are saved to files
 # in this format.


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

Add blake hashing algorithms to the supported hash algorithms. These will be used by the warehouse project when integrating tuf per [PEP 458](https://www.python.org/dev/peps/pep-0458/)

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


