### PR TITLE
Throw exception on empty filepath in create_folder

### DIFF
--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -254,10 +254,6 @@ class FilesystemBackend(StorageBackendInterface):
 
 
   def create_folder(self, filepath):
-    # If called with an empty string, return immediately
-    if not filepath:
-      return
-
     try:
       os.makedirs(filepath)
     except OSError as e:
@@ -266,6 +262,9 @@ class FilesystemBackend(StorageBackendInterface):
       # silently ignore.
       if e.errno == errno.EEXIST:
         pass
+      elif e.errno == errno.ENOENT and not filepath:
+        raise securesystemslib.exceptions.StorageError(
+            "Can't create a folder with an empty filepath!")
       else:
         raise securesystemslib.exceptions.StorageError(
             "Can't create folder at %s" % filepath)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -66,6 +66,9 @@ class TestStorage(unittest.TestCase):
         self.storage_backend.create_folder, '/none/existent/path')
 
     self.assertRaises(securesystemslib.exceptions.StorageError,
+        self.storage_backend.create_folder, '')
+
+    self.assertRaises(securesystemslib.exceptions.StorageError,
         self.storage_backend.list_folder, '/none/existent/path')
 
 
@@ -97,6 +100,3 @@ class TestStorage(unittest.TestCase):
         fi.write(leaf.encode('utf-8'))
     found_leaves = self.storage_backend.list_folder(folder)
     self.assertListEqual(leaves, sorted(found_leaves))
-
-    # Test trying to create a folder with an empty string
-    self.storage_backend.create_folder('')


### PR DESCRIPTION
**Fixes issue #**: https://github.com/secure-systems-lab/securesystemslib/issues/241

**Description of the changes being introduced by the pull request**:

Now, when securesystemslib.storage.FilesystemBackend.create_folder()
is called with an empty string it returns immediately,
without exception, but if we call os.mkdir() with an empty string
we receive this exception:
"[Errno 2] No such file or directory: ''

If we want to mimic the os.mkdir() function when using the
securesystemslib.storage.FilesystemBackend.create_folder()
the function we need to throw our respective exception
securesystemslib.exceptions.StorageError with an appropriate message
when an empty path is given.

**Please verify and check that the pull request fulfils the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


