### PR TITLE
Consolidate key interface password handling and general overhaul

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,9 +83,9 @@ text without prepended symbols is the output of a command.
 
     # If the key length is unspecified, it defaults to 3072 bits. A length of
     # less than 2048 bits raises an exception. A password may be supplied as an
-    # argument, otherwise a user prompt is presented.  If the password is an
-    # empty string, the private key is saved unencrypted.
-    >>> generate_and_write_rsa_keypair("rsa_key2")
+    # argument like above, or on the prompt. If no password is passed or
+    # entered the private key is saved unencrypted.
+    >>> generate_and_write_rsa_keypair("rsa_key2", prompt=True)
     Enter a password for the RSA key:
     Confirm:
 
@@ -134,10 +134,10 @@ Create and Import Ed25519 Keys
 
     # Continuing from the previous section . . .
 
-    # Generate and write an Ed25519 key pair.  The private key is saved
-    # encrypted.  A 'password' argument may be supplied, otherwise a prompt is
-    # presented.
-    >>> generate_and_write_ed25519_keypair('ed25519_key')
+    # Generate and write an Ed25519 key pair.  A password may be supplied as an
+    # argument, or on the prompt. If no password is passed or entered the
+    # private key is saved unencrypted.
+    >>> generate_and_write_ed25519_keypair('ed25519_key', prompt=True)
     Enter a password for the Ed25519 key:
     Confirm:
 
@@ -145,7 +145,7 @@ Create and Import Ed25519 Keys
     >>> public_ed25519_key = import_ed25519_publickey_from_file('ed25519_key.pub')
 
     # and its corresponding private key.
-    >>> private_ed25519_key = import_ed25519_privatekey_from_file('ed25519_key')
+    >>> private_ed25519_key = import_ed25519_privatekey_from_file('ed25519_key', prompt=True)
     Enter a password for the encrypted Ed25519 key:
 
 
@@ -156,12 +156,12 @@ Create and Import ECDSA Keys
 
     # continuing from the previous sections . . .
 
-    >>> generate_and_write_ecdsa_keypair('ecdsa_key')
+    >>> generate_and_write_ecdsa_keypair('ecdsa_key', prompt=True)
     Enter a password for the ECDSA key:
     Confirm:
 
     >>> public_ecdsa_key = import_ecdsa_publickey_from_file('ecdsa_key.pub')
-    >>> private_ecdsa_key = import_ecdsa_privatekey_from_file('ecdsa_key')
+    >>> private_ecdsa_key = import_ecdsa_privatekey_from_file('ecdsa_key', prompt=True)
     Enter a password for the encrypted ECDSA key:
 
 

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -232,43 +232,24 @@ def verify_signature(signature_object, pubkey_info, content):
 
 
 def export_pubkey(keyid, homedir=None):
-  """
-  <Purpose>
-    Calls gpg command line utility to export the gpg public key bundle
-    identified by the passed keyid from the gpg keyring at the passed homedir
-    in a securesystemslib-style format.
+  """Exports a public key from a GnuPG keyring.
 
-    NOTE: The identified key is exported including the corresponding master
-    key and all subkeys.
+  Arguments:
+    keyid: An OpenPGP keyid in KEYID_SCHEMA format.
+    homedir (optional): A path to the GnuPG home directory. If not set the
+        default GnuPG home directory is used.
 
-    The executed base export command is defined in
-    securesystemslib.gpg.constants.GPG_EXPORT_PUBKEY_COMMAND.
+  Raises:
+    ValueError: Keyid is not a string.
+    UnsupportedLibraryError: The gpg command or pyca/cryptography are not
+        available.
+    KeyNotFoundError: No key or subkey was found for that keyid.
 
-  <Arguments>
-    keyid:
-            The GPG keyid in format: securesystemslib.formats.KEYID_SCHEMA
+  Side Effects:
+    Calls system gpg command in a subprocess.
 
-    homedir: (optional)
-            Path to the gpg keyring. If not passed the default keyring is used.
-
-  <Exceptions>
-    ValueError:
-            if the keyid does not match the required format.
-
-    securesystemslib.exceptions.UnsupportedLibraryError:
-            If the gpg command is not available, or
-            the cryptography library is not installed.
-
-    securesystemslib.gpg.execeptions.KeyNotFoundError:
-            if no key or subkey was found for that keyid.
-
-
-  <Side Effects>
-    None.
-
-  <Returns>
-    The exported public key object in the format:
-    securesystemslib.formats.GPG_PUBKEY_SCHEMA.
+  Returns:
+    An OpenPGP public key object in GPG_PUBKEY_SCHEMA format.
 
   """
   if not HAVE_GPG: # pragma: no cover
@@ -302,7 +283,7 @@ def export_pubkey(keyid, homedir=None):
 
 
 def export_pubkeys(keyids, homedir=None):
-  """Export multiple public keys from a GnuPG keyring.
+  """Exports multiple public keys from a GnuPG keyring.
 
   Arguments:
     keyids: A list of OpenPGP keyids in KEYID_SCHEMA format.
@@ -311,11 +292,18 @@ def export_pubkeys(keyids, homedir=None):
 
   Raises:
     TypeError: Keyids is not iterable.
-    See 'export_pubkey' for other exceptions.
+    ValueError: A Keyid is not a string.
+    UnsupportedLibraryError: The gpg command or pyca/cryptography are not
+        available.
+    KeyNotFoundError: No key or subkey was found for that keyid.
+
+  Side Effects:
+    Calls system gpg command in a subprocess.
 
   Returns:
-    A dict with the OpenPGP keyids passed as the keyids argument for dict keys
-    and keys in GPG_PUBKEY_SCHEMA format for values.
+    A dict of OpenPGP public key objects in GPG_PUBKEY_SCHEMA format as values,
+    and their keyids as dict keys.
+
 
   """
   public_key_dict = {}

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -173,7 +173,6 @@ def _get_key_file_decryption_password(password, prompt, path):
 
 
 
-
 def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     password=None, prompt=False):
   """Generates RSA key pair and writes PEM-encoded keys to disk.
@@ -205,7 +204,8 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     StorageError: Key files cannot be written.
 
   Side Effects:
-      Writes key files to disk.
+    Prompts user for a password if 'prompt' is True.
+    Writes key files to disk.
 
   Returns:
     The private key filepath.
@@ -244,7 +244,6 @@ def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   securesystemslib.util.persist_temp_file(file_object, filepath)
 
   return filepath
-
 
 
 
@@ -297,8 +296,6 @@ def import_rsa_privatekey_from_file(filepath, password=None,
 
 
 
-
-
 def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
     storage_backend=None):
   """Imports PEM-encoded RSA public key from file storage.
@@ -344,8 +341,6 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
 
 
 
-
-
 def generate_and_write_ed25519_keypair(filepath=None, password=None,
     prompt=False):
   """Generates ed25519 key pair and writes custom JSON-formatted keys to disk.
@@ -373,6 +368,7 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None,
     StorageError: Key files cannot be written.
 
   Side Effects:
+    Prompts user for a password if 'prompt' is True.
     Writes key files to disk.
 
   Returns:
@@ -419,7 +415,6 @@ def generate_and_write_ed25519_keypair(filepath=None, password=None,
 
 
 
-
 def import_ed25519_publickey_from_file(filepath):
   """Imports custom JSON-formatted ed25519 public key from disk.
 
@@ -451,9 +446,6 @@ def import_ed25519_publickey_from_file(filepath):
     raise securesystemslib.exceptions.FormatError(message)
 
   return ed25519_key
-
-
-
 
 
 
@@ -504,8 +496,6 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False,
 
 
 
-
-
 def generate_and_write_ecdsa_keypair(filepath=None, password=None,
     prompt=False):
   """Generates ecdsa key pair and writes custom JSON-formatted keys to disk.
@@ -533,6 +523,7 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None,
     StorageError: Key files cannot be written.
 
   Side Effects:
+    Prompts user for a password if 'prompt' is True.
     Writes key files to disk.
 
   Returns:
@@ -579,7 +570,6 @@ def generate_and_write_ecdsa_keypair(filepath=None, password=None,
 
 
 
-
 def import_ecdsa_publickey_from_file(filepath):
   """Imports custom JSON-formatted ecdsa public key from disk.
 
@@ -606,8 +596,6 @@ def import_ecdsa_publickey_from_file(filepath):
       ecdsa_key_metadata)
 
   return ecdsa_key
-
-
 
 
 
@@ -785,6 +773,7 @@ def import_privatekey_from_file(filepath, key_type=None, password=None,
     raise securesystemslib.exceptions.FormatError(
         "Unsupported key type '{}'. Must be '{}', '{}' or '{}'.".format(
         key_type, KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA))
+
 
 
 if __name__ == '__main__':

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -105,12 +105,18 @@ def get_password(prompt='Password: ', confirm=False):
 
 
 def _get_key_file_encryption_password(password, prompt, path):
-  """Encryption password helper.
+  """Encryption password helper for `_generate_and_write_*_keypair` functions.
 
-  - Fail if 'password' is passed and 'prompt' is True (precedence unclear)
-  - Fail if empty 'password' arg is passed (encryption desire unclear)
-  - Return None on empty pw on prompt (suggests desire to not encrypt)
-
+  Combinations of 'password' and 'prompt' -> result (explanation)
+  ----------------------------------------------------------------
+  None                  False -> return None (clear non-encryption desire)
+  "<non-empty string>"  False -> return password (clear encryption desire)
+  <anything else>       False -> raise (bad pw type, unclear encryption desire)
+  <not None>            True  -> raise (unclear password/prompt precedence)
+  None                  True  -> prompt and return password if entered and None
+                                 otherwise (users on the prompt can only
+                                 indicate desire to not encrypt by entering no
+                                 password)
   """
   securesystemslib.formats.BOOLEAN_SCHEMA.check_match(prompt)
 
@@ -142,10 +148,17 @@ def _get_key_file_encryption_password(password, prompt, path):
 
 
 def _get_key_file_decryption_password(password, prompt, path):
-  """Decryption password helper.
+  """Decryption password helper for `import_*_privatekey_from_file` functions.
 
-  - Fail if 'password' is passed and 'prompt' is True (precedence unclear)
-  - Return None on empty pw on prompt (suggests desire to not decrypt)
+  Combinations of 'password' and 'prompt' -> result (explanation)
+  ----------------------------------------------------------------
+  None             False -> return None (clear non-decryption desire)
+  "<any string>"   False -> return password (clear decryption desire)
+  <anything else>  False -> raise (bad pw type, unclear decryption desire)
+  <not None>       True  -> raise (unclear password/prompt precedence)
+  None             True  -> prompt and return password if entered and None
+                            otherwise (users on the prompt can only indicate
+                            desire to not decrypt by entering no password)
 
   """
   securesystemslib.formats.BOOLEAN_SCHEMA.check_match(prompt)
@@ -179,7 +192,7 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
 
   If a password is passed or entered on the prompt, the private key is
   encrypted. According to the documentation of the used pyca/cryptography
-  library encryption is performed "using the best available encryption for a
+  library, encryption is performed "using the best available encryption for a
   given key's backend", which "is a curated encryption choice and the algorithm
   may change over time."  The private key is written in PKCS#1 and the public
   key in X.509 SubjectPublicKeyInfo format.

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -173,7 +173,7 @@ def _get_key_file_decryption_password(password, prompt, path):
 
 
 
-def generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
+def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     password=None, prompt=False):
   """Generates RSA key pair and writes PEM-encoded keys to disk.
 
@@ -341,7 +341,7 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
 
 
 
-def generate_and_write_ed25519_keypair(filepath=None, password=None,
+def _generate_and_write_ed25519_keypair(filepath=None, password=None,
     prompt=False):
   """Generates ed25519 key pair and writes custom JSON-formatted keys to disk.
 
@@ -496,7 +496,7 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False,
 
 
 
-def generate_and_write_ecdsa_keypair(filepath=None, password=None,
+def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
     prompt=False):
   """Generates ecdsa key pair and writes custom JSON-formatted keys to disk.
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -122,7 +122,7 @@ def _get_key_file_encryption_password(password, prompt, path):
   if prompt:
     password = get_password("enter password to encrypt private key file "
         "'" + TERM_RED + str(path) + TERM_RESET + "' (leave empty if key "
-        "should not be encrypted): '", confirm=True)
+        "should not be encrypted): ", confirm=True)
 
     # Treat empty password as no password. A user on the prompt can only
     # indicate the desire to not encrypt by entering no password.
@@ -158,7 +158,7 @@ def _get_key_file_decryption_password(password, prompt, path):
   if prompt:
     password = get_password("enter password to decrypt private key file "
         "'" + TERM_RED + str(path) + TERM_RESET + "' "
-        "(leave empty if key not encrypted): '", confirm=False)
+        "(leave empty if key not encrypted): ", confirm=False)
 
     # Treat empty password as no password. A user on the prompt can only
     # indicate the desire to not decrypt by entering no password.
@@ -213,8 +213,6 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   """
   securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match(bits)
 
-  password = _get_key_file_encryption_password(password, prompt, filepath)
-
   # Generate private RSA key and extract public and private both in PEM
   rsa_key = securesystemslib.keys.generate_rsa_key(bits)
   public = rsa_key['keyval']['public']
@@ -225,6 +223,8 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     filepath = os.path.join(os.getcwd(), rsa_key['keyid'])
 
   securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+
+  password = _get_key_file_encryption_password(password, prompt, filepath)
 
   # Encrypt the private key if a 'password' was passed or entered on the prompt
   if password is not None:
@@ -478,8 +478,6 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
     The private key filepath.
 
   """
-  password = _get_key_file_encryption_password(password, prompt, filepath)
-
   ed25519_key = securesystemslib.keys.generate_ed25519_key()
 
   # Use passed 'filepath' or keyid as file name
@@ -487,6 +485,8 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
     filepath = os.path.join(os.getcwd(), ed25519_key['keyid'])
 
   securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+
+  password = _get_key_file_encryption_password(password, prompt, filepath)
 
   # Create intermediate directories as required
   securesystemslib.util.ensure_parent_dir(filepath)
@@ -723,8 +723,6 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
     The private key filepath.
 
   """
-  password = _get_key_file_encryption_password(password, prompt, filepath)
-
   ecdsa_key = securesystemslib.keys.generate_ecdsa_key()
 
   # Use passed 'filepath' or keyid as file name
@@ -732,6 +730,8 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
     filepath = os.path.join(os.getcwd(), ecdsa_key['keyid'])
 
   securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+
+  password = _get_key_file_encryption_password(password, prompt, filepath)
 
   # Create intermediate directories as required
   securesystemslib.util.ensure_parent_dir(filepath)

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -247,6 +247,109 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
 
 
 
+def generate_and_write_rsa_keypair(password, filepath=None,
+      bits=DEFAULT_RSA_KEY_BITS):
+  """Generates RSA key pair and writes PEM-encoded keys to disk.
+
+  The private key is encrypted using the best available encryption algorithm
+  chosen by 'pyca/cryptography', which may change over time. The private key is
+  written in PKCS#1 and the public key in X.509 SubjectPublicKeyInfo format.
+
+  NOTE: A signing scheme can be assigned on key import (see import functions).
+
+  Arguments:
+    password: An encryption password.
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+    bits (optional): The number of bits of the generated RSA key.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    ValueError: An empty string is passed as 'password'.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  return _generate_and_write_rsa_keypair(
+      filepath=filepath, bits=bits, password=password, prompt=False)
+
+
+
+def generate_and_write_rsa_keypair_with_prompt(filepath=None,
+      bits=DEFAULT_RSA_KEY_BITS):
+  """Generates RSA key pair and writes PEM-encoded keys to disk.
+
+  The private key is encrypted with a password entered on the prompt, using the
+  best available encryption algorithm chosen by 'pyca/cryptography', which may
+  change over time. The private key is written in PKCS#1 and the public key in
+  X.509 SubjectPublicKeyInfo format.
+
+  NOTE: A signing scheme can be assigned on key import (see import functions).
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+    bits (optional): The number of bits of the generated RSA key.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Prompts user for a password.
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_rsa_keypair(
+      filepath=filepath, bits=bits, password=None, prompt=True)
+
+
+
+def generate_and_write_unencrypted_rsa_keypair(filepath=None,
+      bits=DEFAULT_RSA_KEY_BITS):
+  """Generates RSA key pair and writes PEM-encoded keys to disk.
+
+  The private key is written in PKCS#1 and the public key in X.509
+  SubjectPublicKeyInfo format.
+
+  NOTE: A signing scheme can be assigned on key import (see import functions).
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+    bits (optional): The number of bits of the generated RSA key.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes unencrypted key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_rsa_keypair(
+      filepath=filepath, bits=bits, password=None, prompt=False)
+
+
+
 def import_rsa_privatekey_from_file(filepath, password=None,
     scheme='rsassa-pss-sha256', prompt=False,
     storage_backend=None):
@@ -415,6 +518,96 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
 
 
 
+def generate_and_write_ed25519_keypair(password, filepath=None):
+  """Generates ed25519 key pair and writes custom JSON-formatted keys to disk.
+
+  The private key is encrypted using AES-256 in CTR mode, with the passed
+  password strengthened in PBKDF2-HMAC-SHA256.
+
+  NOTE: The custom key format includes 'ed25519' as signing scheme.
+
+  Arguments:
+    password: An encryption password.
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/pynacl or pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    ValueError: An empty string is passed as 'password'.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  return _generate_and_write_ed25519_keypair(
+      filepath=filepath, password=password, prompt=False)
+
+
+
+def generate_and_write_ed25519_keypair_with_prompt(filepath=None):
+  """Generates ed25519 key pair and writes custom JSON-formatted keys to disk.
+
+  The private key is encrypted using AES-256 in CTR mode, with the password
+  entered on the prompt strengthened in PBKDF2-HMAC-SHA256.
+
+  NOTE: The custom key format includes 'ed25519' as signing scheme.
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/pynacl or pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Prompts user for a password.
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_ed25519_keypair(
+      filepath=filepath, password=None, prompt=True)
+
+
+
+def generate_and_write_unencrypted_ed25519_keypair(filepath=None):
+  """Generates ed25519 key pair and writes custom JSON-formatted keys to disk.
+
+  NOTE: The custom key format includes 'ed25519' as signing scheme.
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/pynacl or pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes unencrypted key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_ed25519_keypair(
+      filepath=filepath, password=None, prompt=False)
+
+
 def import_ed25519_publickey_from_file(filepath):
   """Imports custom JSON-formatted ed25519 public key from disk.
 
@@ -567,6 +760,97 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   securesystemslib.util.persist_temp_file(file_object, filepath)
 
   return filepath
+
+
+
+def generate_and_write_ecdsa_keypair(password, filepath=None):
+  """Generates ecdsa key pair and writes custom JSON-formatted keys to disk.
+
+  The private key is encrypted using AES-256 in CTR mode, with the passed
+  password strengthened in PBKDF2-HMAC-SHA256.
+
+  NOTE: The custom key format includes 'ecdsa-sha2-nistp256' as signing scheme.
+
+  Arguments:
+    password: An encryption password.
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    ValueError: An empty string is passed as 'password'.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  return _generate_and_write_ecdsa_keypair(
+      filepath=filepath, password=password, prompt=False)
+
+
+
+def generate_and_write_ecdsa_keypair_with_prompt(filepath=None):
+  """Generates ecdsa key pair and writes custom JSON-formatted keys to disk.
+
+  The private key is encrypted using AES-256 in CTR mode, with the password
+  entered on the prompt strengthened in PBKDF2-HMAC-SHA256.
+
+  NOTE: The custom key format includes 'ecdsa-sha2-nistp256' as signing scheme.
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Prompts user for a password.
+    Writes key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_ecdsa_keypair(
+      filepath=filepath, password=None, prompt=True)
+
+
+
+def generate_and_write_unencrypted_ecdsa_keypair(filepath=None):
+  """Generates ecdsa key pair and writes custom JSON-formatted keys to disk.
+
+  NOTE: The custom key format includes 'ecdsa-sha2-nistp256' as signing scheme.
+
+  Arguments:
+    filepath (optional): The path to write the private key to. If not passed,
+        the key is written to CWD using the keyid as filename. The public key
+        is written to the same path as the private key using the suffix '.pub'.
+
+  Raises:
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    FormatError: Arguments are malformed.
+    StorageError: Key files cannot be written.
+
+  Side Effects:
+    Writes unencrypted key files to disk.
+
+  Returns:
+    The private key filepath.
+
+  """
+  return _generate_and_write_ecdsa_keypair(
+      filepath=filepath, password=None, prompt=False)
 
 
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -732,6 +732,61 @@ def import_publickeys_from_file(filepaths, key_types=None):
   return key_dict
 
 
+
+def import_privatekey_from_file(filepath, key_type=None, password=None,
+    prompt=False):
+  """Imports private key from file.
+
+  If a password is passed or entered on the prompt, the private key is
+  decrypted, otherwise it is treated as unencrypted.
+
+  NOTE: The default signing scheme 'rsassa-pss-sha256' is assigned to RSA keys.
+  Use 'import_rsa_publickey_from_file' to specify any other than the default
+  signing scheme for an RSA key. ed25519 and ecdsa keys have the signing scheme
+  included in the custom key format (see generate functions).
+
+  Arguments:
+    filepath: The path to read the file from.
+    key_type (optional): One of KEY_TYPE_RSA, KEY_TYPE_ED25519 or
+        KEY_TYPE_ECDSA. Default is KEY_TYPE_RSA.
+    password (optional): A password to decrypt the key.
+    prompt (optional): A boolean indicating if the user should be prompted
+        for a decryption password. If the user enters an empty password, the
+        key is not decrypted.
+
+  Raises:
+    FormatError: Arguments are malformed or 'key_type' is not supported.
+    ValueError: Both a 'password' is passed and 'prompt' is true.
+    UnsupportedLibraryError: pyca/cryptography is not available.
+    StorageError: Key file cannot be read.
+    Error, CryptoError: Key cannot be parsed.
+
+  Returns:
+    A private key object conformant with one of 'ED25519KEY_SCHEMA',
+    'RSAKEY_SCHEMA' or 'ECDSAKEY_SCHEMA'.
+
+  """
+  if key_type is None:
+    key_type = KEY_TYPE_RSA
+
+  if key_type == KEY_TYPE_ED25519:
+    return import_ed25519_privatekey_from_file(
+        filepath, password=password, prompt=prompt)
+
+  elif key_type == KEY_TYPE_RSA:
+    return import_rsa_privatekey_from_file(
+        filepath, password=password, prompt=prompt)
+
+  elif key_type == KEY_TYPE_ECDSA:
+    return import_ecdsa_privatekey_from_file(
+        filepath, password=password, prompt=prompt)
+
+  else:
+    raise securesystemslib.exceptions.FormatError(
+        "Unsupported key type '{}'. Must be '{}', '{}' or '{}'.".format(
+        key_type, KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA))
+
+
 if __name__ == '__main__':
   # The interactive sessions of the documentation strings can
   # be tested by running interface.py as a standalone module:

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -442,7 +442,7 @@ def import_ed25519_publickey_from_file(filepath):
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
   ed25519_key_metadata = securesystemslib.util.load_json_file(filepath)
-  ed25519_key, junk = securesystemslib.keys.format_metadata_to_key(
+  ed25519_key, _ = securesystemslib.keys.format_metadata_to_key(
       ed25519_key_metadata)
 
   # Check that the generic loading functions indeed loaded an ed25519 key
@@ -602,7 +602,7 @@ def import_ecdsa_publickey_from_file(filepath):
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
   ecdsa_key_metadata = securesystemslib.util.load_json_file(filepath)
-  ecdsa_key, junk = securesystemslib.keys.format_metadata_to_key(
+  ecdsa_key, _ = securesystemslib.keys.format_metadata_to_key(
       ecdsa_key_metadata)
 
   return ecdsa_key
@@ -741,7 +741,7 @@ def import_privatekey_from_file(filepath, key_type=None, password=None,
   decrypted, otherwise it is treated as unencrypted.
 
   NOTE: The default signing scheme 'rsassa-pss-sha256' is assigned to RSA keys.
-  Use 'import_rsa_publickey_from_file' to specify any other than the default
+  Use 'import_rsa_privatekey_from_file' to specify any other than the default
   signing scheme for an RSA key. ed25519 and ecdsa keys have the signing scheme
   included in the custom key format (see generate functions).
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -40,6 +40,10 @@ import sys
 import tempfile
 import unittest
 
+if sys.version_info >= (3, 3):
+  import unittest.mock as mock
+else:
+  import mock
 
 import securesystemslib.exceptions
 import securesystemslib.gpg.constants
@@ -68,6 +72,25 @@ class TestPublicInterfaces(unittest.TestCase):
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_rsa_keypair('pw')
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_rsa_keypair('pw')
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      # Mock entry on prompt which is presented before lower-level functions
+      # raise UnsupportedLibraryError
+      with mock.patch("securesystemslib.interface.get_password", return_value=""):
+        securesystemslib.interface.generate_and_write_rsa_keypair_with_prompt()
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_unencrypted_rsa_keypair()
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
       path = os.path.join(self.temp_dir, 'rsa_key')
       with open(path, 'a'):
         securesystemslib.interface.import_rsa_privatekey_from_file(
@@ -77,6 +100,21 @@ class TestPublicInterfaces(unittest.TestCase):
           securesystemslib.exceptions.UnsupportedLibraryError):
       securesystemslib.interface._generate_and_write_ed25519_keypair(
           password='pw')
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_ed25519_keypair('pw')
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      # Mock entry on prompt which is presented before lower-level functions
+      # raise UnsupportedLibraryError
+      with mock.patch("securesystemslib.interface.get_password", return_value=""):
+        securesystemslib.interface.generate_and_write_ed25519_keypair_with_prompt()
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_unencrypted_ed25519_keypair()
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
@@ -93,11 +131,24 @@ class TestPublicInterfaces(unittest.TestCase):
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_ecdsa_keypair('pw')
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      # Mock entry on prompt which is presented before lower-level functions
+      # raise UnsupportedLibraryError
+      with mock.patch("securesystemslib.interface.get_password", return_value=""):
+        securesystemslib.interface.generate_and_write_ecdsa_keypair_with_prompt()
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.interface.generate_and_write_unencrypted_ecdsa_keypair()
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
       path = os.path.join(self.temp_dir, 'ecddsa.priv')
       with open(path, 'a') as f:
         f.write('{}')
-        # TODO: this is the only none generate_and_write_ function
-        # that prompts for a password when password == None
         securesystemslib.interface.import_ecdsa_privatekey_from_file(
             path, password='pw')
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -64,7 +64,7 @@ class TestPublicInterfaces(unittest.TestCase):
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
-      securesystemslib.interface.generate_and_write_rsa_keypair(password='pw')
+      securesystemslib.interface._generate_and_write_rsa_keypair(password='pw')
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
@@ -75,7 +75,7 @@ class TestPublicInterfaces(unittest.TestCase):
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
-      securesystemslib.interface.generate_and_write_ed25519_keypair(
+      securesystemslib.interface._generate_and_write_ed25519_keypair(
           password='pw')
 
     with self.assertRaises(
@@ -88,7 +88,7 @@ class TestPublicInterfaces(unittest.TestCase):
 
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):
-      securesystemslib.interface.generate_and_write_ecdsa_keypair(
+      securesystemslib.interface._generate_and_write_ecdsa_keypair(
           password='pw')
 
     with self.assertRaises(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -60,13 +60,13 @@ from securesystemslib.formats import (
 from securesystemslib.exceptions import Error, FormatError, CryptoError
 
 from securesystemslib.interface import (
-    generate_and_write_rsa_keypair,
+    _generate_and_write_rsa_keypair,
     import_rsa_privatekey_from_file,
     import_rsa_publickey_from_file,
-    generate_and_write_ed25519_keypair,
+    _generate_and_write_ed25519_keypair,
     import_ed25519_publickey_from_file,
     import_ed25519_privatekey_from_file,
-    generate_and_write_ecdsa_keypair,
+    _generate_and_write_ecdsa_keypair,
     import_ecdsa_publickey_from_file,
     import_ecdsa_privatekey_from_file,
     import_publickeys_from_file,
@@ -101,12 +101,12 @@ class TestInterfaceFunctions(unittest.TestCase):
 
 
   def test_rsa(self):
-    """Test RSA key generation and import interface functions. """
+    """Test RSA key _generation and import interface functions. """
 
     # TEST: Generate default keys and import
     # Assert location and format
     fn_default = "default"
-    fn_default_ret = generate_and_write_rsa_keypair(filepath=fn_default)
+    fn_default_ret = _generate_and_write_rsa_keypair(filepath=fn_default)
 
     pub = import_rsa_publickey_from_file(fn_default + ".pub")
     priv = import_rsa_privatekey_from_file(fn_default)
@@ -123,13 +123,13 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Assert importable without password
     fn_empty_prompt = "empty_prompt"
     with mock.patch("securesystemslib.interface.get_password", return_value=""):
-      generate_and_write_rsa_keypair(filepath=fn_empty_prompt, prompt=True)
+      _generate_and_write_rsa_keypair(filepath=fn_empty_prompt, prompt=True)
     import_rsa_privatekey_from_file(fn_empty_prompt)
 
 
     # TEST: Generate keys with auto-filename, i.e. keyid
     # Assert filename is keyid
-    fn_keyid = generate_and_write_rsa_keypair()
+    fn_keyid = _generate_and_write_rsa_keypair()
     pub = import_rsa_publickey_from_file(fn_keyid + ".pub")
     priv = import_rsa_privatekey_from_file(fn_keyid)
     self.assertTrue(
@@ -140,7 +140,7 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Assert length
     bits = 4096
     fn_bits = "bits"
-    generate_and_write_rsa_keypair(filepath=fn_bits, bits=bits)
+    _generate_and_write_rsa_keypair(filepath=fn_bits, bits=bits)
 
     priv = import_rsa_privatekey_from_file(fn_bits)
     # NOTE: Parse PEM with pyca/cryptography to get the key size property
@@ -158,10 +158,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     fn_prompt = "prompt"
 
     # ... a passed pw ...
-    generate_and_write_rsa_keypair(filepath=fn_encrypted, password=pw)
+    _generate_and_write_rsa_keypair(filepath=fn_encrypted, password=pw)
     with mock.patch("securesystemslib.interface.get_password", return_value=pw):
       # ... and a prompted pw.
-      generate_and_write_rsa_keypair(filepath=fn_prompt, prompt=True)
+      _generate_and_write_rsa_keypair(filepath=fn_prompt, prompt=True)
 
       # Assert that both private keys are importable using the prompted pw ...
       import_rsa_privatekey_from_file(fn_prompt, prompt=True)
@@ -194,7 +194,7 @@ class TestInterfaceFunctions(unittest.TestCase):
           "passing 'password' and 'prompt=True' is not allowed")]):
 
       with self.assertRaises(ValueError, msg="(row {})".format(idx)) as ctx:
-        generate_and_write_rsa_keypair(**kwargs)
+        _generate_and_write_rsa_keypair(**kwargs)
 
       self.assertEqual(err_msg, str(ctx.exception),
           "expected: '{}' got: '{}' (row {})".format(
@@ -208,7 +208,7 @@ class TestInterfaceFunctions(unittest.TestCase):
         {"password": 123456}, # Not a string
         {"prompt": "not-a-bool"}]):
       with self.assertRaises(FormatError, msg="(row {})".format(idx)):
-        generate_and_write_rsa_keypair(**kwargs)
+        _generate_and_write_rsa_keypair(**kwargs)
 
 
     # TEST: Import errors
@@ -280,12 +280,12 @@ class TestInterfaceFunctions(unittest.TestCase):
 
 
   def test_ed25519(self):
-    """Test ed25519 key generation and import interface functions. """
+    """Test ed25519 key _generation and import interface functions. """
 
     # TEST: Generate default keys and import
     # Assert location and format
     fn_default = "default"
-    fn_default_ret = generate_and_write_ed25519_keypair(filepath=fn_default)
+    fn_default_ret = _generate_and_write_ed25519_keypair(filepath=fn_default)
 
     pub = import_ed25519_publickey_from_file(fn_default + ".pub")
     priv = import_ed25519_privatekey_from_file(fn_default)
@@ -302,14 +302,14 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Assert importable with empty prompt password and without password
     fn_empty_prompt = "empty_prompt"
     with mock.patch("securesystemslib.interface.get_password", return_value=""):
-      generate_and_write_ed25519_keypair(filepath=fn_empty_prompt)
+      _generate_and_write_ed25519_keypair(filepath=fn_empty_prompt)
       import_ed25519_privatekey_from_file(fn_empty_prompt, prompt=True)
     import_ed25519_privatekey_from_file(fn_empty_prompt)
 
 
     # TEST: Generate keys with auto-filename, i.e. keyid
     # Assert filename is keyid
-    fn_keyid = generate_and_write_ed25519_keypair()
+    fn_keyid = _generate_and_write_ed25519_keypair()
     pub = import_ed25519_publickey_from_file(fn_keyid + ".pub")
     priv = import_ed25519_privatekey_from_file(fn_keyid)
     self.assertTrue(
@@ -321,10 +321,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     fn_encrypted = "encrypted"
     fn_prompt = "prompt"
     # ... a passed pw ...
-    generate_and_write_ed25519_keypair(filepath=fn_encrypted, password=pw)
+    _generate_and_write_ed25519_keypair(filepath=fn_encrypted, password=pw)
     with mock.patch("securesystemslib.interface.get_password", return_value=pw):
       # ... and a prompted pw.
-      generate_and_write_ed25519_keypair(filepath=fn_prompt, prompt=True)
+      _generate_and_write_ed25519_keypair(filepath=fn_prompt, prompt=True)
 
       # Assert that both private keys are importable using the prompted pw ...
       import_ed25519_privatekey_from_file(fn_prompt, prompt=True)
@@ -370,7 +370,7 @@ class TestInterfaceFunctions(unittest.TestCase):
           "passing 'password' and 'prompt=True' is not allowed")]):
 
       with self.assertRaises(ValueError, msg="(row {})".format(idx)) as ctx:
-        generate_and_write_ed25519_keypair(**kwargs)
+        _generate_and_write_ed25519_keypair(**kwargs)
 
       self.assertEqual(err_msg, str(ctx.exception),
           "expected: '{}' got: '{}' (row {})".format(
@@ -382,7 +382,7 @@ class TestInterfaceFunctions(unittest.TestCase):
         {"password": 123456}, # Not a string
         {"prompt": "not-a-bool"}]):
       with self.assertRaises(FormatError, msg="(row {})".format(idx)):
-        generate_and_write_ed25519_keypair(**kwargs)
+        _generate_and_write_ed25519_keypair(**kwargs)
 
 
     # TEST: Import errors
@@ -459,11 +459,11 @@ class TestInterfaceFunctions(unittest.TestCase):
 
 
   def test_ecdsa(self):
-    """Test ecdsa key generation and import interface functions. """
+    """Test ecdsa key _generation and import interface functions. """
     # TEST: Generate default keys and import
     # Assert location and format
     fn_default = "default"
-    fn_default_ret = generate_and_write_ecdsa_keypair(filepath=fn_default)
+    fn_default_ret = _generate_and_write_ecdsa_keypair(filepath=fn_default)
 
     pub = import_ecdsa_publickey_from_file(fn_default + ".pub")
     priv = import_ecdsa_privatekey_from_file(fn_default)
@@ -479,14 +479,14 @@ class TestInterfaceFunctions(unittest.TestCase):
     # Assert importable with empty prompt password and without password
     fn_empty_prompt = "empty_prompt"
     with mock.patch("securesystemslib.interface.get_password", return_value=""):
-      generate_and_write_ecdsa_keypair(filepath=fn_empty_prompt)
+      _generate_and_write_ecdsa_keypair(filepath=fn_empty_prompt)
       import_ecdsa_privatekey_from_file(fn_empty_prompt, prompt=True)
     import_ecdsa_privatekey_from_file(fn_empty_prompt)
 
 
     # TEST: Generate keys with auto-filename, i.e. keyid
     # Assert filename is keyid
-    fn_keyid = generate_and_write_ecdsa_keypair()
+    fn_keyid = _generate_and_write_ecdsa_keypair()
     pub = import_ecdsa_publickey_from_file(fn_keyid + ".pub")
     priv = import_ecdsa_privatekey_from_file(fn_keyid)
     self.assertTrue(
@@ -498,10 +498,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     fn_encrypted = "encrypted"
     fn_prompt = "prompt"
     # ...  a passed pw ...
-    generate_and_write_ecdsa_keypair(filepath=fn_encrypted, password=pw)
+    _generate_and_write_ecdsa_keypair(filepath=fn_encrypted, password=pw)
     with mock.patch("securesystemslib.interface.get_password", return_value=pw):
       # ... and a prompted pw.
-      generate_and_write_ecdsa_keypair(filepath=fn_prompt, prompt=True)
+      _generate_and_write_ecdsa_keypair(filepath=fn_prompt, prompt=True)
 
       # Assert that both private keys are importable using the prompted pw ...
       import_ecdsa_privatekey_from_file(fn_prompt, prompt=True)
@@ -540,7 +540,7 @@ class TestInterfaceFunctions(unittest.TestCase):
           "passing 'password' and 'prompt=True' is not allowed")]):
 
       with self.assertRaises(ValueError, msg="(row {})".format(idx)) as ctx:
-        generate_and_write_ecdsa_keypair(**kwargs)
+        _generate_and_write_ecdsa_keypair(**kwargs)
 
       self.assertEqual(err_msg, str(ctx.exception),
           "expected: '{}' got: '{}' (row {})".format(
@@ -552,7 +552,7 @@ class TestInterfaceFunctions(unittest.TestCase):
         {"password": 123456}, # Not a string
         {"prompt": "not-a-bool"}]):
       with self.assertRaises(FormatError, msg="(row {})".format(idx)):
-        generate_and_write_ecdsa_keypair(**kwargs)
+        _generate_and_write_ecdsa_keypair(**kwargs)
 
 
     # TEST: Import errors

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -218,14 +218,14 @@ class TestInterfaceFunctions(unittest.TestCase):
         ([fn_encrypted], {}, CryptoError,
           "Password was not given but private key is encrypted"),
         # Error on encrypted but empty pw passed
-        ([fn_encrypted], {"password": ""}, ValueError,
-          "Password must be 1 or more character"),
+        ([fn_encrypted], {"password": ""}, CryptoError,
+          "Password was not given but private key is encrypted"),
         # Error on encrypted but bad pw passed
         ([fn_encrypted], {"password": "bad pw"}, CryptoError,
           "Bad decrypt. Incorrect password?"),
         # Error on pw and prompt
         ([fn_default], {"password": pw, "prompt": True}, ValueError,
-          "Passing 'password' and 'prompt' True is not allowed.")]):
+          "passing 'password' and 'prompt=True' is not allowed")]):
 
       with self.assertRaises(err, msg="(row {})".format(idx)) as ctx:
         import_rsa_privatekey_from_file(*args, **kwargs)
@@ -257,6 +257,10 @@ class TestInterfaceFunctions(unittest.TestCase):
     # bad password
     with self.assertRaises(FormatError):
       import_rsa_privatekey_from_file(fn_default, password=123456)
+
+    # bad prompt
+    with self.assertRaises(FormatError):
+      import_rsa_privatekey_from_file(fn_default, prompt="not-a-bool")
 
 
 
@@ -381,15 +385,15 @@ class TestInterfaceFunctions(unittest.TestCase):
         ([fn_encrypted], {}, CryptoError,
           "Malformed Ed25519 key JSON, possibly due to encryption, "
           "but no password provided?"),
-        # Error on encrypted but empty pw passed
-        ([fn_encrypted], {"password": ""}, ValueError,
-          "Password must be 1 or more character"),
+        # Error on encrypted but empty pw
+        ([fn_encrypted], {"password": ""}, CryptoError,
+          "Decryption failed."),
         # Error on encrypted but bad pw passed
         ([fn_encrypted], {"password": "bad pw"}, CryptoError,
           "Decryption failed."),
         # Error on pw and prompt
         ([fn_default], {"password": pw, "prompt": True}, ValueError,
-          "Passing 'password' and 'prompt' True is not allowed.")]):
+          "passing 'password' and 'prompt=True' is not allowed")]):
 
       with self.assertRaises(err, msg="(row {})".format(idx)) as ctx:
         import_ed25519_privatekey_from_file(*args, **kwargs)
@@ -420,6 +424,9 @@ class TestInterfaceFunctions(unittest.TestCase):
     with self.assertRaises(FormatError):
       import_ed25519_privatekey_from_file(fn_default, password=123456)
 
+    # Error on bad prompt format
+    with self.assertRaises(FormatError):
+      import_ed25519_privatekey_from_file(fn_default, prompt="not-a-bool")
 
 
   def test_ecdsa(self):

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands =
 [testenv:purepy27]
 deps =
     -r{toxinidir}/requirements-min.txt
+    -r{toxinidir}/requirements-test.txt
 
 commands =
     python -m tests.check_public_interfaces


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #122
Follows up on: #124 (see for interface discussion) and #148 
Partially fixes in-toto/in-toto#80

### Description of the changes being introduced by the pull request:

- Adds and adopts helper functions to aggregate repetitive code that handles encryption- (in key pair generation), and decryption- (in private key import) passwords, in order to make the behavior consistent for all key types.
- Cleans up the code, comments and docstrings and use Google style formatting for the latter to nicely render on readthedocs. A demo is available at: https://in-toto-lukpueh.readthedocs.io/en/latest/api.html#utilities
- Adds generic private key import interface functions, to import any of the supported private key types from file (rsa, ecdsa, ed25519).
- Changes the behavior of  `generate_and_write_*_keypair` and adds two additional functions (see below).


**Behavior changes**:
- Adds support to optionally not encrypt (on generation) and decrypt (on import) ecdsa private keys to be consistent with rsa and ecdsa key interface functions.
- ~Adds optional `prompt` kwarg to all key generation functions.~
- Adds optional `prompt` kwarg to ecdsa private key import function (rsa and ed25519 already had it).
- Changes handling of `None` or `""` passwords passed to key generation or private key import functions.
  - ~**MOST IMPORTANTLY:** generation function no longer open a prompt if no password is passed as argument, i.e. keys are written to disk **unencrypted by default**. This may be revisited in the future (see https://github.com/secure-systems-lab/securesystemslib/pull/288#discussion_r511420534 for rationale/discussion).~ 
  - `generate_and_write_*_keypair` functions now require a positional `password` argument as **first** argument, which must be a non-empty string. The functions no longer open a prompt or write unencryted passwords. For that two new interface functions are added per key type,  `generate_and_write_*_keypair_with_prompt` and `generate_and_write_unencrypted_*_keypair`. This follows the principles of secure defaults and least surprise.

**Pain points**:
- Rsa functions use standardized PEM, and ed25519 and ecdsa functions use a custom json format for keys on disk, as a consequence the signing scheme for rsa keys must be assigned on import, and for ed25519 and ecdsa keys on generation.
- Ed25519 and ecdsa key generation  functions in the interface don't take a scheme parameter, as a consequence only the the default scheme can be used.
- The newly added generic key import function does not take a scheme parameter and thus only the default signing scheme can be used. This is a deliberate decision in this PR due to the existing scheme assignment inconsistency described above.
- The newly added generic key import function requires a `key_type` parameter to dispatch to the appropriate function. It would be nice if the key type could be assessed based on the on-disk format, but this does not seem feasible given the different formats as described above.
- Minor: The used sphinx napoleon plugin to render docstrings as html does not handle the custom "Side Effects" section well (see demo above and https://github.com/sphinx-contrib/napoleon/issues/2).


**Note to reviewer**
I advise to review commit by commit, or at least to read the commit messages for details





### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


