### PR TITLE
Update Travis CI build badge after migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Secure Systems Library
 ----------------------
 
-.. image:: https://travis-ci.org/secure-systems-lab/securesystemslib.svg?branch=master
-   :target: https://travis-ci.org/secure-systems-lab/securesystemslib
+.. image:: https://travis-ci.com/secure-systems-lab/securesystemslib.svg?branch=master
+   :target: https://travis-ci.com/secure-systems-lab/securesystemslib
 
 .. image:: https://coveralls.io/repos/github/secure-systems-lab/securesystemslib/badge.svg?branch=master
    :target: https://coveralls.io/github/secure-systems-lab/securesystemslib?branch=master


### PR DESCRIPTION
Update badge URL in readme after migrating from travis-ci.org to travis-ci.com, due to brownout on the former.

Migration was performed via Travis Web UI:
https://docs.travis-ci.com/user/migrate/open-source-repository-migration

NOTE: This is a quick fix to speed up Travis builds until we switch to GitHub Actions (#297)