### PR TITLE
Add gpg.export_pubkeys convenience function

### DIFF
--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -299,3 +299,29 @@ def export_pubkey(keyid, homedir=None):
   key_bundle = securesystemslib.gpg.common.get_pubkey_bundle(key_packet, keyid)
 
   return key_bundle
+
+
+def export_pubkeys(keyids, homedir=None):
+  """Export multiple public keys from a GnuPG keyring.
+
+  Arguments:
+    keyids: A list of OpenPGP keyids in KEYID_SCHEMA format.
+    homedir (optional): A path to the GnuPG home directory. If not set the
+        default GnuPG home directory is used.
+
+  Raises:
+    TypeError: Keyids is not iterable.
+    See 'export_pubkey' for other exceptions.
+
+  Returns:
+    A dict with the OpenPGP keyids passed as the keyids argument for dict keys
+    and keys in GPG_PUBKEY_SCHEMA format for values.
+
+  """
+  public_key_dict = {}
+  for gpg_keyid in keyids:
+    public_key = export_pubkey(gpg_keyid, homedir=homedir)
+    keyid = public_key["keyid"]
+    public_key_dict[keyid] = public_key
+
+  return public_key_dict

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -27,7 +27,7 @@ import unittest
 from securesystemslib.gpg.constants import HAVE_GPG, NO_GPG_MSG
 from securesystemslib.gpg.util import get_version
 from securesystemslib.gpg.functions import (
-    create_signature, export_pubkey, verify_signature)
+    create_signature, export_pubkey, export_pubkeys, verify_signature)
 
 from securesystemslib.exceptions import UnsupportedLibraryError
 
@@ -46,6 +46,10 @@ class TestPublicInterfacesGPG(unittest.TestCase):
 
     with self.assertRaises(UnsupportedLibraryError) as ctx:
       export_pubkey('f00')
+    self.assertEqual(NO_GPG_MSG, str(ctx.exception))
+
+    with self.assertRaises(UnsupportedLibraryError) as ctx:
+      export_pubkeys(['f00'])
     self.assertEqual(NO_GPG_MSG, str(ctx.exception))
 
     with self.assertRaises(UnsupportedLibraryError) as ctx:


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: # -
Related to in-toto/in-toto#80

### Description of the changes being introduced by the pull request:
Add convenience function to export multiple public keys from a gpg keyring into an sslib dict format at once and tests.

Note: Uses the new pseudo-standard docstring style suggested in secure-systems-lab/code-style-guidelines#20. All new interface functions should use that style (existing docstrings will be converted in separate PRs).



### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


