### PR TITLE
Add remove() method to StorageBackendInterface

### DIFF
--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -233,6 +233,14 @@ class FilesystemBackend(StorageBackendInterface):
           "Can't write file %s" % filepath)
 
 
+  def remove(self, filepath):
+    try:
+      os.remove(filepath)
+    except (FileNotFoundError, PermissionError, OSError):  # pragma: no cover
+      raise securesystemslib.exceptions.StorageError(
+          "Can't remove file %s" % filepath)
+
+
   def getsize(self, filepath):
     try:
       return os.path.getsize(filepath)

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -94,6 +94,25 @@ class StorageBackendInterface():
 
 
   @abc.abstractmethod
+  def remove(self, filepath):
+    """
+    <Purpose>
+      Remove the file at 'filepath' from the storage.
+
+    <Arguments>
+      filepath:
+        The full path to the file.
+
+    <Exceptions>
+      securesystemslib.exceptions.StorageError, if the file can not be removed.
+
+    <Returns>
+      None
+    """
+    raise NotImplementedError # pragma: no cover
+
+
+  @abc.abstractmethod
   def getsize(self, filepath):
     """
     <Purpose>

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -81,6 +81,10 @@ class TestStorage(unittest.TestCase):
       with open(put_path, 'rb') as put_file:
         self.assertEqual(put_file.read(), self.fileobj.read())
 
+    self.assertTrue(os.path.exists(put_path))
+    self.storage_backend.remove(put_path)
+    self.assertFalse(os.path.exists(put_path))
+
 
   def test_folders(self):
     leaves = ['test1', 'test2', 'test3']


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
tuf needs to be able to delete files when tidying up outdated/revoked metadata, therefore our storage abstraction needs a method to remove files from storage.
* Add `remove()` method to `storage.StorageBackendInterface`
* Implement `remove()` in `storage.FilesystemBackend`

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


