### PR TITLE
Add interface.export_pubkeys convenience function

### DIFF
--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -9,3 +9,10 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.addHandler(logging.StreamHandler())
+
+
+# Global constants
+# TODO: Replace hard-coded key types with these constants (and add more)
+KEY_TYPE_RSA = "rsa"
+KEY_TYPE_ED25519 = "ed25519"
+KEY_TYPE_ECDSA = "ecdsa"


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: # -
Related to in-toto/in-toto#80

### Description of the changes being introduced by the pull request:

Add convenience function to import multiple public keys of different key types from file into an sslib dict format at once, and tests.

Note: Uses the new pseudo-standard docstring style suggested in secure-systems-lab/code-style-guidelines#20. All new interface functions should use that style (existing docstrings will be converted in separate PRs).

Note2: This PR also adds a few package-wide constants for key types, that are still hardcoded in many places.  We should switch to using these and probably other global constants in a separate PR.


### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


