### PR TITLE
Add nistp384 signature verification support

### DIFF
--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -57,6 +57,12 @@ try:
   from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
   import cryptography.exceptions
+
+  _SCHEME_HASHER = {
+    'ecdsa-sha2-nistp256': ec.ECDSA(hashes.SHA256()),
+    'ecdsa-sha2-nistp384': ec.ECDSA(hashes.SHA384())
+  }
+
 except ImportError:
   CRYPTO = False
 
@@ -331,7 +337,7 @@ def verify_signature(public_key, scheme, signature, data):
   # verify() raises an 'InvalidSignature' exception if 'signature'
   # is invalid.
   try:
-    ecdsa_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
+    ecdsa_key.verify(signature, data, _SCHEME_HASHER[scheme])
     return True
 
   except (TypeError, cryptography.exceptions.InvalidSignature):

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -164,9 +164,8 @@ BOOLEAN_SCHEMA = SCHEMA.Boolean()
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
 RSAKEYBITS_SCHEMA = SCHEMA.Integer(lo=2048)
 
-# The supported ECDSA signature schemes (ecdsa-sha2-nistp256 is supported by
-# default).
-ECDSA_SCHEME_SCHEMA = SCHEMA.OneOf([SCHEMA.String('ecdsa-sha2-nistp256')])
+# The supported ECDSA signature schemes
+ECDSA_SCHEME_SCHEMA = SCHEMA.RegularExpression(r'ecdsa-sha2-nistp(256|384)')
 
 # A pyca-cryptography signature.
 PYCACRYPTOSIGNATURE_SCHEMA = SCHEMA.AnyBytes()
@@ -201,7 +200,7 @@ PUBLIC_KEYVAL_SCHEMA = SCHEMA.Object(
 # Supported securesystemslib key types.
 KEYTYPE_SCHEMA = SCHEMA.OneOf(
   [SCHEMA.String('rsa'), SCHEMA.String('ed25519'),
-   SCHEMA.String('ecdsa-sha2-nistp256')])
+   SCHEMA.RegularExpression(r'ecdsa-sha2-nistp(256|384)')])
 
 # A generic securesystemslib key.  All securesystemslib keys should be saved to
 # metadata files in this format.
@@ -254,7 +253,7 @@ RSAKEY_SCHEMA = SCHEMA.Object(
 # An ECDSA securesystemslib key.
 ECDSAKEY_SCHEMA = SCHEMA.Object(
   object_name = 'ECDSAKEY_SCHEMA',
-  keytype = SCHEMA.String('ecdsa-sha2-nistp256'),
+  keytype = SCHEMA.RegularExpression(r'ecdsa-sha2-nistp(256|384)'),
   scheme = ECDSA_SCHEME_SCHEMA,
   keyid = KEYID_SCHEMA,
   keyid_hash_algorithms = SCHEMA.Optional(HASHALGORITHMS_SCHEMA),
@@ -271,12 +270,6 @@ ED25519SIGNATURE_SCHEMA = SCHEMA.LengthBytes(64)
 
 # An ECDSA signature.
 ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
-
-# Required installation libraries expected by the repository tools and other
-# cryptography modules.
-REQUIRED_LIBRARIES_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
-  [SCHEMA.String('general'), SCHEMA.String('ed25519'), SCHEMA.String('rsa'),
-   SCHEMA.String('ecdsa-sha2-nistp256')]))
 
 # Ed25519 signature schemes.  The vanilla Ed25519 signature scheme is currently
 # supported.

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -847,8 +847,8 @@ def verify_signature(key_dict, signature, data):
       raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
           ' signature scheme is specified: ' + repr(scheme))
 
-  elif keytype == 'ecdsa-sha2-nistp256':
-    if scheme == 'ecdsa-sha2-nistp256':
+  elif keytype in ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384']:
+    if scheme in ['ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384']:
       valid_signature = securesystemslib.ecdsa_keys.verify_signature(public,
         scheme, sig, data)
 


### PR DESCRIPTION
**Fixes issue #**:
Required for PEP 458

**Description of the changes being introduced by the pull request**:
- Update public `keys` and internal `ecdsa_keys` modules to support verification of nistp384 signatures.
- Update formats relevant for ecdsa keys and signature to support nistp384 in addition to the already supported nistp256.


Testing will be added in a subsequent PR that adds HSM signing and pubkey export functionality.

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


