### PR TITLE
Remove python-dateutil dependency

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,4 +1,3 @@
 # Minimal runtime requirements (see 'install_requires' in setup.py)
 six
-python-dateutil
 subprocess32; python_version < '3'

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -5,6 +5,5 @@ enum34==1.1.6             ; python_version < "3" # via cryptography
 ipaddress==1.0.23         ; python_version < "3" # via cryptography
 pycparser==2.20           # via cffi
 pynacl==1.4.0
-python-dateutil==2.8.1
 six==1.15.0
 subprocess32==3.5.4       ; python_version < "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,4 @@ cryptography
 pynacl
 colorama
 six
-python-dateutil
 subprocess32; python_version < '3'

--- a/securesystemslib/gpg/exceptions.py
+++ b/securesystemslib/gpg/exceptions.py
@@ -19,7 +19,6 @@
 
 """
 import datetime
-import dateutil.tz
 
 
 class PacketParsingError(Exception):
@@ -43,11 +42,10 @@ class KeyExpirationError(Exception):
     self.key = key
 
   def __str__(self):
-    creation_time = datetime.datetime.fromtimestamp(
-        self.key["creation_time"], dateutil.tz.UTC)
-    expiration_time = datetime.datetime.fromtimestamp(
-        self.key["creation_time"] + self.key["validity_period"],
-        dateutil.tz.UTC)
+    creation_time = datetime.datetime.utcfromtimestamp(
+        self.key["creation_time"])
+    expiration_time = datetime.datetime.utcfromtimestamp(
+        self.key["creation_time"] + self.key["validity_period"])
     validity_period = expiration_time - creation_time
 
     return ("GPG key '{}' created on '{:%Y-%m-%d %H:%M} UTC' with validity "

--- a/setup.py
+++ b/setup.py
@@ -103,8 +103,7 @@ setup(
     'Source': 'https://github.com/secure-systems-lab/securesystemslib',
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
-  install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"',
-      'python-dateutil>=2.8.0'],
+  install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],
       'crypto': ['cryptography>=2.6'],


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**: Switch to using `datetime.utcfromtimestamp()` in order to reduce the dependency footprint for securesystemslib.

**Please verify and check that the pull request fulfils the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


