### PR TITLE
include keyid in public ed25519/ecdsa public key files

### DIFF
--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -516,13 +516,15 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None):
   # to final destination.
   file_object = tempfile.TemporaryFile()
 
-  # Generate the ed25519 public key file contents in metadata format (i.e.,
-  # does not include the keyid portion).
+  # Generate the ed25519 public key file contents in metadata format
+  # We can include the keyid here, because the keyid is calculated
+  # by the key data without the private key.
   keytype = ed25519_key['keytype']
+  keyid = ed25519_key['keyid']
   keyval = ed25519_key['keyval']
   scheme = ed25519_key['scheme']
   ed25519key_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
-      keytype, scheme, keyval, private=False)
+      keytype, scheme, keyval, keyid=keyid, private=False)
 
   file_object.write(json.dumps(ed25519key_metadata_format).encode('utf-8'))
 
@@ -786,8 +788,9 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   keytype = ecdsa_key['keytype']
   keyval = ecdsa_key['keyval']
   scheme = ecdsa_key['scheme']
+  keyid = ecdsa_key['keyid']
   ecdsakey_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
-      keytype, scheme, keyval, private=False)
+      keytype, scheme, keyval, keyid=keyid, private=False)
 
   file_object.write(json.dumps(ecdsakey_metadata_format).encode('utf-8'))
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -378,7 +378,7 @@ def generate_ed25519_key(scheme='ed25519'):
 
 
 
-def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
+def format_keyval_to_metadata(keytype, scheme, key_value, keyid=None, private=False):
   """
   <Purpose>
     Return a dictionary conformant to 'securesystemslib.formats.KEY_SCHEMA'.
@@ -464,7 +464,15 @@ def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
 
   else:
     public_key_value = {'public': key_value['public']}
-
+    # If we encounter a keyid, we are dealing with pub key file generation
+    # as in interface.py#L526
+    if keyid is not None:
+      return {'keytype': keytype,
+            'scheme': scheme,
+            'keyid': keyid,
+            'keyid_hash_algorithms': securesystemslib.settings.HASH_ALGORITHMS,
+            'keyval': public_key_value}
+    
     return {'keytype': keytype,
             'scheme': scheme,
             'keyid_hash_algorithms': securesystemslib.settings.HASH_ALGORITHMS,


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue**: https://github.com/in-toto/docs/issues/33

**Description of the changes being introduced by the pull request**:

In the past we did not include the keyid in public ed25519/ecdsa key files. This commit changes this behavior and introduces a new argument to the `format_keyval_to_metadata` function. The argument is optional,
so this should not have any affect on using `format_keyval_to_metadata` for keyid generation.

**Please verify and check that the pull request fulfils the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

Do we need further tests/documentation for this change? The new argument is optional, so it should be API stable, however the generated public key itself may be different from now on. I have not tested this PR with in-toto-keygen yet.

