### PR TITLE
Remove support for gzipped files in load_json_file

### DIFF
--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import gzip
 import shutil
 import logging
 import tempfile
@@ -327,15 +326,7 @@ def load_json_file(filepath):
   securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
 
   deserialized_object = None
-
-  # The file is mostly likely gzipped.
-  if filepath.endswith('.gz'):
-    logger.debug('gzip.open(' + str(filepath) + ')')
-    fileobject = six.StringIO(gzip.open(filepath).read().decode('utf-8'))
-
-  else:
-    logger.debug('open(' + str(filepath) + ')')
-    fileobject = open(filepath)
+  fileobject = open(filepath)
 
   try:
     deserialized_object = json.load(fileobject)
@@ -345,7 +336,6 @@ def load_json_file(filepath):
       ' Python object: ' + repr(filepath))
 
   else:
-    fileobject.close()
     return deserialized_object
 
   finally:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -27,7 +27,6 @@ from __future__ import unicode_literals
 
 import os
 import sys
-import gzip
 import shutil
 import logging
 import tempfile
@@ -54,30 +53,6 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
   def tearDown(self):
     unittest_toolbox.Modified_TestCase.tearDown(self)
     self.temp_fileobj.close()
-
-
-
-  def _compress_existing_file(self, filepath):
-    """
-    [Helper]Compresses file 'filepath' and returns file path of
-    the compresses file.
-    """
-
-    # NOTE: DO NOT forget to remove the newly created compressed file!
-    if os.path.exists(filepath):
-      compressed_filepath = filepath+'.gz'
-      f_in = open(filepath, 'rb')
-      f_out = gzip.open(compressed_filepath, 'wb')
-      f_out.writelines(f_in)
-      f_out.close()
-      f_in.close()
-
-      return compressed_filepath
-
-    else:
-      logger.error('Compression of ' + repr(filepath)  +' failed.'
-          '  Path does not exist.')
-      sys.exit(1)
 
 
 
@@ -189,11 +164,6 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
     securesystemslib.util.json.dump(data, fileobj)
     fileobj.close()
     self.assertEqual(data, securesystemslib.util.load_json_file(filepath))
-
-    # Test a gzipped file.
-    compressed_filepath = self._compress_existing_file(filepath)
-    self.assertEqual(data,
-        securesystemslib.util.load_json_file(compressed_filepath))
 
     # Improperly formatted arguments.
     for bogus_arg in [1, [b'a'], {'a':b'b'}]:


### PR DESCRIPTION
Compression related functions were removed from securesystemslib as it was
deemed more appropriate for callers to handle compression/decompression at
a different level. However, the automatic decompression functionality in
load_json_file() had remained.

Remove that change and tidy up load_json_file() to only close the
fileobject once. Since Python 2.5 a finally block is always called,
regardless of whether there is an exception or not. Therefore there's no
need to close the fileobject in the else block and the finally block.

Signed-off-by: Joshua Lock <jlock@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


