### PR TITLE
Implement filesystem abstraction

### DIFF
--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -121,3 +121,7 @@ class InvalidConfigurationError(Error):
   """If a configuration object does not match the expected format."""
   pass
 
+class StorageError(Error):
+  """Indicate an error occured during interaction with an abstracted storage
+     backend."""
+  pass

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -36,6 +36,7 @@ import six
 
 import securesystemslib.exceptions
 import securesystemslib.formats
+import securesystemslib.storage
 
 
 DEFAULT_CHUNK_SIZE = 4096
@@ -314,7 +315,8 @@ def digest_fileobject(file_object, algorithm=DEFAULT_HASH_ALGORITHM,
 
 
 def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
-    hash_library=DEFAULT_HASH_LIBRARY, normalize_line_endings=False):
+    hash_library=DEFAULT_HASH_LIBRARY, normalize_line_endings=False,
+    storage_backend=None):
   """
   <Purpose>
     Generate a digest object, update its hash using a file object
@@ -332,6 +334,11 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
 
     normalize_line_endings:
       Whether or not to normalize line endings for cross-platform support.
+
+    storage_backend:
+      An object which implements
+      securesystemslib.storage.StorageBackendInterface. When no object is
+      passed a FilesystemBackend will be instantiated and used.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are
@@ -361,8 +368,11 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
 
   digest_object = None
 
+  if storage_backend is None:
+    storage_backend = securesystemslib.storage.FilesystemBackend()
+
   # Open 'filename' in read+binary mode.
-  with open(filename, 'rb') as file_object:
+  with storage_backend.get(filename) as file_object:
     # Create digest_object and update its hash data from file_object.
     # digest_fileobject() raises:
     # securesystemslib.exceptions.UnsupportedAlgorithmError

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -55,7 +55,7 @@ try:
   from colorama import Fore
   TERM_RED = Fore.RED
   TERM_RESET = Fore.RESET
-except ImportError:
+except ImportError: # pragma: no cover
   logger.debug("Failed to find colorama module, terminal output won't be colored")
   TERM_RED = ''
   TERM_RESET = ''

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -1,0 +1,150 @@
+"""
+<Program Name>
+  storage.py
+
+<Author>
+  Joshua Lock <jlock@vmware.com>
+
+<Started>
+  April 9, 2020
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides an interface for filesystem interactions, StorageBackendInterface.
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import abc
+import errno
+import logging
+import os
+import shutil
+
+import securesystemslib.exceptions
+
+logger = logging.getLogger(__name__)
+
+
+
+class StorageBackendInterface():
+  """
+  <Purpose>
+  Defines an interface for abstract storage operations which can be implemented
+  for a variety of storage solutions, such as remote and local filesystems.
+  """
+
+  __metaclass__ = abc.ABCMeta
+
+
+  @abc.abstractmethod
+  def get(self, filepath):
+    """
+    <Purpose>
+      A context manager for 'with' statements that is used for retrieving files
+      from a storage backend and cleans up the files upon exit.
+
+        with storage_backend.get('/path/to/file') as file_object:
+          # operations
+        # file is now closed
+
+    <Arguments>
+      filepath:
+        The full path of the file to be retrieved.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the file does not exist or is
+      no accessible.
+
+    <Returns>
+      A ContextManager object that emits a file-like object for the file at
+      'filepath'.
+    """
+    raise NotImplementedError # pragma: no cover
+
+
+  @abc.abstractmethod
+  def put(self, fileobj, filepath):
+    """
+    <Purpose>
+      Store a file-like object in the storage backend.
+
+    <Arguments>
+      fileobj:
+        The file-like object to be stored.
+
+      filepath:
+        The full path to the location where 'fileobj' will be stored.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the file can not be stored.
+
+    <Returns>
+      None
+    """
+    raise NotImplementedError # pragma: no cover
+
+
+  @abc.abstractmethod
+  def getsize(self, filepath):
+    """
+    <Purpose>
+      Retrieve the size, in bytes, of the file at 'filepath'.
+
+    <Arguments>
+      filepath:
+        The full path to the file.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the file does not exist or is
+      not accessible.
+
+    <Returns>
+      The size in bytes of the file at 'filepath'.
+    """
+    raise NotImplementedError # pragma: no cover
+
+
+  @abc.abstractmethod
+  def create_folder(self, filepath):
+    """
+    <Purpose>
+      Create a folder at filepath and ensure all intermediate components of the
+      path exist.
+
+    <Arguments>
+      filepath:
+        The full path of the folder to be created.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the folder can not be
+      created.
+
+    <Returns>
+      None
+    """
+    raise NotImplementedError # pragma: no cover
+
+
+  @abc.abstractmethod
+  def list_folder(self, filepath):
+    """
+    <Purpose>
+      List the contents of the folder at 'filepath'.
+
+    <Arguments>
+      filepath:
+        The full path of the folder to be listed.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the file does not exist or is
+      not accessible.
+
+    <Returns>
+      A list containing the names of the files in the folder. May be an empty
+      list.
+    """
+    raise NotImplementedError # pragma: no cover

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -218,8 +218,8 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
         'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_rsa_privatekey_from_file,
-        nonexistent_keypath, 'pw')
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_rsa_privatekey_from_file, nonexistent_keypath, 'pw')
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')
@@ -252,8 +252,8 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
         'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_rsa_publickey_from_file,
-        nonexistent_keypath)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_rsa_publickey_from_file, nonexistent_keypath)
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')
@@ -426,8 +426,9 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
         'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_ed25519_privatekey_from_file,
-        nonexistent_keypath, 'pw')
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_ed25519_privatekey_from_file, nonexistent_keypath,
+        'pw')
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')
@@ -576,8 +577,8 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Test invalid argument.
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory, 'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_ecdsa_privatekey_from_file,
-        nonexistent_keypath, 'pw')
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_ecdsa_privatekey_from_file, nonexistent_keypath, 'pw')
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -42,6 +42,7 @@ if sys.version_info >= (3, 3):
 else:
   import mock
 
+import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.hash
 import securesystemslib.interface as interface
@@ -373,8 +374,8 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
         'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_ed25519_publickey_from_file,
-        nonexistent_keypath)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_ed25519_publickey_from_file, nonexistent_keypath)
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')
@@ -525,8 +526,8 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
         'nonexistent_keypath')
-    self.assertRaises(IOError, interface.import_ecdsa_publickey_from_file,
-        nonexistent_keypath)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        interface.import_ecdsa_publickey_from_file, nonexistent_keypath)
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,96 @@
+"""
+<Program Name>
+  test_storage.py
+
+<Author>
+  Joshua Lock <jlock@vmware.com>
+
+<Started>
+  April 17, 2020
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Unit test for 'storage.py'
+"""
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import os
+import tempfile
+import unittest
+
+import securesystemslib.exceptions
+import securesystemslib.storage
+
+import six
+
+
+class TestStorage(unittest.TestCase):
+  def setUp(self):
+    self.storage_backend = securesystemslib.storage.FilesystemBackend()
+    self.temp_dir = tempfile.mkdtemp(dir=os.getcwd())
+    self.filepath = os.path.join(self.temp_dir, 'testfile')
+    with open(self.filepath, 'wb') as test:
+        test.write(b'testing')
+    self.fileobj = open(self.filepath, 'rb')
+
+
+  def tearDown(self):
+    self.fileobj.close()
+
+
+  def test_exceptions(self):
+    try:
+      with self.storage_backend.get('/none/existent/path') as file_object:
+        file_object.read()
+    except Exception as exc:
+      self.assertIsInstance(exc, securesystemslib.exceptions.StorageError)
+
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        self.storage_backend.put, self.fileobj, '/none/existent/path')
+
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        self.storage_backend.getsize, '/none/existent/path')
+
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        self.storage_backend.create_folder, '/none/existent/path')
+
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        self.storage_backend.list_folder, '/none/existent/path')
+
+
+  def test_files(self):
+    with self.storage_backend.get(self.filepath) as get_fileobj:
+      self.assertEqual(get_fileobj.read(), self.fileobj.read())
+
+    self.assertEqual(self.storage_backend.getsize(self.filepath),
+        os.path.getsize(self.filepath))
+
+    put_path = os.path.join(self.temp_dir, 'put')
+    with self.storage_backend.get(self.filepath) as get_fileobj:
+      self.storage_backend.put(get_fileobj, put_path)
+      self.fileobj.seek(0)
+      with open(put_path, 'rb') as put_file:
+        self.assertEqual(put_file.read(), self.fileobj.read())
+
+
+  def test_folders(self):
+    leaves = ['test1', 'test2', 'test3']
+    folder = os.path.join(self.temp_dir, 'test_dir')
+    self.storage_backend.create_folder(folder)
+    for leaf in leaves:
+      with open(os.path.join(folder, leaf), 'wb') as fi:
+        fi.write(leaf.encode('utf-8'))
+    found_leaves = self.storage_backend.list_folder(folder)
+    self.assertListEqual(leaves, sorted(found_leaves))
+
+    # Test trying to create a folder with an empty string
+    self.storage_backend.create_folder('')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -171,7 +171,7 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
           securesystemslib.util.load_json_file, bogus_arg)
 
     # Non-existent path.
-    self.assertRaises(IOError,
+    self.assertRaises(securesystemslib.exceptions.StorageError,
         securesystemslib.util.load_json_file, 'non-existent.json')
 
     # Invalid JSON content.
@@ -188,11 +188,23 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
   def test_B7_persist_temp_file(self):
     # Destination directory to save the temporary file in.
     dest_temp_dir = self.make_temp_directory()
+
+    # Test the default of persisting the file and closing the tmpfile
     dest_path = os.path.join(dest_temp_dir, self.random_string())
     tmpfile = tempfile.TemporaryFile()
     tmpfile.write(self.random_string().encode('utf-8'))
     securesystemslib.util.persist_temp_file(tmpfile, dest_path)
     self.assertTrue(dest_path)
+    self.assertTrue(tmpfile.closed)
+
+    # Test persisting a file without automatically closing the tmpfile
+    dest_path2 = os.path.join(dest_temp_dir, self.random_string())
+    tmpfile = tempfile.TemporaryFile()
+    tmpfile.write(self.random_string().encode('utf-8'))
+    securesystemslib.util.persist_temp_file(tmpfile, dest_path2,
+        should_close=False)
+    self.assertFalse(tmpfile.closed)
+    tmpfile.close()
 
 
 


### PR DESCRIPTION
**Note**: this branch of securesystemslib doesn't currently work with theupdateframework/tuf – it's very much WIP.

It feels like the shape these changes are taking introduces a conflict between the desire to support abstract filesystem backends vs. reasonable feature enhancements that have been suggested such as #222. It's not yet clear to me how we will support both abstract filesystem backends _and_ creating private key files with restricted privileges.

**Fixes issue #**: step one, two and four of theupdateframework/tuf#1009

**Description of the changes being introduced by the pull request**:
* Add an abstract base class defining an interface for storage
* Add a concrete implementation of the storage interface for accessing the local file system 
* Add abstract storage support to `securesystemslib.hash.digest_filename()`
* Add abstract storage support to `securesystemslib.util.[get_file_details|ensure_parent_dir|load_json_file]()`

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


