### PR TITLE
Remove invalid escape sequence from docstring

### DIFF
--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -110,11 +110,8 @@ def generate_public_and_private():
   <Purpose>
     Generate a pair of ed25519 public and private keys with PyNaCl.  The public
     and private keys returned conform to
-    'securesystemslib.formats.ED25519PULIC_SCHEMA' and
-    'securesystemslib.formats.ED25519SEED_SCHEMA', respectively, and have the
-    form:
-
-    '\xa2F\x99\xe0\x86\x80%\xc8\xee\x11\xb95T\xd9\...'
+    'securesystemslib.formats.ED25519PUBLIC_SCHEMA' and
+    'securesystemslib.formats.ED25519SEED_SCHEMA', respectively.
 
     An ed25519 seed key is a random 32-byte string.  Public keys are also 32
     bytes.


### PR DESCRIPTION
generate_public_and_private() docstring contains an invalid escape sequence which can lead to an annoying
    `DeprecationWarning: invalid escape sequence`
Remove the whole string as it does not seem very useful.

--- 

The related issue is #290: this fixes half of it. Updating the vendored ed25519 will fix the other instance.
