### PR TITLE
securesystemslib/storage: Document some storage invariants

### DIFF
--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -76,6 +76,8 @@ class StorageBackendInterface():
     """
     <Purpose>
       Store a file-like object in the storage backend.
+      The file-like object is read from the beginning, not its current
+      offset (if any).
 
     <Arguments>
       fileobj:
@@ -138,6 +140,8 @@ class StorageBackendInterface():
     <Purpose>
       Create a folder at filepath and ensure all intermediate components of the
       path exist.
+      Passing an empty string for filepath does nothing and does not raise an
+      exception.
 
     <Arguments>
       filepath:


### PR DESCRIPTION
This documents two previously undocumented invariants of the storage interface:

* `put` rewinds (or seeks) the given `fileobj` to its beginning before attempting to store it
* `create_folder` does nothing (and does not throw) if `filepath` is an empty string

cc @joshuagl @lukpueh @mnm678 


