### PR TITLE
Restore PATH_SCHEMA to be AnyString

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -128,7 +128,7 @@ KEYIDS_SCHEMA = SCHEMA.ListOf(KEYID_SCHEMA)
 SCHEME_SCHEMA = SCHEMA.AnyString()
 
 # A path string, whether relative or absolute, e.g. 'metadata/root/'
-PATH_SCHEMA = SCHEMA.AnyNonemptyString()
+PATH_SCHEMA = SCHEMA.AnyString()
 PATHS_SCHEMA = SCHEMA.ListOf(PATH_SCHEMA)
 
 # An integer representing logger levels, such as logging.CRITICAL (=50).


### PR DESCRIPTION
**Fixes issue #**: https://github.com/theupdateframework/tuf/issues/1059

**Description of the changes being introduced by the pull request**:

In one of the latest commits AnyNonemptyString was introduced
and with it, PATH_SCHEMA was changed to AnyNonemptyString from
AnyString. This led to unit tests failures in TUF.

One could argue what is the right approach: to consider
that PATH_SCHEMA is every non-empty string or every string.
I think this is not of much importance, but for TUF and
possibly for other securesystemslib adopters, this leads to tests
failures. The reason is that there are multiple functions
with arguments which should conformant against the PATH_SCHEMA
but have default values of `''`

See :
- "location_in_repository" argument in create_new_project function
both of which are in tuf/developer_tool.py: https://github.com/theupdateframework/tuf/blob/49031b424b65e852194c911f85bc29c14ad97432/tuf/developer_tool.py#L519
- "prefix" argument in load_repository function:
https://github.com/theupdateframework/tuf/blob/49031b424b65e852194c911f85bc29c14ad97432/tuf/developer_tool.py#L758

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


