### PR TITLE
Fix directory being empty in ensure_parent_dir

### DIFF
--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -182,7 +182,10 @@ def ensure_parent_dir(filename, storage_backend=None):
   # Split 'filename' into head and tail, check if head exists.
   directory = os.path.split(filename)[0]
 
-  storage_backend.create_folder(directory)
+  # Check for cases where filename is without directory like 'file.txt'
+  # and as a result directory is an empty string
+  if directory:
+    storage_backend.create_folder(directory)
 
 
 def file_in_confined_directories(filepath, confined_directories):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -98,6 +98,13 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
         self.assertRaises(securesystemslib.exceptions.FormatError,
             securesystemslib.util.ensure_parent_dir, parent_dir)
 
+    # When we call ensure_parent_dir with filepath arg like "a.txt",
+    # then the directory of that filepath will be an empty string.
+    # We want to make sure that securesyslib.storage.create_folder()
+    # won't be called with an empty string and thus raise an exception.
+    # If an exception is thrown the test will fail.
+    securesystemslib.util.ensure_parent_dir('a.txt')
+
 
 
   def  test_B3_file_in_confined_directories(self):


### PR DESCRIPTION
**Fixes issue #**: None

**Description of the changes being introduced by the pull request**:
If you pass filename like "a.txt" to
securesyslib.util.ensure_parent_dir function, then the directory
of the file will be '' and when calling
securesyslib.storage.create_folder() with '' argument
an exception will be thrown because of the latest changes
in securesyslib.

**Please verify and check that the pull request fulfils the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


