### PR TITLE
Fix empty list as a default value for function arg

### DIFF
--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -878,7 +878,7 @@ class Struct(Schema):
     False
   """
 
-  def __init__(self, sub_schemas, optional_schemas=[], allow_more=False,
+  def __init__(self, sub_schemas, optional_schemas=None, allow_more=False,
                struct_name='list'):
     """
     <Purpose>
@@ -886,10 +886,13 @@ class Struct(Schema):
 
     <Arguments>
       sub_schemas: The sub-schemas recognized.
-      optional_schemas: The optional list of schemas.
+      optional_schemas: Optional list. If none is given, it will be "[]".
       allow_more: Specifies that an optional list of types is allowed.
       struct_name: A string identifier for the Struct object.
     """
+
+    if optional_schemas is None:
+      optional_schemas = []
 
     # Ensure each item of the list contains the expected object type.
     if not isinstance(sub_schemas, (list, tuple)):


### PR DESCRIPTION
This quote from the Google Python style guide made me realize
why empty list as a default value for an argument could be
dangerous:

"Default arguments are evaluated once at module load time.
This may cause problems if the argument is a mutable object
such as a list or a dictionary. If the function modifies the object
(e.g., by appending an item to a list), the default value is modified."

Read more here:
https://google.github.io/styleguide/pyguide.html#2123-cons

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


