### PR TITLE
storage: make FilesystemBackend a singleton

### DIFF
--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -188,6 +188,20 @@ class FilesystemBackend(StorageBackendInterface):
     local filesystems using Python standard library functions.
   """
 
+  # As FilesystemBackend is effectively a stateless wrapper around various
+  # standard library operations, we only ever need a single instance of it.
+  # That single instance is safe to be (re-)used by all callers. Therefore
+  # implement the singleton pattern to avoid uneccesarily creating multiple
+  # objects.
+  _instance = None
+
+  def __new__(cls, *args, **kwargs):
+    if cls._instance is None:
+      cls._instance = object.__new__(cls, *args, **kwargs)
+    return cls._instance
+
+
+
   class GetFile(object):
     # Implementing get() as a function with the @contextmanager decorator
     # doesn't allow us to cleanly capture exceptions thrown by the underlying

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -100,3 +100,15 @@ class TestStorage(unittest.TestCase):
         fi.write(leaf.encode('utf-8'))
     found_leaves = self.storage_backend.list_folder(folder)
     self.assertListEqual(leaves, sorted(found_leaves))
+
+
+  def test_singleton(self):
+    # There should only ever be a single instance of FilesystemBackend.
+    # An object's id is unique and constant for the object during its
+    # lifetime. Therefore create more than one instance of FilesystemBackend
+    # and compare their id's
+    fb1 = securesystemslib.storage.FilesystemBackend()
+    fb2 = securesystemslib.storage.FilesystemBackend()
+    self.assertEqual(id(fb1), id(fb2))
+    self.assertEqual(id(self.storage_backend), id(fb1))
+    self.assertEqual(id(fb2), id(self.storage_backend))


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

We only ever need a single instance of FilesystemBackend, therefore implement the singleton pattern to prevent unnecessary object instantiation.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


