### PR TITLE
Drop support for Python 3.5 and add 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ matrix:
       env: TOXENV=py27-no-gpg
       before_install:
         - sudo apt-get remove -y --allow-remove-essential gnupg gnupg2
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
+    - python: "3.9"
+      env: TOXENV=py39
     - python: "3.8"
       env: TOXENV=purepy38
     - python: "3.8"

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,7 +1,7 @@
 cffi==1.14.4              # via cryptography, pynacl
 colorama==0.4.4
-cryptography==3.2.1
-enum34==1.1.6             ; python_version < "3" # via cryptography
+cryptography==3.3.1
+enum34==1.1.10            ; python_version < "3" # via cryptography
 ipaddress==1.0.23         ; python_version < "3" # via cryptography
 pycparser==2.20           # via cffi
 pynacl==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # 1. Use this script to create a pinned requirements file for each Python
 #    version
 # ```
-# for v in 2.7 3.5 3.6 3.7 3.8; do
+# for v in 2.7 3.6 3.7 3.8 3.9; do
 #   mkvirtualenv sslib-env-${v} -p python${v};
 #   pip install pip-tools;
 #   pip-compile --no-header -o requirements-${v}.txt requirements.txt;

--- a/setup.py
+++ b/setup.py
@@ -91,10 +91,10 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'
@@ -103,6 +103,7 @@ setup(
     'Source': 'https://github.com/secure-systems-lab/securesystemslib',
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
+  python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, purepy27, purepy38
+envlist = py27, py36, py37, py38, py39 purepy27, purepy38
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Fixes: # None

### Description of the changes being introduced by the pull request:

Python 3.5 has now reached its end-of-life and has been retired: https://www.python.org/dev/peps/pep-0478/

The optional (but highly recommended) 'cryptography' dependency has also just dropped support for 3.5. Continuing support for 3.5 does not seem worth the effort.  Instead we add support for the new stable Python 3.9.

This PR also updates the test configuration accordingly and recomputes the pinned dependencies.


Note, securesystemslib's dependent TUF is also dropping 3.5 support (https://github.com/theupdateframework/tuf/pull/1238) and in-toto will follow shortly. 


### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


