### PR TITLE
github: Add workflow to check ed25519 upstream

### DIFF
--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -1,0 +1,46 @@
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  check-ed25519-upstream:
+    name: Open an issue if upstream ed25519 has new commits
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Test if ed25519 upstream master HEAD is what we expect
+      id: test_ed25519
+      run: |
+        if sh securesystemslib/_vendor/test-ed25519-upstream.sh; then
+          echo "::set-output name=result::0"
+        else
+          echo "::set-output name=result::1"
+        fi
+    - name: Create issue (unless one is open already)
+      uses: actions/github-script@v3
+      if: ${{ steps.test_ed25519.outputs.result == '1' }}
+      with:
+        script: |
+          console.log("ed25519 upstream master has changed!")
+          const repo = context.repo.owner + "/" + context.repo.repo
+          const issues = await github.search.issuesAndPullRequests({
+            q: "ed25519+upstream+has+new+commits+in:title+state:open+type:issue+repo:" + repo,
+          })
+
+          if (issues.data.total_count > 0) {
+            console.log("Issue is already open, not creating.")
+          } else {
+            console.log("Creating a new issue...")
+            await github.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "ed25519 upstream has new commits",
+              body: "It seems https://github.com/pyca/ed25519.git has new commits. " +
+                    "Please review them, update the vendored copy if needed, and then " +
+                    "update the expected hash in _vendor/test-ed25519-upstream.sh"
+            })
+          }
+

--- a/securesystemslib/_vendor/test-ed25519-upstream.sh
+++ b/securesystemslib/_vendor/test-ed25519-upstream.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Check for new commits in upstream ed25519
+#
+# Return 0 if the upstream ed25519 master branch HEAD matches the
+# commit that our copy was vendored from.
+#
+# This is used in CI workflow to open an issue if new commits are found
+
+set -eu
+
+# This commit matches our securesystemslib/_vendor/ed25519/ content.
+# If upstream changes, we should review the changes, vendor them,
+# and update the hash here
+pyca_ed25519_expected="18d0b5515c8bda6bab0148f1946845bf3027bc4f"
+pyca_ed25519_git_url="https://github.com/pyca/ed25519.git"
+
+pyca_ed25519_master_head=$(git ls-remote "$pyca_ed25519_git_url" master | cut -f1)
+if [ "$pyca_ed25519_master_head" != "$pyca_ed25519_expected" ]; then
+    echo "$pyca_ed25519_git_url master branch has been updated." >&2
+    echo "Expected $pyca_ed25519_expected, found $pyca_ed25519_master_head." >&2
+    exit 1
+fi
+
+echo "No unexpected commits in https://github.com/pyca/ed25519.git"


### PR DESCRIPTION
securesystemslib includes a vendored copy of https://github.com/pyca/ed25519.git . The upstream is not a very lively project by any means but we would like to know if something ever happens there (like a bug fix).

* Add a script that checks if upstream master HEAD is unchanged. The script could be included in the workflow but is separate for two purposes:
  a) specifying the expected hash in git
  b) running the check on developers machine
* Add a github workflow that once a day files an issue if the upstream master head has changed and if an issue is not open yet

The opened issue looks like this https://github.com/jku/securesystemslib/issues/3. I've tested this in my repo but unfortunately I think it won't be possible to test the workflow in securesystemslib repo before the file exists in master branch (after it exists, the workflow can be executed manually even from a branch).