### PR TITLE
Allow to provide GPG client through env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -346,12 +346,13 @@ GnuPG interface
 
 Signature creation and public key export requires installation of the `gpg` or
 `gpg2` command line tool, which may be downloaded from
-`https://gnupg.org/download <https://gnupg.org/>`_. It is
-is also needed to generate the supported RSA or DSA signing keys (see `gpg` man
+`https://gnupg.org/download <https://gnupg.org/>`_.
+It is also needed to generate the supported RSA or DSA signing keys (see `gpg` man
 pages for detailed instructions). Sample keys are available in a test keyring
 at `tests/gpg_keyrings/rsa`, which may be passed to the signing and export
 functions using the `homedir` argument (if not passed the default keyring is
-used).
+used). The GPG client to use can be also specified with the help of environment
+variable `GNUPG`.
 
 ::
 
@@ -367,7 +368,7 @@ used).
 
     >>> gpg.verify_signature(signature, public_key, data)
     True
-    
+
 Testing
 ++++++++++++
 

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -36,24 +36,26 @@ def is_available_gnupg(gnupg):
     return False
 
 
-# By default, we allow providing GPG client through the environment
-# assuming gpg2 as default value and test if exists. Otherwise, we assume gpg
-# exists.
-HAVE_GPG = True
+GPG_COMMAND = ""
+HAVE_GPG = False
 
 GPG_ENV_COMMAND = os.environ.get('GNUPG')
 GPG2_COMMAND = "gpg2"
 GPG1_COMMAND = "gpg"
 
-if GPG_ENV_COMMAND and is_available_gnupg(GPG_ENV_COMMAND):
-  GPG_COMMAND = GPG_ENV_COMMAND
+# By default, we allow providing GPG client through the environment
+# assuming gpg2 as default value and test if exists. Otherwise, we assume gpg
+# exists.
+if GPG_ENV_COMMAND:
+  if is_available_gnupg(GPG_ENV_COMMAND):
+    GPG_COMMAND = GPG_ENV_COMMAND
 elif is_available_gnupg(GPG2_COMMAND):
   GPG_COMMAND = GPG2_COMMAND
 elif is_available_gnupg(GPG1_COMMAND):
   GPG_COMMAND = GPG1_COMMAND
-else:
-  GPG_COMMAND = ""
-  HAVE_GPG = False
+
+if GPG_COMMAND:
+  HAVE_GPG = True
 
 GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -55,6 +55,7 @@ elif is_available_gnupg(GPG1_COMMAND):
   GPG_COMMAND = GPG1_COMMAND
 
 if GPG_COMMAND:
+  # Use bool to skip tests or fail early and gracefully if no gpg is available
   HAVE_GPG = True
 
 GPG_VERSION_COMMAND = GPG_COMMAND + " --version"

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -16,6 +16,7 @@
   handling
 """
 import logging
+import os
 
 import securesystemslib.gpg.rsa as rsa
 import securesystemslib.gpg.dsa as dsa
@@ -25,9 +26,10 @@ import securesystemslib.process as process
 
 log = logging.getLogger(__name__)
 
-# By default, we assume and test that gpg2 exists. Otherwise, we assume gpg
+# By default, we allow providing GPG client through the environment
+# assuming gpg2 as default value and test if exists. Otherwise, we assume gpg
 # exists.
-GPG_COMMAND = "gpg2"
+GPG_COMMAND = os.environ.get('GNUPG', "gpg2")
 GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 


### PR DESCRIPTION
When `gpg2` or `gpg` is not used at all but an alternative client/wrapper, it allows to generate `in-toto` metadata with such client. For example, in case of Qubes OS we use `qubes-gpg-client` (see for the reference: https://www.qubes-os.org/doc/split-gpg/)

