### PR TITLE
Refactor format_metadata_to_key

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -474,7 +474,8 @@ def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
 
 
 
-def format_metadata_to_key(key_metadata, default_keyid=None):
+def format_metadata_to_key(key_metadata, default_keyid=None,
+    keyid_hash_algorithms=None):
   """
   <Purpose>
     Construct a key dictionary (e.g., securesystemslib.formats.RSAKEY_SCHEMA)
@@ -522,6 +523,10 @@ def format_metadata_to_key(key_metadata, default_keyid=None):
       provided, the keyid will be calculated by _get_keyid using the default
       hash algorithm. If provided, the default keyid can be any string.
 
+    keyid_hash_algorithms:
+      An optional list of hash algorithms to use when generating keyids.
+      Defaults to securesystemslib.settings.HASH_ALGORITHMS.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'key_metadata' does not conform
     to 'securesystemslib.formats.KEY_SCHEMA'.
@@ -553,7 +558,10 @@ def format_metadata_to_key(key_metadata, default_keyid=None):
   keyids = set()
   keyids.add(default_keyid)
 
-  for hash_algorithm in securesystemslib.settings.HASH_ALGORITHMS:
+  if keyid_hash_algorithms is None:
+    keyid_hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+
+  for hash_algorithm in keyid_hash_algorithms:
     keyid = _get_keyid(keytype, scheme, key_value, hash_algorithm)
     keyids.add(keyid)
 
@@ -562,7 +570,7 @@ def format_metadata_to_key(key_metadata, default_keyid=None):
   key_dict['keytype'] = keytype
   key_dict['scheme'] = scheme
   key_dict['keyid'] = default_keyid
-  key_dict['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
+  key_dict['keyid_hash_algorithms'] = keyid_hash_algorithms
   key_dict['keyval'] = key_value
 
   return key_dict, keyids


### PR DESCRIPTION
**Fixes issue #**:

https://github.com/secure-systems-lab/securesystemslib/issues/220

**Description of the changes being introduced by the pull request**:

Refactor format_metadata_to_key so that it won't depend
on settings.HASH_ALGORITHMS.
There are couple of code snippets in tuf where in order to provide
a custom list of hash algorithms, tuf is temporary changing
settings.HASH_ALGORITHMS and then returning it to its formal state.

This could lead to problems in future and one should
be able to control hash algorithms used for generating keyids in f
ormat_metadata_to_key() without having to change
package level settings in securesystemslib.settings.

**Please verify and check that the pull request fulfils the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


