### PR TITLE
Rename generic publickey import function

### DIFF
--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -937,8 +937,11 @@ def import_ecdsa_privatekey_from_file(filepath, password=None,
 
 
 
-def import_public_keys_from_file(filepaths, key_types=None):
-  """Import multiple public keys from files.
+def import_publickeys_from_file(filepaths, key_types=None):
+  """Imports multiple public keys from files.
+
+  NOTE: Use 'import_rsa_publickey_from_file' to specify any other than the
+  default signing schemes for an RSA key.
 
   Arguments:
     filepaths: A list of paths to public key files.
@@ -949,8 +952,8 @@ def import_public_keys_from_file(filepaths, key_types=None):
 
   Raises:
     TypeError: filepaths or key_types (if passed) is not iterable.
-    securesystemslib.exceptions.FormatError: key_types is passed and does not
-        have the same length as filepaths or contains an unsupported key type.
+    FormatError: key_types is passed and does not have the same length as
+        filepaths or contains an unsupported key type.
     See import_ed25519_publickey_from_file, import_rsa_publickey_from_file and
     import_ecdsa_publickey_from_file for other exceptions.
 
@@ -959,7 +962,7 @@ def import_public_keys_from_file(filepaths, key_types=None):
 
   """
   if key_types is None:
-    key_types = [securesystemslib.KEY_TYPE_RSA] * len(filepaths)
+    key_types = [KEY_TYPE_RSA] * len(filepaths)
 
   if len(key_types) != len(filepaths):
     raise securesystemslib.exceptions.FormatError(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -69,7 +69,7 @@ from securesystemslib.interface import (
     generate_and_write_ecdsa_keypair,
     import_ecdsa_publickey_from_file,
     import_ecdsa_privatekey_from_file,
-    import_public_keys_from_file)
+    import_publickeys_from_file)
 
 
 
@@ -499,11 +499,11 @@ class TestInterfaceFunctions(unittest.TestCase):
 
 
 
-  def test_import_public_keys_from_file(self):
+  def test_import_publickeys_from_file(self):
     """Test import multiple public keys with different types. """
 
     # Successfully import key dict with one key per supported key type
-    key_dict = import_public_keys_from_file([
+    key_dict = import_publickeys_from_file([
         self.path_rsa + ".pub",
         self.path_ed25519  + ".pub",
         self.path_ecdsa  + ".pub"],
@@ -516,28 +516,28 @@ class TestInterfaceFunctions(unittest.TestCase):
       )
 
     # Successfully import default rsa key
-    key_dict = import_public_keys_from_file([self.path_rsa + ".pub"])
+    key_dict = import_publickeys_from_file([self.path_rsa + ".pub"])
     ANY_PUBKEY_DICT_SCHEMA.check_match(key_dict)
     RSAKEY_SCHEMA.check_match(
         list(key_dict.values()).pop())
 
     # Bad default rsa key type for ed25519
     with self.assertRaises(Error):
-      import_public_keys_from_file([self.path_ed25519 + ".pub"])
+      import_publickeys_from_file([self.path_ed25519 + ".pub"])
 
     # Bad ed25519 key type for rsa key
     with self.assertRaises(Error):
-      import_public_keys_from_file(
+      import_publickeys_from_file(
           [self.path_rsa + ".pub"], [KEY_TYPE_ED25519])
 
     # Unsupported key type
     with self.assertRaises(FormatError):
-      import_public_keys_from_file(
+      import_publickeys_from_file(
           [self.path_ed25519 + ".pub"], ["KEY_TYPE_UNSUPPORTED"])
 
     # Mismatching arguments lists lenghts
     with self.assertRaises(FormatError):
-      import_public_keys_from_file(
+      import_publickeys_from_file(
           [self.path_rsa + ".pub", self.path_ed25519 + ".pub"],
           [KEY_TYPE_ED25519])
 


### PR DESCRIPTION

<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: # -

### Description of the changes being introduced by the pull request:
Rename "_public_key_" to "_publickey_" for consistency with other interface key import functions.

This commit also fixes a typo in an error message, removes unnecessary module paths and adds a note to the function docstring to inform about the shortcoming of the generic function.

*Note: We might want to revisit said shortcoming in a future interface enhancing PR (also see #251). For now we primarily want to  sort out in-toto/in-toto#80, of which this PR is a part.*



### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


