### PR TITLE
Vendoring-compatible imports

### DIFF
--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -62,8 +62,8 @@ except ImportError:
   CRYPTO = False
 
 # Perform object format-checking and add ability to handle/raise exceptions.
+from securesystemslib import exceptions
 import securesystemslib.formats
-import securesystemslib.exceptions
 
 _SUPPORTED_ECDSA_SCHEMES = ['ecdsa-sha2-nistp256']
 
@@ -131,7 +131,7 @@ def generate_public_and_private(scheme='ecdsa-sha2-nistp256'):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'scheme' have the correct format?
   # Verify that 'scheme' is of the correct type, and that it's one of the
@@ -153,7 +153,7 @@ def generate_public_and_private(scheme='ecdsa-sha2-nistp256'):
   # The ECDSA_SCHEME_SCHEMA.check_match() above should have detected any
   # invalid 'scheme'.  This is a defensive check.
   else: #pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedAlgorithmError('An unsupported'
+    raise exceptions.UnsupportedAlgorithmError('An unsupported'
       ' scheme specified: ' + repr(scheme) + '.\n  Supported'
       ' algorithms: ' + repr(_SUPPORTED_ECDSA_SCHEMES))
 
@@ -220,7 +220,7 @@ def create_signature(public_key, private_key, data, scheme='ecdsa-sha2-nistp256'
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Do 'public_key' and 'private_key' have the correct format?
   # This check will ensure that the arguments conform to
@@ -246,13 +246,13 @@ def create_signature(public_key, private_key, data, scheme='ecdsa-sha2-nistp256'
       signature = private_key.sign(data, ec.ECDSA(hashes.SHA256()))
 
     except TypeError as e:
-      raise securesystemslib.exceptions.CryptoError('Could not create'
+      raise exceptions.CryptoError('Could not create'
         ' signature: ' + str(e))
 
   # A defensive check for an invalid 'scheme'.  The
   # ECDSA_SCHEME_SCHEMA.check_match() above should have already validated it.
   else: #pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+    raise exceptions.UnsupportedAlgorithmError('Unsupported'
       ' signature scheme is specified: ' + repr(scheme))
 
   return signature, scheme
@@ -311,7 +311,7 @@ def verify_signature(public_key, scheme, signature, data):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Are the arguments properly formatted?
   # If not, raise 'securesystemslib.exceptions.FormatError'.
@@ -323,7 +323,7 @@ def verify_signature(public_key, scheme, signature, data):
       backend=default_backend())
 
   if not isinstance(ecdsa_key, ec.EllipticCurvePublicKey):
-    raise securesystemslib.exceptions.FormatError('Invalid ECDSA public'
+    raise exceptions.FormatError('Invalid ECDSA public'
       ' key: ' + repr(public_key))
 
   else:
@@ -394,7 +394,7 @@ def create_ecdsa_public_and_private_from_pem(pem, password=None):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'pem' have the correct format?
   # This check will ensure 'pem' conforms to
@@ -419,7 +419,7 @@ def create_ecdsa_public_and_private_from_pem(pem, password=None):
       backend=default_backend())
 
   except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as e:
-    raise securesystemslib.exceptions.CryptoError('Could not import private'
+    raise exceptions.CryptoError('Could not import private'
       ' PEM.\n' + str(e))
 
   public = private.public_key()
@@ -481,7 +481,7 @@ def create_ecdsa_encrypted_pem(private_pem, passphrase):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'private_key' have the correct format?
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.

--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -51,7 +51,7 @@ try:
   from cryptography.hazmat.primitives.serialization import load_pem_public_key
   from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
-  import cryptography.exceptions
+  from cryptography.exceptions import (InvalidSignature, UnsupportedAlgorithm)
 
   _SCHEME_HASHER = {
     'ecdsa-sha2-nistp256': ec.ECDSA(hashes.SHA256()),
@@ -335,7 +335,7 @@ def verify_signature(public_key, scheme, signature, data):
     ecdsa_key.verify(signature, data, _SCHEME_HASHER[scheme])
     return True
 
-  except (TypeError, cryptography.exceptions.InvalidSignature):
+  except (TypeError, InvalidSignature):
     return False
 
 
@@ -418,7 +418,7 @@ def create_ecdsa_public_and_private_from_pem(pem, password=None):
     private = load_pem_private_key(pem.encode('utf-8'), password=password,
       backend=default_backend())
 
-  except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as e:
+  except (ValueError, UnsupportedAlgorithm) as e:
     raise exceptions.CryptoError('Could not import private'
       ' PEM.\n' + str(e))
 

--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -63,7 +63,7 @@ except ImportError:
 
 # Perform object format-checking and add ability to handle/raise exceptions.
 from securesystemslib import exceptions
-import securesystemslib.formats
+from securesystemslib import formats
 
 _SUPPORTED_ECDSA_SCHEMES = ['ecdsa-sha2-nistp256']
 
@@ -138,7 +138,7 @@ def generate_public_and_private(scheme='ecdsa-sha2-nistp256'):
   # supported ECDSA .  It must conform to
   # 'securesystemslib.formats.ECDSA_SCHEME_SCHEMA'.  Raise
   # 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   public_key = None
   private_key = None
@@ -226,13 +226,13 @@ def create_signature(public_key, private_key, data, scheme='ecdsa-sha2-nistp256'
   # This check will ensure that the arguments conform to
   # 'securesystemslib.formats.PEMECDSA_SCHEMA'.  Raise
   # 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(public_key)
+  formats.PEMECDSA_SCHEMA.check_match(public_key)
 
   # Is 'private_key' properly formatted?
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(private_key)
+  formats.PEMECDSA_SCHEMA.check_match(private_key)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   # 'ecdsa-sha2-nistp256' is the only currently supported ECDSA scheme, so this
   # if-clause isn't strictly needed.  Nevertheless, the conditional statement
@@ -315,9 +315,9 @@ def verify_signature(public_key, scheme, signature, data):
 
   # Are the arguments properly formatted?
   # If not, raise 'securesystemslib.exceptions.FormatError'.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(public_key)
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
-  securesystemslib.formats.ECDSASIGNATURE_SCHEMA.check_match(signature)
+  formats.PEMECDSA_SCHEMA.check_match(public_key)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSASIGNATURE_SCHEMA.check_match(signature)
 
   ecdsa_key = load_pem_public_key(public_key.encode('utf-8'),
       backend=default_backend())
@@ -399,10 +399,10 @@ def create_ecdsa_public_and_private_from_pem(pem, password=None):
   # Does 'pem' have the correct format?
   # This check will ensure 'pem' conforms to
   # 'securesystemslib.formats.ECDSARSA_SCHEMA'.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(pem)
+  formats.PEMECDSA_SCHEMA.check_match(pem)
 
   if password is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
     password = password.encode('utf-8')
 
   else:
@@ -485,10 +485,10 @@ def create_ecdsa_encrypted_pem(private_pem, passphrase):
 
   # Does 'private_key' have the correct format?
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(private_pem)
+  formats.PEMRSA_SCHEMA.check_match(private_pem)
 
   # Does 'passphrase' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase)
+  formats.PASSWORD_SCHEMA.check_match(passphrase)
 
   private = load_pem_private_key(private_pem.encode('utf-8'), password=None,
     backend=default_backend())

--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -82,8 +82,8 @@ except ImportError:
 # 'securesystemslib.exceptions.UnsupportedLibraryError' exception is raised.
 import securesystemslib._vendor.ed25519.ed25519
 
+from securesystemslib import exceptions
 import securesystemslib.formats
-import securesystemslib.exceptions
 
 # Supported ed25519 signing schemes: 'ed25519'.  The pure Python implementation
 # (i.e., ed25519') and PyNaCl (i.e., 'nacl', libsodium + Python bindings)
@@ -130,7 +130,7 @@ def generate_public_and_private():
   """
 
   if not NACL: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_NACL_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_NACL_MSG)
 
   # Generate ed25519's seed key by calling os.urandom().  The random bytes
   # returned should be suitable for cryptographic use and is OS-specific.
@@ -210,7 +210,7 @@ def create_signature(public_key, private_key, data, scheme):
   """
 
   if not NACL: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_NACL_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_NACL_MSG)
 
   # Does 'public_key' have the correct format?
   # This check will ensure 'public_key' conforms to
@@ -238,13 +238,13 @@ def create_signature(public_key, private_key, data, scheme):
       signature = nacl_sig.signature
 
     except (ValueError, TypeError, nacl.exceptions.CryptoError) as e:
-      raise securesystemslib.exceptions.CryptoError('An "ed25519" signature'
+      raise exceptions.CryptoError('An "ed25519" signature'
           ' could not be created with PyNaCl.' + str(e))
 
   # This is a defensive check for a valid 'scheme', which should have already
   # been validated in the check_match() above.
   else: #pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+    raise exceptions.UnsupportedAlgorithmError('Unsupported'
       ' signature scheme is specified: ' + repr(scheme))
 
   return signature, scheme
@@ -349,7 +349,7 @@ def verify_signature(public_key, scheme, signature, data):
   else: #pragma: no cover
     message = 'Unsupported ed25519 signature scheme: ' + repr(scheme) + '.\n' + \
       'Supported schemes: ' + repr(_SUPPORTED_ED25519_SIGNING_SCHEMES) + '.'
-    raise securesystemslib.exceptions.UnsupportedAlgorithmError(message)
+    raise exceptions.UnsupportedAlgorithmError(message)
 
   return valid_signature
 

--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -83,7 +83,7 @@ except ImportError:
 import securesystemslib._vendor.ed25519.ed25519
 
 from securesystemslib import exceptions
-import securesystemslib.formats
+from securesystemslib import formats
 
 # Supported ed25519 signing schemes: 'ed25519'.  The pure Python implementation
 # (i.e., ed25519') and PyNaCl (i.e., 'nacl', libsodium + Python bindings)
@@ -216,13 +216,13 @@ def create_signature(public_key, private_key, data, scheme):
   # This check will ensure 'public_key' conforms to
   # 'securesystemslib.formats.ED25519PUBLIC_SCHEMA', which must have length 32
   # bytes.  Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ED25519PUBLIC_SCHEMA.check_match(public_key)
+  formats.ED25519PUBLIC_SCHEMA.check_match(public_key)
 
   # Is 'private_key' properly formatted?
-  securesystemslib.formats.ED25519SEED_SCHEMA.check_match(private_key)
+  formats.ED25519SEED_SCHEMA.check_match(private_key)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ED25519_SIG_SCHEMA.check_match(scheme)
+  formats.ED25519_SIG_SCHEMA.check_match(scheme)
 
   # Signing the 'data' object requires a seed and public key.
   # nacl.signing.SigningKey.sign() generates the signature.
@@ -309,13 +309,13 @@ def verify_signature(public_key, scheme, signature, data):
   # This check will ensure 'public_key' conforms to
   # 'securesystemslib.formats.ED25519PUBLIC_SCHEMA', which must have length 32
   # bytes.  Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ED25519PUBLIC_SCHEMA.check_match(public_key)
+  formats.ED25519PUBLIC_SCHEMA.check_match(public_key)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ED25519_SIG_SCHEMA.check_match(scheme)
+  formats.ED25519_SIG_SCHEMA.check_match(scheme)
 
   # Is 'signature' properly formatted?
-  securesystemslib.formats.ED25519SIGNATURE_SCHEMA.check_match(signature)
+  formats.ED25519SIGNATURE_SCHEMA.check_match(signature)
 
   # Verify 'signature'.  Before returning the Boolean result, ensure 'ed25519'
   # was used as the signature scheme.

--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -80,7 +80,7 @@ except ImportError:
 # The optimized pure Python implementation of Ed25519.  If
 # PyNaCl cannot be imported and an attempt to use is made in this module, a
 # 'securesystemslib.exceptions.UnsupportedLibraryError' exception is raised.
-import securesystemslib._vendor.ed25519.ed25519
+from securesystemslib._vendor.ed25519 import ed25519 as python_ed25519
 
 from securesystemslib import exceptions
 from securesystemslib import formats
@@ -335,8 +335,7 @@ def verify_signature(public_key, scheme, signature, data):
     # Verify 'ed25519' signature with the pure Python implementation.
     else:
       try:
-        securesystemslib._vendor.ed25519.ed25519.checkvalid(signature,
-            data, public)
+        python_ed25519.checkvalid(signature, data, public)
         valid_signature = True
 
       # The pure Python implementation raises 'Exception' if 'signature' is

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -78,8 +78,8 @@ import datetime
 import time
 import six
 
+from securesystemslib import exceptions
 import securesystemslib.schema as SCHEMA
-import securesystemslib.exceptions
 
 # Note that in the schema definitions below, the 'SCHEMA.Object' types allow
 # additional keys which are not defined. Thus, any additions to them will be
@@ -476,7 +476,7 @@ def datetime_to_unix_timestamp(datetime_object):
   # Raise 'securesystemslib.exceptions.FormatError' if not.
   if not isinstance(datetime_object, datetime.datetime):
     message = repr(datetime_object) + ' is not a datetime.datetime() object.'
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   unix_timestamp = calendar.timegm(datetime_object.timetuple())
 
@@ -554,7 +554,7 @@ def format_base64(data):
     return binascii.b2a_base64(data).decode('utf-8').rstrip('=\n ')
 
   except (TypeError, binascii.Error) as e:
-    raise securesystemslib.exceptions.FormatError('Invalid base64'
+    raise exceptions.FormatError('Invalid base64'
       ' encoding: ' + str(e))
 
 
@@ -583,7 +583,7 @@ def parse_base64(base64_string):
 
   if not isinstance(base64_string, six.string_types):
     message = 'Invalid argument: '+repr(base64_string)
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   extra = len(base64_string) % 4
   if extra:
@@ -594,7 +594,7 @@ def parse_base64(base64_string):
     return binascii.a2b_base64(base64_string.encode('utf-8'))
 
   except (TypeError, binascii.Error) as e:
-    raise securesystemslib.exceptions.FormatError('Invalid base64'
+    raise exceptions.FormatError('Invalid base64'
       ' encoding: ' + str(e))
 
 
@@ -661,7 +661,7 @@ def _encode_canonical(object, output_function):
       _encode_canonical(value, output_function)
     output_function("}")
   else:
-    raise securesystemslib.exceptions.FormatError('I cannot encode '+repr(object))
+    raise exceptions.FormatError('I cannot encode '+repr(object))
 
 
 def encode_canonical(object, output_function=None):
@@ -724,9 +724,9 @@ def encode_canonical(object, output_function=None):
   try:
     _encode_canonical(object, output_function)
 
-  except (TypeError, securesystemslib.exceptions.FormatError) as e:
+  except (TypeError, exceptions.FormatError) as e:
     message = 'Could not encode ' + repr(object) + ': ' + str(e)
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   # Return the encoded 'object' as a string.
   # Note: Implies 'output_function' is None,

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -79,7 +79,7 @@ import time
 import six
 
 from securesystemslib import exceptions
-import securesystemslib.schema as SCHEMA
+from securesystemslib import schema as SCHEMA
 
 # Note that in the schema definitions below, the 'SCHEMA.Object' types allow
 # additional keys which are not defined. Thus, any additions to them will be

--- a/securesystemslib/gpg/common.py
+++ b/securesystemslib/gpg/common.py
@@ -22,7 +22,7 @@ import binascii
 import logging
 import collections
 
-import securesystemslib.gpg.util
+from securesystemslib.gpg import util as gpg_util
 from securesystemslib.gpg.exceptions import (PacketVersionNotSupportedError,
     SignatureAlgorithmNotSupportedError, KeyNotFoundError, PacketParsingError)
 
@@ -117,7 +117,7 @@ def parse_pubkey_payload(data):
   keyinfo['type'] = SUPPORTED_SIGNATURE_ALGORITHMS[algorithm]['type']
   keyinfo['method'] = SUPPORTED_SIGNATURE_ALGORITHMS[algorithm]['method']
   handler = SIGNATURE_HANDLERS[keyinfo['type']]
-  keyinfo['keyid'] = securesystemslib.gpg.util.compute_keyid(data)
+  keyinfo['keyid'] = gpg_util.compute_keyid(data)
   key_params = handler.get_pubkey_params(data[ptr:])
 
   return {
@@ -182,7 +182,7 @@ def parse_pubkey_bundle(data):
   while position < len(data):
     try:
       packet_type, header_len, body_len, packet_length = \
-          securesystemslib.gpg.util.parse_packet_header(data[position:])
+          gpg_util.parse_packet_header(data[position:])
 
       packet = data[position:position+packet_length]
       payload = packet[header_len:]
@@ -617,7 +617,7 @@ def parse_signature_packet(data, supported_signature_types=None,
   if not supported_hash_algorithms:
     supported_hash_algorithms = {SHA256}
 
-  _, header_len, _, packet_len = securesystemslib.gpg.util.parse_packet_header(
+  _, header_len, _, packet_len = gpg_util.parse_packet_header(
       data, PACKET_TYPE_SIGNATURE)
 
   data = bytearray(data[header_len:packet_len])
@@ -668,8 +668,7 @@ def parse_signature_packet(data, supported_signature_types=None,
   hashed_octet_count = struct.unpack(">H", data[ptr:ptr+2])[0]
   ptr += 2
   hashed_subpackets = data[ptr:ptr+hashed_octet_count]
-  hashed_subpacket_info = securesystemslib.gpg.util.parse_subpackets(
-      hashed_subpackets)
+  hashed_subpacket_info = gpg_util.parse_subpackets(hashed_subpackets)
 
   # Check whether we were actually able to read this much hashed octets
   if len(hashed_subpackets) != hashed_octet_count: # pragma: no cover
@@ -683,8 +682,7 @@ def parse_signature_packet(data, supported_signature_types=None,
   ptr += 2
 
   unhashed_subpackets = data[ptr:ptr+unhashed_octet_count]
-  unhashed_subpacket_info = securesystemslib.gpg.util.parse_subpackets(
-      unhashed_subpackets)
+  unhashed_subpacket_info = gpg_util.parse_subpackets(unhashed_subpackets)
 
   ptr += unhashed_octet_count
 

--- a/securesystemslib/gpg/common.py
+++ b/securesystemslib/gpg/common.py
@@ -22,21 +22,21 @@ import binascii
 import logging
 import collections
 
+from securesystemslib import formats
 from securesystemslib.gpg import util as gpg_util
 from securesystemslib.gpg.exceptions import (PacketVersionNotSupportedError,
     SignatureAlgorithmNotSupportedError, KeyNotFoundError, PacketParsingError)
-
 from securesystemslib.gpg.constants import (
     PACKET_TYPE_PRIMARY_KEY, PACKET_TYPE_USER_ID, PACKET_TYPE_USER_ATTR,
     PACKET_TYPE_SUB_KEY, PACKET_TYPE_SIGNATURE,
     SUPPORTED_PUBKEY_PACKET_VERSIONS, SIGNATURE_TYPE_BINARY,
     SIGNATURE_TYPE_CERTIFICATES, SIGNATURE_TYPE_SUB_KEY_BINDING,
-    SUPPORTED_SIGNATURE_PACKET_VERSIONS, SUPPORTED_SIGNATURE_ALGORITHMS,
-    SIGNATURE_HANDLERS, FULL_KEYID_SUBPACKET, PARTIAL_KEYID_SUBPACKET,
+    SUPPORTED_SIGNATURE_PACKET_VERSIONS,
+    FULL_KEYID_SUBPACKET, PARTIAL_KEYID_SUBPACKET,
     SHA1,SHA256, SHA512, KEY_EXPIRATION_SUBPACKET, PRIMARY_USERID_SUBPACKET,
     SIG_CREATION_SUBPACKET)
-
-from securesystemslib import formats
+from securesystemslib.gpg.handlers import (
+    SIGNATURE_HANDLERS, SUPPORTED_SIGNATURE_ALGORITHMS)
 
 log = logging.getLogger(__name__)
 

--- a/securesystemslib/gpg/common.py
+++ b/securesystemslib/gpg/common.py
@@ -36,7 +36,7 @@ from securesystemslib.gpg.constants import (
     SHA1,SHA256, SHA512, KEY_EXPIRATION_SUBPACKET, PRIMARY_USERID_SUBPACKET,
     SIG_CREATION_SUBPACKET)
 
-import securesystemslib.formats
+from securesystemslib import formats
 
 log = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ def parse_pubkey_payload(data):
   return {
     "method": keyinfo['method'],
     "type": keyinfo['type'],
-    "hashes": [securesystemslib.formats.GPG_HASH_ALGORITHM_STRING],
+    "hashes": [formats.GPG_HASH_ALGORITHM_STRING],
     "creation_time": time_of_creation[0],
     "keyid": keyinfo['keyid'],
     "keyval" : {
@@ -527,7 +527,7 @@ def get_pubkey_bundle(data, keyid):
     optional subkeys.
 
   """
-  securesystemslib.formats.KEYID_SCHEMA.check_match(keyid)
+  formats.KEYID_SCHEMA.check_match(keyid)
   if not data:
     raise KeyNotFoundError("Could not find gpg key '{}' in empty exported key "
         "data.".format(keyid))

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -18,11 +18,10 @@
 import logging
 import os
 
+from securesystemslib import process
 import securesystemslib.gpg.rsa as rsa
 import securesystemslib.gpg.dsa as dsa
 import securesystemslib.gpg.eddsa as eddsa
-
-import securesystemslib.process as process
 
 log = logging.getLogger(__name__)
 

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -19,9 +19,9 @@ import logging
 import os
 
 from securesystemslib import process
-import securesystemslib.gpg.rsa as rsa
-import securesystemslib.gpg.dsa as dsa
-import securesystemslib.gpg.eddsa as eddsa
+from securesystemslib.gpg import rsa
+from securesystemslib.gpg import dsa
+from securesystemslib.gpg import eddsa
 
 log = logging.getLogger(__name__)
 

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -19,9 +19,6 @@ import logging
 import os
 
 from securesystemslib import process
-from securesystemslib.gpg import rsa
-from securesystemslib.gpg import dsa
-from securesystemslib.gpg import eddsa
 
 log = logging.getLogger(__name__)
 
@@ -80,31 +77,6 @@ PACKET_TYPE_SUB_KEY = 0x0E
 # See sections 5.2.3 (signature) and 5.5.2 (public key) of RFC4880
 SUPPORTED_SIGNATURE_PACKET_VERSIONS = {0x04}
 SUPPORTED_PUBKEY_PACKET_VERSIONS = {0x04}
-
-# See section 9.1. (public-key algorithms) of RFC4880 (-bis8)
-SUPPORTED_SIGNATURE_ALGORITHMS = {
-    0x01: {
-      "type":"rsa",
-      "method": "pgp+rsa-pkcsv1.5",
-      "handler": rsa
-    },
-    0x11: {
-      "type": "dsa",
-      "method": "pgp+dsa-fips-180-2",
-      "handler": dsa
-    },
-    0x16: {
-      "type": "eddsa",
-      "method": "pgp+eddsa-ed25519",
-      "handler": eddsa
-    }
-}
-
-SIGNATURE_HANDLERS = {
-    "rsa": rsa,
-    "dsa": dsa,
-    "eddsa": eddsa
-}
 
 # The constants for hash algorithms are taken from section 9.4 of RFC4880.
 SHA1 = 0x02

--- a/securesystemslib/gpg/dsa.py
+++ b/securesystemslib/gpg/dsa.py
@@ -27,9 +27,9 @@ except ImportError:
   CRYPTO = False
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.gpg.util
 import securesystemslib.gpg.exceptions
-import securesystemslib.formats
 
 
 def create_pubkey(pubkey_info):
@@ -58,7 +58,7 @@ def create_pubkey(pubkey_info):
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   y = int(pubkey_info['keyval']['public']['y'], 16)
   g = int(pubkey_info['keyval']['public']['g'], 16)
@@ -230,8 +230,8 @@ def verify_signature(signature_object, pubkey_info, content,
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
-  securesystemslib.formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
+  formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
 

--- a/securesystemslib/gpg/dsa.py
+++ b/securesystemslib/gpg/dsa.py
@@ -26,9 +26,9 @@ try:
 except ImportError:
   CRYPTO = False
 
+from securesystemslib import exceptions
 import securesystemslib.gpg.util
 import securesystemslib.gpg.exceptions
-import securesystemslib.exceptions
 import securesystemslib.formats
 
 
@@ -56,7 +56,7 @@ def create_pubkey(pubkey_info):
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
@@ -160,7 +160,7 @@ def get_signature_params(data):
     The decoded signature buffer
   """
   if not CRYPTO: # pragma: no cover
-    return securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    return exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   ptr = 0
   r_length = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr+2])
@@ -228,7 +228,7 @@ def verify_signature(signature_object, pubkey_info, content,
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   securesystemslib.formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)

--- a/securesystemslib/gpg/dsa.py
+++ b/securesystemslib/gpg/dsa.py
@@ -28,8 +28,8 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import formats
+from securesystemslib.gpg.exceptions import PacketParsingError
 from securesystemslib.gpg import util as gpg_util
-import securesystemslib.gpg.exceptions
 
 
 def create_pubkey(pubkey_info):
@@ -99,32 +99,28 @@ def get_pubkey_params(data):
   ptr += 2
   prime_p = data[ptr:ptr + prime_p_length]
   if len(prime_p) != prime_p_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This MPI was truncated!")
+    raise PacketParsingError("This MPI was truncated!")
   ptr += prime_p_length
 
   group_order_q_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   group_order_q = data[ptr:ptr + group_order_q_length]
   if len(group_order_q) != group_order_q_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This MPI has been truncated!")
+    raise PacketParsingError("This MPI has been truncated!")
   ptr += group_order_q_length
 
   generator_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   generator = data[ptr:ptr + generator_length]
   if len(generator) != generator_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This MPI has been truncated!")
+    raise PacketParsingError("This MPI has been truncated!")
   ptr += generator_length
 
   value_y_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   value_y = data[ptr:ptr + value_y_length]
   if len(value_y) != value_y_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This MPI has been truncated!")
+    raise PacketParsingError("This MPI has been truncated!")
 
   return {
     "y": binascii.hexlify(value_y).decode('ascii'),
@@ -165,16 +161,14 @@ def get_signature_params(data):
   ptr += 2
   r = data[ptr:ptr + r_length]
   if len(r) != r_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "r-value truncated in signature")
+    raise PacketParsingError("r-value truncated in signature")
   ptr += r_length
 
   s_length = gpg_util.get_mpi_length(data[ptr: ptr+2])
   ptr += 2
   s = data[ptr: ptr + s_length]
   if len(s) != s_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "s-value truncated in signature")
+    raise PacketParsingError("s-value truncated in signature")
 
   s = int(binascii.hexlify(s), 16)
   r = int(binascii.hexlify(r), 16)

--- a/securesystemslib/gpg/dsa.py
+++ b/securesystemslib/gpg/dsa.py
@@ -19,10 +19,10 @@ import binascii
 CRYPTO = True
 NO_CRYPTO_MSG = 'DSA key support for GPG requires the cryptography library'
 try:
-  import cryptography.hazmat.primitives.asymmetric.dsa as dsa
-  import cryptography.hazmat.backends as backends
-  import cryptography.hazmat.primitives.asymmetric.utils as dsautils
-  import cryptography.exceptions
+  from cryptography.exceptions import InvalidSignature
+  from cryptography.hazmat import backends
+  from cryptography.hazmat.primitives.asymmetric import dsa
+  from cryptography.hazmat.primitives.asymmetric import utils as dsautils
 except ImportError:
   CRYPTO = False
 
@@ -240,5 +240,5 @@ def verify_signature(signature_object, pubkey_info, content,
       dsautils.Prehashed(hasher())
     )
     return True
-  except cryptography.exceptions.InvalidSignature:
+  except InvalidSignature:
     return False

--- a/securesystemslib/gpg/dsa.py
+++ b/securesystemslib/gpg/dsa.py
@@ -28,7 +28,7 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.gpg.util
+from securesystemslib.gpg import util as gpg_util
 import securesystemslib.gpg.exceptions
 
 
@@ -95,7 +95,7 @@ def get_pubkey_params(data):
   """
   ptr = 0
 
-  prime_p_length = securesystemslib.gpg.util.get_mpi_length(data[ptr: ptr + 2])
+  prime_p_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   prime_p = data[ptr:ptr + prime_p_length]
   if len(prime_p) != prime_p_length: # pragma: no cover
@@ -103,8 +103,7 @@ def get_pubkey_params(data):
         "This MPI was truncated!")
   ptr += prime_p_length
 
-  group_order_q_length = securesystemslib.gpg.util.get_mpi_length(
-      data[ptr: ptr + 2])
+  group_order_q_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   group_order_q = data[ptr:ptr + group_order_q_length]
   if len(group_order_q) != group_order_q_length: # pragma: no cover
@@ -112,8 +111,7 @@ def get_pubkey_params(data):
         "This MPI has been truncated!")
   ptr += group_order_q_length
 
-  generator_length = securesystemslib.gpg.util.get_mpi_length(
-      data[ptr: ptr + 2])
+  generator_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   generator = data[ptr:ptr + generator_length]
   if len(generator) != generator_length: # pragma: no cover
@@ -121,7 +119,7 @@ def get_pubkey_params(data):
         "This MPI has been truncated!")
   ptr += generator_length
 
-  value_y_length = securesystemslib.gpg.util.get_mpi_length(data[ptr: ptr + 2])
+  value_y_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   value_y = data[ptr:ptr + value_y_length]
   if len(value_y) != value_y_length: # pragma: no cover
@@ -163,7 +161,7 @@ def get_signature_params(data):
     return exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   ptr = 0
-  r_length = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr+2])
+  r_length = gpg_util.get_mpi_length(data[ptr:ptr+2])
   ptr += 2
   r = data[ptr:ptr + r_length]
   if len(r) != r_length: # pragma: no cover
@@ -171,7 +169,7 @@ def get_signature_params(data):
         "r-value truncated in signature")
   ptr += r_length
 
-  s_length = securesystemslib.gpg.util.get_mpi_length(data[ptr: ptr+2])
+  s_length = gpg_util.get_mpi_length(data[ptr: ptr+2])
   ptr += 2
   s = data[ptr: ptr + s_length]
   if len(s) != s_length: # pragma: no cover
@@ -233,11 +231,11 @@ def verify_signature(signature_object, pubkey_info, content,
   formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   formats.GPG_DSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
-  hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
+  hasher = gpg_util.get_hashing_class(hash_algorithm_id)
 
   pubkey_object = create_pubkey(pubkey_info)
 
-  digest = securesystemslib.gpg.util.hash_object(
+  digest = gpg_util.hash_object(
       binascii.unhexlify(signature_object['other_headers']),
       hasher(), content)
 

--- a/securesystemslib/gpg/eddsa.py
+++ b/securesystemslib/gpg/eddsa.py
@@ -21,6 +21,7 @@ import binascii
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib.gpg import util as gpg_util
+from securesystemslib.gpg.exceptions import PacketParsingError
 
 CRYPTO = True
 NO_CRYPTO_MSG = 'EdDSA key support for GPG requires the cryptography library'
@@ -75,7 +76,7 @@ def get_pubkey_params(data):
 
   # See 9.2. ECC Curve OID
   if curve_oid != ED25519_PUBLIC_KEY_OID:
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
+    raise PacketParsingError(
         "bad ed25519 curve OID '{}', expected {}'".format(
         curve_oid, ED25519_PUBLIC_KEY_OID))
 
@@ -84,7 +85,7 @@ def get_pubkey_params(data):
   ptr += 2
 
   if public_key_len != ED25519_PUBLIC_KEY_LENGTH:
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
+    raise PacketParsingError(
         "bad ed25519 MPI length '{}', expected {}'".format(
         public_key_len, ED25519_PUBLIC_KEY_LENGTH))
 
@@ -92,7 +93,7 @@ def get_pubkey_params(data):
   ptr += 1
 
   if public_key_prefix != ED25519_PUBLIC_KEY_PREFIX:
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
+    raise PacketParsingError(
         "bad ed25519 MPI prefix '{}', expected '{}'".format(
         public_key_prefix, ED25519_PUBLIC_KEY_PREFIX))
 

--- a/securesystemslib/gpg/eddsa.py
+++ b/securesystemslib/gpg/eddsa.py
@@ -19,6 +19,7 @@
 import binascii
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.gpg.util
 
 CRYPTO = True
@@ -168,7 +169,7 @@ def create_pubkey(pubkey_info):
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   public_bytes = binascii.unhexlify(pubkey_info["keyval"]["public"]["q"])
   public_key = pyca_ed25519.Ed25519PublicKey.from_public_bytes(public_bytes)
@@ -221,8 +222,8 @@ def verify_signature(signature_object, pubkey_info, content,
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
-  securesystemslib.formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
+  formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
 

--- a/securesystemslib/gpg/eddsa.py
+++ b/securesystemslib/gpg/eddsa.py
@@ -20,7 +20,7 @@ import binascii
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.gpg.util
+from securesystemslib.gpg import util as gpg_util
 
 CRYPTO = True
 NO_CRYPTO_MSG = 'EdDSA key support for GPG requires the cryptography library'
@@ -80,7 +80,7 @@ def get_pubkey_params(data):
         curve_oid, ED25519_PUBLIC_KEY_OID))
 
   # See 13.3. EdDSA Point Format
-  public_key_len = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr + 2])
+  public_key_len = gpg_util.get_mpi_length(data[ptr:ptr + 2])
   ptr += 2
 
   if public_key_len != ED25519_PUBLIC_KEY_LENGTH:
@@ -129,13 +129,13 @@ def get_signature_params(data):
 
   """
   ptr = 0
-  r_length = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr + 2])
+  r_length = gpg_util.get_mpi_length(data[ptr:ptr + 2])
 
   ptr += 2
   r = data[ptr:ptr + r_length]
   ptr += r_length
 
-  s_length = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr + 2])
+  s_length = gpg_util.get_mpi_length(data[ptr:ptr + 2])
   ptr += 2
   s = data[ptr:ptr + s_length]
 
@@ -225,12 +225,12 @@ def verify_signature(signature_object, pubkey_info, content,
   formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
 
-  hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
+  hasher = gpg_util.get_hashing_class(hash_algorithm_id)
 
   pubkey_object = create_pubkey(pubkey_info)
 
   # See RFC4880-bis8 14.8. EdDSA and 5.2.4 "Computing Signatures"
-  digest = securesystemslib.gpg.util.hash_object(
+  digest = gpg_util.hash_object(
       binascii.unhexlify(signature_object["other_headers"]),
       hasher(), content)
 

--- a/securesystemslib/gpg/eddsa.py
+++ b/securesystemslib/gpg/eddsa.py
@@ -26,8 +26,8 @@ from securesystemslib.gpg.exceptions import PacketParsingError
 CRYPTO = True
 NO_CRYPTO_MSG = 'EdDSA key support for GPG requires the cryptography library'
 try:
-  import cryptography.hazmat.primitives.asymmetric.ed25519 as pyca_ed25519
-  import cryptography.exceptions
+  from cryptography.hazmat.primitives.asymmetric import ed25519 as pyca_ed25519
+  from cryptography.exceptions import InvalidSignature
 except ImportError:
   CRYPTO = False
 
@@ -242,5 +242,5 @@ def verify_signature(signature_object, pubkey_info, content,
     )
     return True
 
-  except cryptography.exceptions.InvalidSignature:
+  except InvalidSignature:
     return False

--- a/securesystemslib/gpg/eddsa.py
+++ b/securesystemslib/gpg/eddsa.py
@@ -17,7 +17,8 @@
 
 """
 import binascii
-import securesystemslib.exceptions
+
+from securesystemslib import exceptions
 import securesystemslib.gpg.util
 
 CRYPTO = True
@@ -165,7 +166,7 @@ def create_pubkey(pubkey_info):
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)
 
@@ -218,7 +219,7 @@ def verify_signature(signature_object, pubkey_info, content,
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   securesystemslib.formats.GPG_ED25519_PUBKEY_SCHEMA.check_match(pubkey_info)

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -21,7 +21,8 @@ import time
 from securesystemslib import exceptions
 from securesystemslib import formats
 import securesystemslib.gpg.common
-import securesystemslib.gpg.exceptions
+from securesystemslib.gpg.exceptions import (
+    CommandError, KeyExpirationError)
 from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
     SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION, SHA256,
     HAVE_GPG, NO_GPG_MSG)
@@ -115,7 +116,7 @@ def create_signature(content, keyid=None, homedir=None):
   # reporting, as there is no clear distinction between the return codes
   # https://lists.gnupg.org/pipermail/gnupg-devel/2005-December/022559.html
   if gpg_process.returncode != 0:
-    raise securesystemslib.gpg.exceptions.CommandError("Command '{}' returned "
+    raise CommandError("Command '{}' returned "
         "non-zero exit status '{}', stderr was:\n{}.".format(gpg_process.args,
         gpg_process.returncode, gpg_process.stderr.decode()))
 
@@ -224,7 +225,7 @@ def verify_signature(signature_object, pubkey_info, content):
 
   if creation_time and validity_period and \
       creation_time + validity_period < time.time():
-    raise securesystemslib.gpg.exceptions.KeyExpirationError(verification_key)
+    raise KeyExpirationError(verification_key)
 
   return handler.verify_signature(
       signature_object, verification_key, content, SHA256)

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -23,9 +23,14 @@ from securesystemslib import formats
 import securesystemslib.gpg.common
 from securesystemslib.gpg.exceptions import (
     CommandError, KeyExpirationError)
-from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
-    SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION, SHA256,
-    HAVE_GPG, NO_GPG_MSG)
+from securesystemslib.gpg.constants import (
+    FULLY_SUPPORTED_MIN_VERSION,
+    GPG_EXPORT_PUBKEY_COMMAND,
+    GPG_SIGN_COMMAND,
+    HAVE_GPG,
+    NO_GPG_MSG,
+    SHA256,
+    SIGNATURE_HANDLERS)
 
 from securesystemslib import process
 from securesystemslib.gpg.rsa import CRYPTO
@@ -270,8 +275,7 @@ def export_pubkey(keyid, homedir=None):
 
   # TODO: Consider adopting command error handling from `create_signature`
   # above, e.g. in a common 'run gpg command' utility function
-  command = securesystemslib.gpg.constants.GPG_EXPORT_PUBKEY_COMMAND.format(
-      keyid=keyid, homearg=homearg)
+  command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
   gpg_process = process.run(command, stdout=process.PIPE, stderr=process.PIPE)
 
   key_packet = gpg_process.stdout

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -26,7 +26,7 @@ from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
     SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION, SHA256,
     HAVE_GPG, NO_GPG_MSG)
 
-import securesystemslib.process
+from securesystemslib import process
 from securesystemslib.gpg.rsa import CRYPTO
 
 log = logging.getLogger(__name__)
@@ -108,9 +108,8 @@ def create_signature(content, keyid=None, homedir=None):
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
 
-  gpg_process = securesystemslib.process.run(command, input=content, check=False,
-      stdout=securesystemslib.process.PIPE,
-      stderr=securesystemslib.process.PIPE)
+  gpg_process = process.run(command, input=content, check=False,
+      stdout=process.PIPE, stderr=process.PIPE)
 
   # TODO: It's suggested to take a look at `--status-fd` for proper error
   # reporting, as there is no clear distinction between the return codes
@@ -272,9 +271,7 @@ def export_pubkey(keyid, homedir=None):
   # above, e.g. in a common 'run gpg command' utility function
   command = securesystemslib.gpg.constants.GPG_EXPORT_PUBKEY_COMMAND.format(
       keyid=keyid, homearg=homearg)
-  gpg_process = securesystemslib.process.run(command,
-      stdout=securesystemslib.process.PIPE,
-      stderr=securesystemslib.process.PIPE)
+  gpg_process = process.run(command, stdout=process.PIPE, stderr=process.PIPE)
 
   key_packet = gpg_process.stdout
   key_bundle = securesystemslib.gpg.common.get_pubkey_bundle(key_packet, keyid)

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -108,19 +108,19 @@ def create_signature(content, keyid=None, homedir=None):
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
 
-  process = securesystemslib.process.run(command, input=content, check=False,
+  gpg_process = securesystemslib.process.run(command, input=content, check=False,
       stdout=securesystemslib.process.PIPE,
       stderr=securesystemslib.process.PIPE)
 
   # TODO: It's suggested to take a look at `--status-fd` for proper error
   # reporting, as there is no clear distinction between the return codes
   # https://lists.gnupg.org/pipermail/gnupg-devel/2005-December/022559.html
-  if process.returncode != 0:
+  if gpg_process.returncode != 0:
     raise securesystemslib.gpg.exceptions.CommandError("Command '{}' returned "
-        "non-zero exit status '{}', stderr was:\n{}.".format(process.args,
-        process.returncode, process.stderr.decode()))
+        "non-zero exit status '{}', stderr was:\n{}.".format(gpg_process.args,
+        gpg_process.returncode, gpg_process.stderr.decode()))
 
-  signature_data = process.stdout
+  signature_data = gpg_process.stdout
   signature = securesystemslib.gpg.common.parse_signature_packet(
       signature_data)
 
@@ -272,11 +272,11 @@ def export_pubkey(keyid, homedir=None):
   # above, e.g. in a common 'run gpg command' utility function
   command = securesystemslib.gpg.constants.GPG_EXPORT_PUBKEY_COMMAND.format(
       keyid=keyid, homearg=homearg)
-  process = securesystemslib.process.run(command,
+  gpg_process = securesystemslib.process.run(command,
       stdout=securesystemslib.process.PIPE,
       stderr=securesystemslib.process.PIPE)
 
-  key_packet = process.stdout
+  key_packet = gpg_process.stdout
   key_bundle = securesystemslib.gpg.common.get_pubkey_bundle(key_packet, keyid)
 
   return key_bundle

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -19,6 +19,7 @@ import logging
 import time
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.gpg.common
 import securesystemslib.gpg.exceptions
 from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
@@ -26,7 +27,6 @@ from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
     HAVE_GPG, NO_GPG_MSG)
 
 import securesystemslib.process
-import securesystemslib.formats
 from securesystemslib.gpg.rsa import CRYPTO
 
 log = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def create_signature(content, keyid=None, homedir=None):
 
   keyarg = ""
   if keyid:
-    securesystemslib.formats.KEYID_SCHEMA.check_match(keyid)
+    formats.KEYID_SCHEMA.check_match(keyid)
     keyarg = "--local-user {}".format(keyid)
 
   homearg = ""
@@ -206,8 +206,8 @@ def verify_signature(signature_object, pubkey_info, content):
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_PUBKEY_SCHEMA.check_match(pubkey_info)
-  securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
+  formats.GPG_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
 
   handler = SIGNATURE_HANDLERS[pubkey_info['type']]
   sig_keyid = signature_object["keyid"]
@@ -258,7 +258,7 @@ def export_pubkey(keyid, homedir=None):
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  if not securesystemslib.formats.KEYID_SCHEMA.matches(keyid):
+  if not formats.KEYID_SCHEMA.matches(keyid):
     # FIXME: probably needs smarter parsing of what a valid keyid is so as to
     # not export more than one pubkey packet.
     raise ValueError("we need to export an individual key. Please provide a "

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -18,7 +18,7 @@
 import logging
 import time
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 import securesystemslib.gpg.common
 import securesystemslib.gpg.exceptions
 from securesystemslib.gpg.constants import (GPG_SIGN_COMMAND,
@@ -92,10 +92,10 @@ def create_signature(content, keyid=None, homedir=None):
 
   """
   if not HAVE_GPG: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_GPG_MSG)
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   keyarg = ""
   if keyid:
@@ -204,7 +204,7 @@ def verify_signature(signature_object, pubkey_info, content):
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_PUBKEY_SCHEMA.check_match(pubkey_info)
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
@@ -253,10 +253,10 @@ def export_pubkey(keyid, homedir=None):
 
   """
   if not HAVE_GPG: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_GPG_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_GPG_MSG)
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   if not securesystemslib.formats.KEYID_SCHEMA.matches(keyid):
     # FIXME: probably needs smarter parsing of what a valid keyid is so as to

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -30,7 +30,8 @@ from securesystemslib.gpg.constants import (
     GPG_SIGN_COMMAND,
     HAVE_GPG,
     NO_GPG_MSG,
-    SHA256,
+    SHA256)
+from securesystemslib.gpg.handlers import (
     SIGNATURE_HANDLERS)
 
 from securesystemslib import process

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -20,7 +20,8 @@ import time
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.gpg.common
+from securesystemslib.gpg.common import (
+    get_pubkey_bundle, parse_signature_packet)
 from securesystemslib.gpg.exceptions import (
     CommandError, KeyExpirationError)
 from securesystemslib.gpg.constants import (
@@ -126,8 +127,7 @@ def create_signature(content, keyid=None, homedir=None):
         gpg_process.returncode, gpg_process.stderr.decode()))
 
   signature_data = gpg_process.stdout
-  signature = securesystemslib.gpg.common.parse_signature_packet(
-      signature_data)
+  signature = parse_signature_packet(signature_data)
 
   # On GPG < 2.1 we cannot derive the full keyid from the signature data.
   # Instead we try to compute the keyid from the public part of the signing
@@ -279,7 +279,7 @@ def export_pubkey(keyid, homedir=None):
   gpg_process = process.run(command, stdout=process.PIPE, stderr=process.PIPE)
 
   key_packet = gpg_process.stdout
-  key_bundle = securesystemslib.gpg.common.get_pubkey_bundle(key_packet, keyid)
+  key_bundle = get_pubkey_bundle(key_packet, keyid)
 
   return key_bundle
 

--- a/securesystemslib/gpg/handlers.py
+++ b/securesystemslib/gpg/handlers.py
@@ -1,0 +1,46 @@
+"""
+<Module Name>
+  handlers.py
+
+<Author>
+  Santiago Torres-Arias <santiago@nyu.edu>
+
+<Started>
+  Jan 15, 2020
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides links from signatures/algorithms to modules implementing
+  the signature verification and key parsing.
+"""
+
+from securesystemslib.gpg import rsa
+from securesystemslib.gpg import dsa
+from securesystemslib.gpg import eddsa
+
+# See section 9.1. (public-key algorithms) of RFC4880 (-bis8)
+SUPPORTED_SIGNATURE_ALGORITHMS = {
+    0x01: {
+      "type":"rsa",
+      "method": "pgp+rsa-pkcsv1.5",
+      "handler": rsa
+    },
+    0x11: {
+      "type": "dsa",
+      "method": "pgp+dsa-fips-180-2",
+      "handler": dsa
+    },
+    0x16: {
+      "type": "eddsa",
+      "method": "pgp+eddsa-ed25519",
+      "handler": eddsa
+    }
+}
+
+SIGNATURE_HANDLERS = {
+    "rsa": rsa,
+    "dsa": dsa,
+    "eddsa": eddsa
+}

--- a/securesystemslib/gpg/rsa.py
+++ b/securesystemslib/gpg/rsa.py
@@ -27,9 +27,9 @@ try:
 except ImportError:
   CRYPTO = False
 
+from securesystemslib import exceptions
 import securesystemslib.gpg.util
 import securesystemslib.gpg.exceptions
-import securesystemslib.exceptions
 import securesystemslib.formats
 
 
@@ -57,7 +57,7 @@ def create_pubkey(pubkey_info):
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
@@ -189,7 +189,7 @@ def verify_signature(signature_object, pubkey_info, content,
 
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   securesystemslib.formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)

--- a/securesystemslib/gpg/rsa.py
+++ b/securesystemslib/gpg/rsa.py
@@ -29,7 +29,7 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.gpg.util
+from securesystemslib.gpg import util as gpg_util
 import securesystemslib.gpg.exceptions
 
 
@@ -92,7 +92,7 @@ def get_pubkey_params(data):
   """
   ptr = 0
 
-  modulus_length = securesystemslib.gpg.util.get_mpi_length(data[ptr: ptr + 2])
+  modulus_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   modulus = data[ptr:ptr + modulus_length]
   if len(modulus) != modulus_length: # pragma: no cover
@@ -100,8 +100,7 @@ def get_pubkey_params(data):
         "This modulus MPI was truncated!")
   ptr += modulus_length
 
-  exponent_e_length = securesystemslib.gpg.util.get_mpi_length(
-      data[ptr: ptr + 2])
+  exponent_e_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   exponent_e = data[ptr:ptr + exponent_e_length]
   if len(exponent_e) != exponent_e_length: # pragma: no cover
@@ -136,7 +135,7 @@ def get_signature_params(data):
   """
 
   ptr = 0
-  signature_length = securesystemslib.gpg.util.get_mpi_length(data[ptr:ptr+2])
+  signature_length = gpg_util.get_mpi_length(data[ptr:ptr+2])
   ptr += 2
   signature = data[ptr:ptr + signature_length]
   if len(signature) != signature_length: # pragma: no cover
@@ -194,7 +193,7 @@ def verify_signature(signature_object, pubkey_info, content,
   formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
   formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
-  hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
+  hasher = gpg_util.get_hashing_class(hash_algorithm_id)
 
   pubkey_object = create_pubkey(pubkey_info)
 
@@ -210,7 +209,7 @@ def verify_signature(signature_object, pubkey_info, content,
     signature_object['signature'] = "{}{}".format(zero_pad,
         signature_object['signature'])
 
-  digest = securesystemslib.gpg.util.hash_object(
+  digest = gpg_util.hash_object(
       binascii.unhexlify(signature_object['other_headers']),
       hasher(), content)
 

--- a/securesystemslib/gpg/rsa.py
+++ b/securesystemslib/gpg/rsa.py
@@ -19,11 +19,11 @@ import binascii
 CRYPTO = True
 NO_CRYPTO_MSG = 'RSA key support for GPG requires the cryptography library'
 try:
-  import cryptography.hazmat.primitives.asymmetric.rsa as rsa
-  import cryptography.hazmat.backends as backends
-  import cryptography.hazmat.primitives.asymmetric.padding as padding
-  import cryptography.hazmat.primitives.asymmetric.utils as utils
-  import cryptography.exceptions
+  from cryptography.hazmat.primitives.asymmetric import rsa
+  from cryptography.hazmat import backends
+  from cryptography.hazmat.primitives.asymmetric import padding
+  from cryptography.hazmat.primitives.asymmetric import utils
+  from cryptography.exceptions import InvalidSignature
 except ImportError:
   CRYPTO = False
 
@@ -218,5 +218,5 @@ def verify_signature(signature_object, pubkey_info, content,
       utils.Prehashed(hasher())
     )
     return True
-  except cryptography.exceptions.InvalidSignature:
+  except InvalidSignature:
     return False

--- a/securesystemslib/gpg/rsa.py
+++ b/securesystemslib/gpg/rsa.py
@@ -28,9 +28,9 @@ except ImportError:
   CRYPTO = False
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.gpg.util
 import securesystemslib.gpg.exceptions
-import securesystemslib.formats
 
 
 def create_pubkey(pubkey_info):
@@ -59,7 +59,7 @@ def create_pubkey(pubkey_info):
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   e = int(pubkey_info['keyval']['public']['e'], 16)
   n = int(pubkey_info['keyval']['public']['n'], 16)
@@ -191,8 +191,8 @@ def verify_signature(signature_object, pubkey_info, content,
   if not CRYPTO: # pragma: no cover
     raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
-  securesystemslib.formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
-  securesystemslib.formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
+  formats.GPG_SIGNATURE_SCHEMA.check_match(signature_object)
+  formats.GPG_RSA_PUBKEY_SCHEMA.check_match(pubkey_info)
 
   hasher = securesystemslib.gpg.util.get_hashing_class(hash_algorithm_id)
 

--- a/securesystemslib/gpg/rsa.py
+++ b/securesystemslib/gpg/rsa.py
@@ -30,7 +30,7 @@ except ImportError:
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib.gpg import util as gpg_util
-import securesystemslib.gpg.exceptions
+from securesystemslib.gpg.exceptions import PacketParsingError
 
 
 def create_pubkey(pubkey_info):
@@ -96,16 +96,14 @@ def get_pubkey_params(data):
   ptr += 2
   modulus = data[ptr:ptr + modulus_length]
   if len(modulus) != modulus_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This modulus MPI was truncated!")
+    raise PacketParsingError("This modulus MPI was truncated!")
   ptr += modulus_length
 
   exponent_e_length = gpg_util.get_mpi_length(data[ptr: ptr + 2])
   ptr += 2
   exponent_e = data[ptr:ptr + exponent_e_length]
   if len(exponent_e) != exponent_e_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This e MPI has been truncated!")
+    raise PacketParsingError("This e MPI has been truncated!")
 
   return {
     "e": binascii.hexlify(exponent_e).decode('ascii'),
@@ -139,8 +137,7 @@ def get_signature_params(data):
   ptr += 2
   signature = data[ptr:ptr + signature_length]
   if len(signature) != signature_length: # pragma: no cover
-    raise securesystemslib.gpg.exceptions.PacketParsingError(
-        "This signature was truncated!")
+    raise PacketParsingError("This signature was truncated!")
 
   return signature
 

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -30,8 +30,8 @@ except ImportError:
   CRYPTO = False
 
 from securesystemslib import exceptions
+from securesystemslib import process
 import securesystemslib.gpg.exceptions
-import securesystemslib.process
 import securesystemslib.gpg.constants
 
 log = logging.getLogger(__name__)
@@ -322,9 +322,8 @@ def get_version():
         securesystemslib.gpg.constants.NO_GPG_MSG)
 
   command = securesystemslib.gpg.constants.GPG_VERSION_COMMAND
-  gpg_process = securesystemslib.process.run(command,
-      stdout=securesystemslib.process.PIPE,
-      stderr=securesystemslib.process.PIPE, universal_newlines=True)
+  gpg_process = process.run(command, stdout=process.PIPE,
+      stderr=process.PIPE, universal_newlines=True)
 
   full_version_info = gpg_process.stdout
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -322,11 +322,11 @@ def get_version():
         securesystemslib.gpg.constants.NO_GPG_MSG)
 
   command = securesystemslib.gpg.constants.GPG_VERSION_COMMAND
-  process = securesystemslib.process.run(command,
+  gpg_process = securesystemslib.process.run(command,
       stdout=securesystemslib.process.PIPE,
       stderr=securesystemslib.process.PIPE, universal_newlines=True)
 
-  full_version_info = process.stdout
+  full_version_info = gpg_process.stdout
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)
 
   return version_string

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import process
-import securesystemslib.gpg.exceptions
+from securesystemslib.gpg.exceptions import PacketParsingError
 import securesystemslib.gpg.constants
 
 log = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ def parse_packet_header(data, expected_type=None):
       body_len = (data[1] - 192 << 8) + data[2] + 192
 
     elif data[1] >= 224 and data[1] < 255:
-      raise securesystemslib.gpg.exceptions.PacketParsingError("New length "
+      raise PacketParsingError("New length "
           "format packets of partial body lengths are not supported")
 
     elif data[1] == 255:
@@ -166,8 +166,7 @@ def parse_packet_header(data, expected_type=None):
 
     else: # pragma: no cover
       # Unreachable: octet must be between 0 and 255
-      raise securesystemslib.gpg.exceptions.PacketParsingError("Invalid new "
-          "length")
+      raise PacketParsingError("Invalid new length")
 
   else:
     # In old format packet lengths the packet type is encoded in Bits 5-2 of
@@ -190,21 +189,19 @@ def parse_packet_header(data, expected_type=None):
       body_len = struct.unpack(">I", data[1:header_len])[0]
 
     elif length_type == 3:
-      raise securesystemslib.gpg.exceptions.PacketParsingError("Old length "
+      raise PacketParsingError("Old length "
           "format packets of indeterminate length are not supported")
 
     else: # pragma: no cover (unreachable)
       # Unreachable: bits 1-0 must be one of 0 to 3
-      raise securesystemslib.gpg.exceptions.PacketParsingError("Invalid old "
-          "length")
+      raise PacketParsingError("Invalid old length")
 
   if header_len is None or body_len is None: # pragma: no cover
     # Unreachable: One of above must have assigned lengths or raised error
-    raise securesystemslib.gpg.exceptions.PacketParsingError("Could not "
-        "determine packet length")
+    raise PacketParsingError("Could not determine packet length")
 
   if expected_type is not None and packet_type != expected_type:
-    raise securesystemslib.gpg.exceptions.PacketParsingError("Expected packet "
+    raise PacketParsingError("Expected packet "
         "{}, but got {} instead!".format(expected_type, packet_type))
 
   return packet_type, header_len, body_len, header_len + body_len
@@ -260,8 +257,7 @@ def parse_subpacket_header(data):
     length = struct.unpack(">I", data[1:length_len])[0]
 
   else: # pragma: no cover (unreachable)
-    raise securesystemslib.gpg.exceptions.PacketParsingError("Invalid "
-        "subpacket header")
+    raise PacketParsingError("Invalid subpacket header")
 
   return data[length_len], length_len + 1, length - 1, length_len + length
 

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -29,7 +29,7 @@ try:
 except ImportError:
   CRYPTO = False
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 import securesystemslib.gpg.exceptions
 import securesystemslib.process
 import securesystemslib.gpg.constants
@@ -89,7 +89,7 @@ def hash_object(headers, algorithm, content):
     The RFC4880-compliant hashed buffer
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # As per RFC4880 Section 5.2.4., we need to hash the content,
   # signature headers and add a very opinionated trailing header
@@ -229,7 +229,7 @@ def compute_keyid(pubkey_packet_data):
     The RFC4880-compliant hashed buffer
   """
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   hasher = hashing.Hash(hashing.SHA1(), backend=backends.default_backend())
   hasher.update(b'\x99')
@@ -318,7 +318,7 @@ def get_version():
 
   """
   if not securesystemslib.gpg.constants.HAVE_GPG: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(
+    raise exceptions.UnsupportedLibraryError(
         securesystemslib.gpg.constants.NO_GPG_MSG)
 
   command = securesystemslib.gpg.constants.GPG_VERSION_COMMAND

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -31,8 +31,8 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import process
+from securesystemslib.gpg import constants
 from securesystemslib.gpg.exceptions import PacketParsingError
-import securesystemslib.gpg.constants
 
 log = logging.getLogger(__name__)
 
@@ -313,11 +313,10 @@ def get_version():
     Version number string, e.g. "2.1.22"
 
   """
-  if not securesystemslib.gpg.constants.HAVE_GPG: # pragma: no cover
-    raise exceptions.UnsupportedLibraryError(
-        securesystemslib.gpg.constants.NO_GPG_MSG)
+  if not constants.HAVE_GPG: # pragma: no cover
+    raise exceptions.UnsupportedLibraryError(constants.NO_GPG_MSG)
 
-  command = securesystemslib.gpg.constants.GPG_VERSION_COMMAND
+  command = constants.GPG_VERSION_COMMAND
   gpg_process = process.run(command, stdout=process.PIPE,
       stderr=process.PIPE, universal_newlines=True)
 
@@ -342,7 +341,7 @@ def is_version_fully_supported():
   installed_version = get_version()
   # Excluded so that coverage does not vary in different test environments
   if (StrictVersion(installed_version) >=
-      StrictVersion(securesystemslib.gpg.constants.FULLY_SUPPORTED_MIN_VERSION)): # pragma: no cover
+      StrictVersion(constants.FULLY_SUPPORTED_MIN_VERSION)): # pragma: no cover
     return True
 
   else: # pragma: no cover
@@ -367,9 +366,8 @@ def get_hashing_class(hash_algorithm_id):
     A pyca/cryptography hashing class
 
   """
-  supported_hashing_algorithms = [securesystemslib.gpg.constants.SHA1,
-      securesystemslib.gpg.constants.SHA256,
-      securesystemslib.gpg.constants.SHA512]
+  supported_hashing_algorithms = [constants.SHA1, constants.SHA256,
+      constants.SHA512]
   corresponding_hashing_classes = [hashing.SHA1, hashing.SHA256,
       hashing.SHA512]
 

--- a/securesystemslib/gpg/util.py
+++ b/securesystemslib/gpg/util.py
@@ -24,8 +24,8 @@ from distutils.version import StrictVersion # pylint: disable=no-name-in-module,
 CRYPTO = True
 NO_CRYPTO_MSG = 'gpg.utils requires the cryptography library'
 try:
-  import cryptography.hazmat.backends as backends
-  import cryptography.hazmat.primitives.hashes as hashing
+  from cryptography.hazmat import backends
+  from cryptography.hazmat.primitives import hashes as hashing
 except ImportError:
   CRYPTO = False
 

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -36,7 +36,7 @@ import six
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.storage
+from securesystemslib.storage import FilesystemBackend
 
 
 DEFAULT_CHUNK_SIZE = 4096
@@ -374,7 +374,7 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
   digest_object = None
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   # Open 'filename' in read+binary mode.
   with storage_backend.get(filename) as file_object:

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -47,9 +47,8 @@ SUPPORTED_LIBRARIES = ['hashlib']
 
 # If `pyca_crypto` is installed, add it to supported libraries
 try:
-  import cryptography.exceptions
-  import cryptography.hazmat.backends
-  import cryptography.hazmat.primitives.hashes as _pyca_hashes
+  from cryptography.hazmat.backends import default_backend
+  from cryptography.hazmat.primitives import hashes as _pyca_hashes
   import binascii
 
   # Dictionary of `pyca/cryptography` supported hash algorithms.
@@ -204,8 +203,7 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
     try:
       hash_algorithm = PYCA_DIGEST_OBJECTS_CACHE[algorithm]()
       return PycaDiggestWrapper(
-        cryptography.hazmat.primitives.hashes.Hash(hash_algorithm,
-            cryptography.hazmat.backends.default_backend()))
+        _pyca_hashes.Hash(hash_algorithm, default_backend()))
 
     except KeyError:
       raise exceptions.UnsupportedAlgorithmError(algorithm)

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -35,7 +35,7 @@ import hashlib
 import six
 
 from securesystemslib import exceptions
-import securesystemslib.formats
+from securesystemslib import formats
 import securesystemslib.storage
 
 
@@ -182,8 +182,8 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
 
   # Are the arguments properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
-  securesystemslib.formats.NAME_SCHEMA.check_match(algorithm)
-  securesystemslib.formats.NAME_SCHEMA.check_match(hash_library)
+  formats.NAME_SCHEMA.check_match(algorithm)
+  formats.NAME_SCHEMA.check_match(hash_library)
 
   # Was a hashlib digest object requested and is it supported?
   # If so, return the digest object.
@@ -270,8 +270,8 @@ def digest_fileobject(file_object, algorithm=DEFAULT_HASH_ALGORITHM,
 
   # Are the arguments properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
-  securesystemslib.formats.NAME_SCHEMA.check_match(algorithm)
-  securesystemslib.formats.NAME_SCHEMA.check_match(hash_library)
+  formats.NAME_SCHEMA.check_match(algorithm)
+  formats.NAME_SCHEMA.check_match(hash_library)
 
   # Digest object returned whose hash will be updated using 'file_object'.
   # digest() raises:
@@ -367,9 +367,9 @@ def digest_filename(filename, algorithm=DEFAULT_HASH_ALGORITHM,
   """
   # Are the arguments properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filename)
-  securesystemslib.formats.NAME_SCHEMA.check_match(algorithm)
-  securesystemslib.formats.NAME_SCHEMA.check_match(hash_library)
+  formats.PATH_SCHEMA.check_match(filename)
+  formats.NAME_SCHEMA.check_match(algorithm)
+  formats.NAME_SCHEMA.check_match(hash_library)
 
   digest_object = None
 
@@ -428,7 +428,7 @@ def digest_from_rsa_scheme(scheme, hash_library=DEFAULT_HASH_LIBRARY):
   """
   # Are the arguments properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Get hash algorithm from rsa scheme (hash algorithm id is specified after
   # the last dash; e.g. rsassa-pss-sha256 -> sha256)

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -34,7 +34,7 @@ import hashlib
 
 import six
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 import securesystemslib.formats
 import securesystemslib.storage
 
@@ -197,7 +197,7 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
     except (ValueError, TypeError):
       # ValueError: the algorithm value was unknown
       # TypeError: unexpected argument digest_size (on old python)
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError(algorithm)
+      raise exceptions.UnsupportedAlgorithmError(algorithm)
 
   # Was a pyca_crypto digest object requested and is it supported?
   elif hash_library == 'pyca_crypto' and hash_library in SUPPORTED_LIBRARIES:
@@ -208,11 +208,11 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
             cryptography.hazmat.backends.default_backend()))
 
     except KeyError:
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError(algorithm)
+      raise exceptions.UnsupportedAlgorithmError(algorithm)
 
   # The requested hash library is not supported.
   else:
-    raise securesystemslib.exceptions.UnsupportedLibraryError('Unsupported'
+    raise exceptions.UnsupportedLibraryError('Unsupported'
         ' library requested.  Supported hash'
         ' libraries: ' + repr(SUPPORTED_LIBRARIES))
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -38,7 +38,7 @@ import json
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import keys
-import securesystemslib.settings
+from securesystemslib import settings
 import securesystemslib.storage
 import securesystemslib.util
 
@@ -942,8 +942,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
 
   # Add "keyid_hash_algorithms" so that equal ecdsa keys with different keyids
   # can be associated using supported keyid_hash_algorithms.
-  key_object['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  key_object['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return key_object
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -39,8 +39,8 @@ from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import keys
 from securesystemslib import settings
+from securesystemslib import util
 from securesystemslib.storage import FilesystemBackend
-import securesystemslib.util
 
 from securesystemslib import KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA
 
@@ -237,17 +237,17 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     private = keys.create_rsa_encrypted_pem(private, password)
 
   # Create intermediate directories as required
-  securesystemslib.util.ensure_parent_dir(filepath)
+  util.ensure_parent_dir(filepath)
 
   # Write PEM-encoded public key to <filepath>.pub
   file_object = tempfile.TemporaryFile()
   file_object.write(public.encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath + '.pub')
+  util.persist_temp_file(file_object, filepath + '.pub')
 
   # Write PEM-encoded private key to <filepath>
   file_object = tempfile.TemporaryFile()
   file_object.write(private.encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath)
+  util.persist_temp_file(file_object, filepath)
 
   return filepath
 
@@ -493,7 +493,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
   password = _get_key_file_encryption_password(password, prompt, filepath)
 
   # Create intermediate directories as required
-  securesystemslib.util.ensure_parent_dir(filepath)
+  util.ensure_parent_dir(filepath)
 
   # Use custom JSON format for ed25519 keys on-disk
   keytype = ed25519_key['keytype']
@@ -505,7 +505,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
   # Write public key to <filepath>.pub
   file_object = tempfile.TemporaryFile()
   file_object.write(json.dumps(ed25519key_metadata_format).encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath + '.pub')
+  util.persist_temp_file(file_object, filepath + '.pub')
 
   # Encrypt private key if we have a password, store as JSON string otherwise
   if password is not None:
@@ -516,7 +516,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
   # Write private key to <filepath>
   file_object = tempfile.TemporaryFile()
   file_object.write(ed25519_key.encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath)
+  util.persist_temp_file(file_object, filepath)
 
   return filepath
 
@@ -633,7 +633,7 @@ def import_ed25519_publickey_from_file(filepath):
 
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
-  ed25519_key_metadata = securesystemslib.util.load_json_file(filepath)
+  ed25519_key_metadata = util.load_json_file(filepath)
   ed25519_key, _ = keys.format_metadata_to_key(ed25519_key_metadata)
 
   # Check that the generic loading functions indeed loaded an ed25519 key
@@ -737,7 +737,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   password = _get_key_file_encryption_password(password, prompt, filepath)
 
   # Create intermediate directories as required
-  securesystemslib.util.ensure_parent_dir(filepath)
+  util.ensure_parent_dir(filepath)
 
   # Use custom JSON format for ecdsa keys on-disk
   keytype = ecdsa_key['keytype']
@@ -749,7 +749,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   # Write public key to <filepath>.pub
   file_object = tempfile.TemporaryFile()
   file_object.write(json.dumps(ecdsakey_metadata_format).encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath + '.pub')
+  util.persist_temp_file(file_object, filepath + '.pub')
 
   # Encrypt private key if we have a password, store as JSON string otherwise
   if password is not None:
@@ -760,7 +760,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   # Write private key to <filepath>
   file_object = tempfile.TemporaryFile()
   file_object.write(ecdsa_key.encode('utf-8'))
-  securesystemslib.util.persist_temp_file(file_object, filepath)
+  util.persist_temp_file(file_object, filepath)
 
   return filepath
 
@@ -878,7 +878,7 @@ def import_ecdsa_publickey_from_file(filepath):
 
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
-  ecdsa_key_metadata = securesystemslib.util.load_json_file(filepath)
+  ecdsa_key_metadata = util.load_json_file(filepath)
   ecdsa_key, _ = keys.format_metadata_to_key(ecdsa_key_metadata)
 
   return ecdsa_key
@@ -928,7 +928,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
   if password is not None:
     key_object = keys.decrypt_key(key_data, password)
   else:
-    key_object = securesystemslib.util.load_json_string(key_data)
+    key_object = util.load_json_string(key_data)
 
   # Raise an exception if an unexpected key type is imported.
   # NOTE: we support keytype's of ecdsa-sha2-nistp256 and ecdsa-sha2-nistp384

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -39,7 +39,7 @@ from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import keys
 from securesystemslib import settings
-import securesystemslib.storage
+from securesystemslib.storage import FilesystemBackend
 import securesystemslib.util
 
 from securesystemslib import KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA
@@ -392,7 +392,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
   password = _get_key_file_decryption_password(password, prompt, filepath)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   with storage_backend.get(filepath) as file_object:
     pem_key = file_object.read().decode('utf-8')
@@ -431,7 +431,7 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
   formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   with storage_backend.get(filepath) as file_object:
     rsa_pubkey_pem = file_object.read().decode('utf-8')
@@ -680,7 +680,7 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False,
   password = _get_key_file_decryption_password(password, prompt, filepath)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   with storage_backend.get(filepath) as file_object:
     json_str = file_object.read()
@@ -919,7 +919,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
   password = _get_key_file_decryption_password(password, prompt, filepath)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   with storage_backend.get(filepath) as file_object:
     key_data = file_object.read().decode('utf-8')

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -36,7 +36,7 @@ import tempfile
 import json
 
 from securesystemslib import exceptions
-import securesystemslib.formats
+from securesystemslib import formats
 import securesystemslib.settings
 import securesystemslib.storage
 import securesystemslib.util
@@ -77,8 +77,8 @@ def get_password(prompt='Password: ', confirm=False):
     The password entered on the prompt.
 
   """
-  securesystemslib.formats.TEXT_SCHEMA.check_match(prompt)
-  securesystemslib.formats.BOOLEAN_SCHEMA.check_match(confirm)
+  formats.TEXT_SCHEMA.check_match(prompt)
+  formats.BOOLEAN_SCHEMA.check_match(confirm)
 
   while True:
     # getpass() prompts the user for a password without echoing
@@ -111,7 +111,7 @@ def _get_key_file_encryption_password(password, prompt, path):
                                  indicate desire to not encrypt by entering no
                                  password)
   """
-  securesystemslib.formats.BOOLEAN_SCHEMA.check_match(prompt)
+  formats.BOOLEAN_SCHEMA.check_match(prompt)
 
   # We don't want to decide which takes precedence so we fail
   if password is not None and prompt:
@@ -129,7 +129,7 @@ def _get_key_file_encryption_password(password, prompt, path):
       return None
 
   if password is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
 
     # Fail on empty passed password. A caller should pass None to indicate the
     # desire to not encrypt.
@@ -154,7 +154,7 @@ def _get_key_file_decryption_password(password, prompt, path):
                             desire to not decrypt by entering no password)
 
   """
-  securesystemslib.formats.BOOLEAN_SCHEMA.check_match(prompt)
+  formats.BOOLEAN_SCHEMA.check_match(prompt)
 
   # We don't want to decide which takes precedence so we fail
   if password is not None and prompt:
@@ -172,7 +172,7 @@ def _get_key_file_decryption_password(password, prompt, path):
       return None
 
   if password is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
     # No additional vetting needed. Decryption will show if it was correct.
 
   return password
@@ -217,7 +217,7 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
     The private key filepath.
 
   """
-  securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match(bits)
+  formats.RSAKEYBITS_SCHEMA.check_match(bits)
 
   # Generate private RSA key and extract public and private both in PEM
   rsa_key = securesystemslib.keys.generate_rsa_key(bits)
@@ -228,7 +228,7 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   if not filepath:
     filepath = os.path.join(os.getcwd(), rsa_key['keyid'])
 
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   password = _get_key_file_encryption_password(password, prompt, filepath)
 
@@ -283,7 +283,7 @@ def generate_and_write_rsa_keypair(password, filepath=None,
     The private key filepath.
 
   """
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
   return _generate_and_write_rsa_keypair(
       filepath=filepath, bits=bits, password=password, prompt=False)
 
@@ -386,8 +386,8 @@ def import_rsa_privatekey_from_file(filepath, password=None,
     An RSA private key object conformant with 'RSAKEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.PATH_SCHEMA.check_match(filepath)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   password = _get_key_file_decryption_password(password, prompt, filepath)
 
@@ -428,8 +428,8 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
     An RSA public key object conformant with 'RSAKEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.PATH_SCHEMA.check_match(filepath)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   if storage_backend is None:
     storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -490,7 +490,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
   if not filepath:
     filepath = os.path.join(os.getcwd(), ed25519_key['keyid'])
 
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   password = _get_key_file_encryption_password(password, prompt, filepath)
 
@@ -551,7 +551,7 @@ def generate_and_write_ed25519_keypair(password, filepath=None):
     The private key filepath.
 
   """
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
   return _generate_and_write_ed25519_keypair(
       filepath=filepath, password=password, prompt=False)
 
@@ -631,7 +631,7 @@ def import_ed25519_publickey_from_file(filepath):
     An ed25519 public key object conformant with 'ED25519KEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
@@ -679,7 +679,7 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False,
     An ed25519 private key object conformant with 'ED25519KEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
   password = _get_key_file_decryption_password(password, prompt, filepath)
 
   if storage_backend is None:
@@ -735,7 +735,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   if not filepath:
     filepath = os.path.join(os.getcwd(), ecdsa_key['keyid'])
 
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   password = _get_key_file_encryption_password(password, prompt, filepath)
 
@@ -796,7 +796,7 @@ def generate_and_write_ecdsa_keypair(password, filepath=None):
     The private key filepath.
 
   """
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
   return _generate_and_write_ecdsa_keypair(
       filepath=filepath, password=password, prompt=False)
 
@@ -877,7 +877,7 @@ def import_ecdsa_publickey_from_file(filepath):
     An ecdsa public key object conformant with 'ECDSAKEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
@@ -918,7 +918,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
     An ecdsa private key object conformant with 'ED25519KEY_SCHEMA'.
 
   """
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   password = _get_key_file_decryption_password(password, prompt, filepath)
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -37,10 +37,10 @@ import json
 
 from securesystemslib import exceptions
 from securesystemslib import formats
+from securesystemslib import keys
 import securesystemslib.settings
 import securesystemslib.storage
 import securesystemslib.util
-import securesystemslib.keys
 
 from securesystemslib import KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA
 
@@ -220,7 +220,7 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
   formats.RSAKEYBITS_SCHEMA.check_match(bits)
 
   # Generate private RSA key and extract public and private both in PEM
-  rsa_key = securesystemslib.keys.generate_rsa_key(bits)
+  rsa_key = keys.generate_rsa_key(bits)
   public = rsa_key['keyval']['public']
   private = rsa_key['keyval']['private']
 
@@ -234,7 +234,7 @@ def _generate_and_write_rsa_keypair(filepath=None, bits=DEFAULT_RSA_KEY_BITS,
 
   # Encrypt the private key if a 'password' was passed or entered on the prompt
   if password is not None:
-    private = securesystemslib.keys.create_rsa_encrypted_pem(private, password)
+    private = keys.create_rsa_encrypted_pem(private, password)
 
   # Create intermediate directories as required
   securesystemslib.util.ensure_parent_dir(filepath)
@@ -398,8 +398,7 @@ def import_rsa_privatekey_from_file(filepath, password=None,
     pem_key = file_object.read().decode('utf-8')
 
   # Optionally decrypt and convert PEM-encoded key to 'RSAKEY_SCHEMA' format
-  rsa_key = securesystemslib.keys.import_rsakey_from_private_pem(
-      pem_key, scheme, password)
+  rsa_key = keys.import_rsakey_from_private_pem(pem_key, scheme, password)
 
   return rsa_key
 
@@ -439,8 +438,7 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
 
   # Convert PEM-encoded key to 'RSAKEY_SCHEMA' format
   try:
-    rsakey_dict = securesystemslib.keys.import_rsakey_from_public_pem(
-        rsa_pubkey_pem, scheme)
+    rsakey_dict = keys.import_rsakey_from_public_pem(rsa_pubkey_pem, scheme)
 
   except exceptions.FormatError as e:
     raise exceptions.Error('Cannot import improperly formatted'
@@ -484,7 +482,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
     The private key filepath.
 
   """
-  ed25519_key = securesystemslib.keys.generate_ed25519_key()
+  ed25519_key = keys.generate_ed25519_key()
 
   # Use passed 'filepath' or keyid as file name
   if not filepath:
@@ -501,7 +499,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
   keytype = ed25519_key['keytype']
   keyval = ed25519_key['keyval']
   scheme = ed25519_key['scheme']
-  ed25519key_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
+  ed25519key_metadata_format = keys.format_keyval_to_metadata(
       keytype, scheme, keyval, private=False)
 
   # Write public key to <filepath>.pub
@@ -511,7 +509,7 @@ def _generate_and_write_ed25519_keypair(filepath=None, password=None,
 
   # Encrypt private key if we have a password, store as JSON string otherwise
   if password is not None:
-    ed25519_key = securesystemslib.keys.encrypt_key(ed25519_key, password)
+    ed25519_key = keys.encrypt_key(ed25519_key, password)
   else:
     ed25519_key = json.dumps(ed25519_key)
 
@@ -636,8 +634,7 @@ def import_ed25519_publickey_from_file(filepath):
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
   ed25519_key_metadata = securesystemslib.util.load_json_file(filepath)
-  ed25519_key, _ = securesystemslib.keys.format_metadata_to_key(
-      ed25519_key_metadata)
+  ed25519_key, _ = keys.format_metadata_to_key(ed25519_key_metadata)
 
   # Check that the generic loading functions indeed loaded an ed25519 key
   if ed25519_key['keytype'] != 'ed25519':
@@ -690,7 +687,7 @@ def import_ed25519_privatekey_from_file(filepath, password=None, prompt=False,
 
     # Load custom on-disk JSON formatted key and convert to its custom
     # in-memory dict key representation, decrypting it if password is not None
-    return securesystemslib.keys.import_ed25519key_from_private_json(
+    return keys.import_ed25519key_from_private_json(
         json_str, password=password)
 
 
@@ -729,7 +726,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
     The private key filepath.
 
   """
-  ecdsa_key = securesystemslib.keys.generate_ecdsa_key()
+  ecdsa_key = keys.generate_ecdsa_key()
 
   # Use passed 'filepath' or keyid as file name
   if not filepath:
@@ -746,7 +743,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
   keytype = ecdsa_key['keytype']
   keyval = ecdsa_key['keyval']
   scheme = ecdsa_key['scheme']
-  ecdsakey_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
+  ecdsakey_metadata_format = keys.format_keyval_to_metadata(
       keytype, scheme, keyval, private=False)
 
   # Write public key to <filepath>.pub
@@ -756,7 +753,7 @@ def _generate_and_write_ecdsa_keypair(filepath=None, password=None,
 
   # Encrypt private key if we have a password, store as JSON string otherwise
   if password is not None:
-    ecdsa_key = securesystemslib.keys.encrypt_key(ecdsa_key, password)
+    ecdsa_key = keys.encrypt_key(ecdsa_key, password)
   else:
     ecdsa_key = json.dumps(ecdsa_key)
 
@@ -882,8 +879,7 @@ def import_ecdsa_publickey_from_file(filepath):
   # Load custom on-disk JSON formatted key and convert to its custom in-memory
   # dict key representation
   ecdsa_key_metadata = securesystemslib.util.load_json_file(filepath)
-  ecdsa_key, _ = securesystemslib.keys.format_metadata_to_key(
-      ecdsa_key_metadata)
+  ecdsa_key, _ = keys.format_metadata_to_key(ecdsa_key_metadata)
 
   return ecdsa_key
 
@@ -930,7 +926,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
 
   # Decrypt private key if we have a password, directly load JSON otherwise
   if password is not None:
-    key_object = securesystemslib.keys.decrypt_key(key_data, password)
+    key_object = keys.decrypt_key(key_data, password)
   else:
     key_object = securesystemslib.util.load_json_string(key_data)
 

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -35,6 +35,7 @@ import logging
 import tempfile
 import json
 
+from securesystemslib import exceptions
 import securesystemslib.formats
 import securesystemslib.settings
 import securesystemslib.storage
@@ -441,8 +442,8 @@ def import_rsa_publickey_from_file(filepath, scheme='rsassa-pss-sha256',
     rsakey_dict = securesystemslib.keys.import_rsakey_from_public_pem(
         rsa_pubkey_pem, scheme)
 
-  except securesystemslib.exceptions.FormatError as e:
-    raise securesystemslib.exceptions.Error('Cannot import improperly formatted'
+  except exceptions.FormatError as e:
+    raise exceptions.Error('Cannot import improperly formatted'
       ' PEM file.' + repr(str(e)))
 
   return rsakey_dict
@@ -641,7 +642,7 @@ def import_ed25519_publickey_from_file(filepath):
   # Check that the generic loading functions indeed loaded an ed25519 key
   if ed25519_key['keytype'] != 'ed25519':
     message = 'Invalid key type loaded: ' + repr(ed25519_key['keytype'])
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   return ed25519_key
 
@@ -941,7 +942,7 @@ def import_ecdsa_privatekey_from_file(filepath, password=None, prompt=False,
   if key_object['keytype'] not in['ecdsa', 'ecdsa-sha2-nistp256',
       'ecdsa-sha2-nistp384']:
     message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   # Add "keyid_hash_algorithms" so that equal ecdsa keys with different keyids
   # can be associated using supported keyid_hash_algorithms.
@@ -983,7 +984,7 @@ def import_publickeys_from_file(filepaths, key_types=None):
     key_types = [KEY_TYPE_RSA] * len(filepaths)
 
   if len(key_types) != len(filepaths):
-    raise securesystemslib.exceptions.FormatError(
+    raise exceptions.FormatError(
         "Pass equal amount of 'filepaths' (got {}) and 'key_types (got {}), "
         "or no 'key_types' at all to default to '{}'.".format(
         len(filepaths), len(key_types), KEY_TYPE_RSA))
@@ -1000,7 +1001,7 @@ def import_publickeys_from_file(filepaths, key_types=None):
       key = import_ecdsa_publickey_from_file(filepath)
 
     else:
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           "Unsupported key type '{}'. Must be '{}', '{}' or '{}'.".format(
           key_types[idx], KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA))
 
@@ -1059,7 +1060,7 @@ def import_privatekey_from_file(filepath, key_type=None, password=None,
         filepath, password=password, prompt=prompt)
 
   else:
-    raise securesystemslib.exceptions.FormatError(
+    raise exceptions.FormatError(
         "Unsupported key type '{}'. Must be '{}', '{}' or '{}'.".format(
         key_type, KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA))
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -61,11 +61,10 @@ import binascii
 
 import logging
 
+from securesystemslib import exceptions
 import securesystemslib.rsa_keys
 import securesystemslib.ed25519_keys
 import securesystemslib.ecdsa_keys
-
-import securesystemslib.exceptions
 
 # Digest objects needed to generate hashes.
 import securesystemslib.hash
@@ -452,7 +451,7 @@ def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
     # present in 'key_val' (a private key is optional for 'KEYVAL_SCHEMA'
     # dicts).
     if 'private' not in key_value:
-      raise securesystemslib.exceptions.FormatError('The required private key'
+      raise exceptions.FormatError('The required private key'
         ' is missing from: ' + repr(key_value))
 
     else:
@@ -704,7 +703,7 @@ def create_signature(key_dict, data):
           private, data, scheme)
 
     else:
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+      raise exceptions.UnsupportedAlgorithmError('Unsupported'
         ' RSA signature scheme specified: ' + repr(scheme))
 
   elif keytype == 'ed25519':
@@ -821,7 +820,7 @@ def verify_signature(key_dict, signature, data):
   # Verify that the KEYID in 'key_dict' matches the KEYID listed in the
   # 'signature'.
   if key_dict['keyid'] != signature['keyid']:
-    raise securesystemslib.exceptions.CryptoError('The KEYID ('
+    raise exceptions.CryptoError('The KEYID ('
         ' ' + repr(key_dict['keyid']) + ' ) in the given key does not match'
         ' the KEYID ( ' + repr(signature['keyid']) + ' ) in the signature.')
 
@@ -846,7 +845,7 @@ def verify_signature(key_dict, signature, data):
         scheme, public, data)
 
     else:
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+      raise exceptions.UnsupportedAlgorithmError('Unsupported'
           ' signature scheme is specified: ' + repr(scheme))
 
   elif keytype == 'ed25519':
@@ -856,7 +855,7 @@ def verify_signature(key_dict, signature, data):
           scheme, sig, data)
 
     else:
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+      raise exceptions.UnsupportedAlgorithmError('Unsupported'
           ' signature scheme is specified: ' + repr(scheme))
 
   elif keytype in ['ecdsa', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384']:
@@ -865,7 +864,7 @@ def verify_signature(key_dict, signature, data):
         scheme, sig, data)
 
     else:
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+      raise exceptions.UnsupportedAlgorithmError('Unsupported'
           ' signature scheme is specified: ' + repr(scheme))
 
   # 'securesystemslib.formats.ANYKEY_SCHEMA' should have detected invalid key
@@ -1046,8 +1045,7 @@ def import_rsakey_from_public_pem(pem, scheme='rsassa-pss-sha256'):
     public_pem = extract_pem(pem, private_pem=False)
 
   else:
-    raise securesystemslib.exceptions.FormatError('Invalid public'
-        ' pem: ' + repr(pem))
+    raise exceptions.FormatError('Invalid public pem: ' + repr(pem))
 
   # Begin building the RSA key dictionary.
   rsakey_dict = {}
@@ -1127,7 +1125,7 @@ def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
     return import_rsakey_from_private_pem(pem, scheme, password=None)
 
   else:
-    raise securesystemslib.exceptions.FormatError('PEM contains neither a'
+    raise exceptions.FormatError('PEM contains neither a'
       ' public nor private key: ' + repr(pem))
 
   # Begin building the RSA key dictionary.
@@ -1217,12 +1215,12 @@ def extract_pem(pem, private_pem=False):
   except ValueError:
     # Be careful not to print private key material in exception message.
     if not private_pem:
-      raise securesystemslib.exceptions.FormatError('Required PEM'
+      raise exceptions.FormatError('Required PEM'
         ' header ' + repr(pem_header) + '\n not found in PEM'
         ' string: ' + repr(pem))
 
     else:
-      raise securesystemslib.exceptions.FormatError('Required PEM'
+      raise exceptions.FormatError('Required PEM'
         ' header ' + repr(pem_header) + '\n not found in private PEM string.')
 
   try:
@@ -1232,12 +1230,12 @@ def extract_pem(pem, private_pem=False):
   except ValueError:
     # Be careful not to print private key material in exception message.
     if not private_pem:
-      raise securesystemslib.exceptions.FormatError('Required PEM'
+      raise exceptions.FormatError('Required PEM'
         ' footer ' + repr(pem_footer) + '\n not found in PEM'
         ' string ' + repr(pem))
 
     else:
-      raise securesystemslib.exceptions.FormatError('Required PEM'
+      raise exceptions.FormatError('Required PEM'
         ' footer ' + repr(pem_footer) + '\n not found in private PEM string.')
 
   # Extract only the public portion of 'pem'.  Leading or trailing whitespace
@@ -1568,7 +1566,7 @@ def is_pem_private(pem, keytype='rsa'):
     pem_footer = '-----END EC PRIVATE KEY-----'
 
   else:
-    raise securesystemslib.exceptions.FormatError('Unsupported key'
+    raise exceptions.FormatError('Unsupported key'
       ' type: ' + repr(keytype) + '.  Supported keytypes: ["rsa", "ec"]')
 
   try:
@@ -1605,16 +1603,15 @@ def import_ed25519key_from_private_json(json_str, password=None):
                securesystemslib.util.load_json_string(json_str.decode('utf-8'))
     # If the JSON could not be decoded, it is very likely, but not necessarily,
     # due to a non-empty password.
-    except securesystemslib.exceptions.Error:
-      raise securesystemslib.exceptions\
-            .CryptoError('Malformed Ed25519 key JSON, '
-                         'possibly due to encryption, '
-                         'but no password provided?')
+    except exceptions.Error:
+      raise exceptions.CryptoError('Malformed Ed25519 key JSON, '
+                                   'possibly due to encryption, '
+                                   'but no password provided?')
 
   # Raise an exception if an unexpected key type is imported.
   if key_object['keytype'] != 'ed25519':
     message = 'Invalid key type loaded: ' + repr(key_object['keytype'])
-    raise securesystemslib.exceptions.FormatError(message)
+    raise exceptions.FormatError(message)
 
   # Add "keyid_hash_algorithms" so that equal ed25519 keys with
   # different keyids can be associated using supported keyid_hash_algorithms.
@@ -1794,7 +1791,7 @@ def import_ecdsakey_from_public_pem(pem, scheme='ecdsa-sha2-nistp256'):
     public_pem = extract_pem(pem, private_pem=False)
 
   else:
-    raise securesystemslib.exceptions.FormatError('Invalid public'
+    raise exceptions.FormatError('Invalid public'
         ' pem: ' + repr(pem))
 
   # Begin building the ECDSA key dictionary.
@@ -1874,7 +1871,7 @@ def import_ecdsakey_from_pem(pem, scheme='ecdsa-sha2-nistp256'):
     return import_ecdsakey_from_private_pem(pem, password=None)
 
   else:
-    raise securesystemslib.exceptions.FormatError('PEM contains neither a public'
+    raise exceptions.FormatError('PEM contains neither a public'
       ' nor private key: ' + repr(pem))
 
   # Begin building the ECDSA key dictionary.

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -66,8 +66,8 @@ from securesystemslib import ed25519_keys
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import rsa_keys
+from securesystemslib import settings
 from securesystemslib.hash import digest
-
 
 
 # The hash algorithm to use in the generation of keyids.
@@ -198,7 +198,7 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
   rsakey_dict['keytype'] = keytype
   rsakey_dict['scheme'] = scheme
   rsakey_dict['keyid'] = keyid
-  rsakey_dict['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
+  rsakey_dict['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
   rsakey_dict['keyval'] = key_value
 
   return rsakey_dict
@@ -282,8 +282,7 @@ def generate_ecdsa_key(scheme='ecdsa-sha2-nistp256'):
 
   # Add "keyid_hash_algorithms" so that equal ECDSA keys with different keyids
   # can be associated using supported keyid_hash_algorithms.
-  ecdsa_key['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  ecdsa_key['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return ecdsa_key
 
@@ -360,7 +359,7 @@ def generate_ed25519_key(scheme='ed25519'):
   ed25519_key['keytype'] = keytype
   ed25519_key['scheme'] = scheme
   ed25519_key['keyid'] = keyid
-  ed25519_key['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
+  ed25519_key['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
   ed25519_key['keyval'] = key_value
 
   return ed25519_key
@@ -458,7 +457,7 @@ def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
 
     return {'keytype': keytype,
             'scheme': scheme,
-            'keyid_hash_algorithms': securesystemslib.settings.HASH_ALGORITHMS,
+            'keyid_hash_algorithms': settings.HASH_ALGORITHMS,
             'keyval': public_key_value}
 
 
@@ -550,7 +549,7 @@ def format_metadata_to_key(key_metadata, default_keyid=None,
   keyids.add(default_keyid)
 
   if keyid_hash_algorithms is None:
-    keyid_hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+    keyid_hash_algorithms = settings.HASH_ALGORITHMS
 
   for hash_algorithm in keyid_hash_algorithms:
     keyid = _get_keyid(keytype, scheme, key_value, hash_algorithm)
@@ -1058,8 +1057,7 @@ def import_rsakey_from_public_pem(pem, scheme='rsassa-pss-sha256'):
 
   # Add "keyid_hash_algorithms" so that equal RSA keys with different keyids
   # can be associated using supported keyid_hash_algorithms.
-  rsakey_dict['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  rsakey_dict['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return rsakey_dict
 
@@ -1141,8 +1139,7 @@ def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
 
   # Add "keyid_hash_algorithms" so that equal RSA keys with
   # different keyids can be associated using supported keyid_hash_algorithms.
-  rsakey_dict['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  rsakey_dict['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return rsakey_dict
 
@@ -1603,8 +1600,7 @@ def import_ed25519key_from_private_json(json_str, password=None):
 
   # Add "keyid_hash_algorithms" so that equal ed25519 keys with
   # different keyids can be associated using supported keyid_hash_algorithms.
-  key_object['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  key_object['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return key_object
 
@@ -1706,8 +1702,7 @@ def import_ecdsakey_from_private_pem(pem, scheme='ecdsa-sha2-nistp256', password
 
   # Add "keyid_hash_algorithms" so equal ECDSA keys with
   # different keyids can be associated using supported keyid_hash_algorithms
-  ecdsakey_dict['keyid_hash_algorithms'] = \
-    securesystemslib.settings.HASH_ALGORITHMS
+  ecdsakey_dict['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return ecdsakey_dict
 
@@ -1801,8 +1796,7 @@ def import_ecdsakey_from_public_pem(pem, scheme='ecdsa-sha2-nistp256'):
 
   # Add "keyid_hash_algorithms" so that equal ECDSA keys with different keyids
   # can be associated using supported keyid_hash_algorithms.
-  ecdsakey_dict['keyid_hash_algorithms'] = \
-      securesystemslib.settings.HASH_ALGORITHMS
+  ecdsakey_dict['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
 
   return ecdsakey_dict
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -62,6 +62,7 @@ import binascii
 import logging
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.rsa_keys
 import securesystemslib.ed25519_keys
 import securesystemslib.ecdsa_keys
@@ -69,8 +70,6 @@ import securesystemslib.ecdsa_keys
 # Digest objects needed to generate hashes.
 import securesystemslib.hash
 
-# Perform format checks of argument objects.
-import securesystemslib.formats
 
 # The hash algorithm to use in the generation of keyids.
 _KEY_ID_HASH_ALGORITHM = 'sha256'
@@ -164,8 +163,8 @@ def generate_rsa_key(bits=_DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
   # conforms to 'securesystemslib.formats.RSAKEYBITS_SCHEMA'.  'bits' must be
   # an integer object, with a minimum value of 2048.  Raise
   # 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match(bits)
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.RSAKEYBITS_SCHEMA.check_match(bits)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Begin building the RSA key dictionary.
   rsakey_dict = {}
@@ -251,7 +250,7 @@ def generate_ecdsa_key(scheme='ecdsa-sha2-nistp256'):
   # This check will ensure 'scheme' is properly formatted and is a supported
   # ECDSA signature scheme.  Raise 'securesystemslib.exceptions.FormatError' if
   # the check fails.
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Begin building the ECDSA key dictionary.
   ecdsa_key = {}
@@ -334,7 +333,7 @@ def generate_ed25519_key(scheme='ed25519'):
 
   # Are the arguments properly formatted?  If not, raise an
   # 'securesystemslib.exceptions.FormatError' exceptions.
-  securesystemslib.formats.ED25519_SIG_SCHEMA.check_match(scheme)
+  formats.ED25519_SIG_SCHEMA.check_match(scheme)
 
   # Begin building the Ed25519 key dictionary.
   ed25519_key = {}
@@ -437,13 +436,13 @@ def format_keyval_to_metadata(keytype, scheme, key_value, private=False):
   # This check will ensure 'keytype' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.KEYTYPE_SCHEMA.check_match(keytype)
+  formats.KEYTYPE_SCHEMA.check_match(keytype)
 
   # Does 'scheme' have the correct format?
-  securesystemslib.formats.SCHEME_SCHEMA.check_match(scheme)
+  formats.SCHEME_SCHEMA.check_match(scheme)
 
   # Does 'key_value' have the correct format?
-  securesystemslib.formats.KEYVAL_SCHEMA.check_match(key_value)
+  formats.KEYVAL_SCHEMA.check_match(key_value)
 
   if private is True:
     # If the caller requests (via the 'private' argument) to include a private
@@ -538,7 +537,7 @@ def format_metadata_to_key(key_metadata, default_keyid=None,
   # This check will ensure 'key_metadata' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.KEY_SCHEMA.check_match(key_metadata)
+  formats.KEY_SCHEMA.check_match(key_metadata)
 
   # Construct the dictionary to be returned.
   key_dict = {}
@@ -582,7 +581,7 @@ def _get_keyid(keytype, scheme, key_value, hash_algorithm = 'sha256'):
 
   # Convert the key to JSON Canonical format, suitable for adding
   # to digest objects.
-  key_update_data = securesystemslib.formats.encode_canonical(key_meta)
+  key_update_data = formats.encode_canonical(key_meta)
 
   # Create a digest object and call update(), using the JSON
   # canonical format of 'rskey_meta' as the update data.
@@ -679,7 +678,7 @@ def create_signature(key_dict, data):
   # and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
   # The key type of 'key_dict' must be either 'rsa' or 'ed25519'.
-  securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_dict)
+  formats.ANYKEY_SCHEMA.check_match(key_dict)
 
   # Signing the 'data' object requires a private key. Signing schemes that are
   # currently supported are: 'ed25519', 'ecdsa-sha2-nistp256',
@@ -812,10 +811,10 @@ def verify_signature(key_dict, signature, data):
   # This check will ensure 'key_dict' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_dict)
+  formats.ANYKEY_SCHEMA.check_match(key_dict)
 
   # Does 'signature' have the correct format?
-  securesystemslib.formats.SIGNATURE_SCHEMA.check_match(signature)
+  formats.SIGNATURE_SCHEMA.check_match(signature)
 
   # Verify that the KEYID in 'key_dict' matches the KEYID listed in the
   # 'signature'.
@@ -936,13 +935,13 @@ def import_rsakey_from_private_pem(pem, scheme='rsassa-pss-sha256', password=Non
   # Does 'pem' have the correct format?
   # This check will ensure 'pem' conforms to
   # 'securesystemslib.formats.PEMRSA_SCHEMA'.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.PEMRSA_SCHEMA.check_match(pem)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   if password is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
 
   else:
     logger.debug('The password/passphrase is unset.  The PEM is expected'
@@ -1031,10 +1030,10 @@ def import_rsakey_from_public_pem(pem, scheme='rsassa-pss-sha256'):
   # This check will ensure arguments has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.PEMRSA_SCHEMA.check_match(pem)
 
   # Does 'scheme' have the correct format?
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Ensure the PEM string has a public header and footer.  Although a simple
   # validation of 'pem' is performed here, a fully valid PEM string is needed
@@ -1106,10 +1105,10 @@ def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
   # This check will ensure arguments has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.PEMRSA_SCHEMA.check_match(pem)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   public_pem = ''
 
@@ -1301,10 +1300,10 @@ def encrypt_key(key_object, password):
   # This check will ensure 'key_object' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_object)
+  formats.ANYKEY_SCHEMA.check_match(key_object)
 
   # Does 'password' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
 
   # Encrypted string of 'key_object'.  The encrypted string may be safely saved
   # to a file and stored offline.
@@ -1377,10 +1376,10 @@ def decrypt_key(encrypted_key, passphrase):
   # This check ensures 'encrypted_key' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ENCRYPTEDKEY_SCHEMA.check_match(encrypted_key)
+  formats.ENCRYPTEDKEY_SCHEMA.check_match(encrypted_key)
 
   # Does 'passphrase' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase)
+  formats.PASSWORD_SCHEMA.check_match(passphrase)
 
   # Store and return the decrypted key object.
   key_object = None
@@ -1449,10 +1448,10 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   # This check will ensure 'private_key' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(private_key)
+  formats.PEMRSA_SCHEMA.check_match(private_key)
 
   # Does 'passphrase' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase)
+  formats.PASSWORD_SCHEMA.check_match(passphrase)
 
   encrypted_pem = None
 
@@ -1501,7 +1500,7 @@ def is_pem_public(pem):
   # This check will ensure arguments have the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.PEMRSA_SCHEMA.check_match(pem)
 
   pem_header = '-----BEGIN PUBLIC KEY-----'
   pem_footer = '-----END PUBLIC KEY-----'
@@ -1554,8 +1553,8 @@ def is_pem_private(pem, keytype='rsa'):
   # This check will ensure arguments have the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
-  securesystemslib.formats.NAME_SCHEMA.check_match(keytype)
+  formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.NAME_SCHEMA.check_match(keytype)
 
   if keytype == 'rsa':
     pem_header = '-----BEGIN RSA PRIVATE KEY-----'
@@ -1587,7 +1586,7 @@ def import_ed25519key_from_private_json(json_str, password=None):
     # This check will not fail, because a mal-formatted passed password fails
     # above and an entered password will always be a string (see get_password)
     # However, we include it in case PASSWORD_SCHEMA or get_password changes.
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
 
     # Decrypt the loaded key file, calling the 'cryptography' library to
     # generate the derived encryption key from 'password'.  Raise
@@ -1677,13 +1676,13 @@ def import_ecdsakey_from_private_pem(pem, scheme='ecdsa-sha2-nistp256', password
   # Does 'pem' have the correct format?
   # This check will ensure 'pem' conforms to
   # 'securesystemslib.formats.ECDSARSA_SCHEMA'.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(pem)
+  formats.PEMECDSA_SCHEMA.check_match(pem)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   if password is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+    formats.PASSWORD_SCHEMA.check_match(password)
 
   else:
     logger.debug('The password/passphrase is unset.  The PEM is expected'
@@ -1777,10 +1776,10 @@ def import_ecdsakey_from_public_pem(pem, scheme='ecdsa-sha2-nistp256'):
   # This check will ensure arguments has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(pem)
+  formats.PEMECDSA_SCHEMA.check_match(pem)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Ensure the PEM string has a public header and footer.  Although a simple
   # validation of 'pem' is performed here, a fully valid PEM string is needed
@@ -1852,10 +1851,10 @@ def import_ecdsakey_from_pem(pem, scheme='ecdsa-sha2-nistp256'):
   # This check will ensure arguments has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMECDSA_SCHEMA.check_match(pem)
+  formats.PEMECDSA_SCHEMA.check_match(pem)
 
   # Is 'scheme' properly formatted?
-  securesystemslib.formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
 
   public_pem = ''
 

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -67,6 +67,7 @@ from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import rsa_keys
 from securesystemslib import settings
+from securesystemslib import util
 from securesystemslib.hash import digest
 
 
@@ -1584,8 +1585,7 @@ def import_ed25519key_from_private_json(json_str, password=None):
     logger.debug('No password was given. Attempting to import an'
         ' unencrypted file.')
     try:
-      key_object = \
-               securesystemslib.util.load_json_string(json_str.decode('utf-8'))
+      key_object = util.load_json_string(json_str.decode('utf-8'))
     # If the JSON could not be decoded, it is very likely, but not necessarily,
     # due to a non-empty password.
     except exceptions.Error:

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -63,12 +63,11 @@ import logging
 
 from securesystemslib import exceptions
 from securesystemslib import formats
+from securesystemslib.hash import digest
 import securesystemslib.rsa_keys
 import securesystemslib.ed25519_keys
 import securesystemslib.ecdsa_keys
 
-# Digest objects needed to generate hashes.
-import securesystemslib.hash
 
 
 # The hash algorithm to use in the generation of keyids.
@@ -585,7 +584,7 @@ def _get_keyid(keytype, scheme, key_value, hash_algorithm = 'sha256'):
 
   # Create a digest object and call update(), using the JSON
   # canonical format of 'rskey_meta' as the update data.
-  digest_object = securesystemslib.hash.digest(hash_algorithm)
+  digest_object = digest(hash_algorithm)
   digest_object.update(key_update_data.encode('utf-8'))
 
   # 'keyid' becomes the hexadecimal representation of the hash.

--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -37,7 +37,7 @@ else: # pragma: no cover
   import subprocess
 
 from securesystemslib import formats
-import securesystemslib.settings
+from securesystemslib import settings
 
 DEVNULL = subprocess.DEVNULL
 PIPE = subprocess.PIPE
@@ -48,7 +48,7 @@ def _default_timeout():
   """Helper to use securesystemslib.settings.SUBPROCESS_TIMEOUT as default
   argument, and still be able to modify it after the function definitions are
   evaluated. """
-  return securesystemslib.settings.SUBPROCESS_TIMEOUT
+  return settings.SUBPROCESS_TIMEOUT
 
 
 

--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -36,7 +36,7 @@ if six.PY2:
 else: # pragma: no cover
   import subprocess
 
-import securesystemslib.formats
+from securesystemslib import formats
 import securesystemslib.settings
 
 DEVNULL = subprocess.DEVNULL
@@ -114,7 +114,7 @@ def run(cmd, check=True, timeout=_default_timeout(), **kwargs):
   if isinstance(cmd, six.string_types):
     cmd = shlex.split(cmd)
   else:
-    securesystemslib.formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
+    formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
 
   # NOTE: The CPython implementation would raise a ValueError here, we just
   # don't pass on `stdin` if the user passes `input` and `stdin`
@@ -173,7 +173,7 @@ def run_duplicate_streams(cmd, timeout=_default_timeout()):
   if isinstance(cmd, six.string_types):
     cmd = shlex.split(cmd)
   else:
-    securesystemslib.formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
+    formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
 
   # Use temporary files as targets for child process standard stream redirects
   # They seem to work better (i.e. do not hang) than pipes, when using

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -121,7 +121,7 @@ except ImportError:
   CRYPTO = False
 
 from securesystemslib import exceptions
-import securesystemslib.formats
+from securesystemslib import formats
 import securesystemslib.hash
 import securesystemslib.util
 
@@ -217,7 +217,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
   # 'securesystemslib.formats.RSAKEYBITS_SCHEMA'.  'bits' must be an integer
   # object, with a minimum value of 2048.  Raise
   # 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.RSAKEYBITS_SCHEMA.check_match(bits)
+  formats.RSAKEYBITS_SCHEMA.check_match(bits)
 
   # Generate the public and private RSA keys.  The pyca/cryptography 'rsa'
   # module performs the actual key generation.  The 'bits' argument is used,
@@ -306,9 +306,9 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   # Does the arguments have the correct format?
   # If not, raise 'securesystemslib.exceptions.FormatError' if any of the
   # checks fail.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(private_key)
-  securesystemslib.formats.DATA_SCHEMA.check_match(data)
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(scheme)
+  formats.PEMRSA_SCHEMA.check_match(private_key)
+  formats.DATA_SCHEMA.check_match(data)
+  formats.RSA_SCHEME_SCHEMA.check_match(scheme)
 
   # Signing 'data' requires a private key. Currently supported RSA signature
   # schemes are defined in `securesystemslib.keys.RSA_SIGNATURE_SCHEMES`.
@@ -443,16 +443,16 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
   # This check will ensure 'public_key' conforms to
   # 'securesystemslib.formats.PEMRSA_SCHEMA'.  Raise
   # 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(public_key)
+  formats.PEMRSA_SCHEMA.check_match(public_key)
 
   # Does 'signature_scheme' have the correct format?
-  securesystemslib.formats.RSA_SCHEME_SCHEMA.check_match(signature_scheme)
+  formats.RSA_SCHEME_SCHEMA.check_match(signature_scheme)
 
   # Does 'signature' have the correct format?
-  securesystemslib.formats.PYCACRYPTOSIGNATURE_SCHEMA.check_match(signature)
+  formats.PYCACRYPTOSIGNATURE_SCHEMA.check_match(signature)
 
   # What about 'data'?
-  securesystemslib.formats.DATA_SCHEMA.check_match(data)
+  formats.DATA_SCHEMA.check_match(data)
 
   # Verify the RSASSA-PSS signature with pyca/cryptography.
   try:
@@ -545,10 +545,10 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   # This check will ensure 'private_key' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(private_key)
+  formats.PEMRSA_SCHEMA.check_match(private_key)
 
   # Does 'passphrase' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase)
+  formats.PASSWORD_SCHEMA.check_match(passphrase)
 
   # 'private_key' may still be a NULL string after the
   # 'securesystemslib.formats.PEMRSA_SCHEMA' so we need an additional check
@@ -651,11 +651,11 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
   # This check will ensure 'pem' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.PEMRSA_SCHEMA.check_match(pem)
+  formats.PEMRSA_SCHEMA.check_match(pem)
 
   # If passed, does 'passphrase' have the correct format?
   if passphrase is not None:
-    securesystemslib.formats.PASSWORD_SCHEMA.check_match(passphrase)
+    formats.PASSWORD_SCHEMA.check_match(passphrase)
     passphrase = passphrase.encode('utf-8')
 
   # Generate a pyca/cryptography key object from 'pem'.  The generated
@@ -774,10 +774,10 @@ def encrypt_key(key_object, password):
   # Ensure the arguments have the appropriate number of objects and object
   # types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ANYKEY_SCHEMA.check_match(key_object)
+  formats.ANYKEY_SCHEMA.check_match(key_object)
 
   # Does 'password' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
 
   # Ensure the private portion of the key is included in 'key_object'.
   if 'private' not in key_object['keyval'] or not key_object['keyval']['private']:
@@ -878,10 +878,10 @@ def decrypt_key(encrypted_key, password):
   # Ensure the arguments have the appropriate number of objects and object
   # types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.ENCRYPTEDKEY_SCHEMA.check_match(encrypted_key)
+  formats.ENCRYPTEDKEY_SCHEMA.check_match(encrypted_key)
 
   # Does 'password' have the correct format?
-  securesystemslib.formats.PASSWORD_SCHEMA.check_match(password)
+  formats.PASSWORD_SCHEMA.check_match(password)
 
   # Decrypt 'encrypted_key', using 'password' (and additional key derivation
   # data like salts and password iterations) to re-derive the decryption key.

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -120,7 +120,7 @@ try:
 except ImportError:
   CRYPTO = False
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 import securesystemslib.formats
 import securesystemslib.hash
 import securesystemslib.util
@@ -210,7 +210,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'bits' have the correct format?
   # This check will ensure 'bits' conforms to
@@ -301,7 +301,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does the arguments have the correct format?
   # If not, raise 'securesystemslib.exceptions.FormatError' if any of the
@@ -350,13 +350,13 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
     # The RSA_SCHEME_SCHEMA.check_match() above should have validated 'scheme'.
     # This is a defensive check check..
     else:  # pragma: no cover
-      raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+      raise exceptions.UnsupportedAlgorithmError('Unsupported'
           ' signature scheme is specified: ' + repr(scheme))
 
   # If the PEM data could not be decrypted, or if its structure could not
   # be decoded successfully.
   except ValueError:
-    raise securesystemslib.exceptions.CryptoError('The private key'
+    raise exceptions.CryptoError('The private key'
         ' (in PEM format) could not be deserialized.')
 
   # 'TypeError' is raised if a password was given and the private key was
@@ -364,7 +364,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   # supplied.  Note: A passphrase or password is not used when generating
   # 'private_key', since it should not be encrypted.
   except TypeError:
-    raise securesystemslib.exceptions.CryptoError('The private key was'
+    raise exceptions.CryptoError('The private key was'
         ' unexpectedly encrypted.')
 
   # 'cryptography.exceptions.UnsupportedAlgorithm' is raised if the
@@ -372,7 +372,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   # the key is encrypted with a symmetric cipher that is not supported by
   # the backend.
   except cryptography.exceptions.UnsupportedAlgorithm:  # pragma: no cover
-    raise securesystemslib.exceptions.CryptoError('The private key is'
+    raise exceptions.CryptoError('The private key is'
         ' encrypted with an unsupported algorithm.')
 
   return signature, scheme
@@ -437,7 +437,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'public_key' have the correct format?
   # This check will ensure 'public_key' conforms to
@@ -479,7 +479,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
       # The RSA_SCHEME_SCHEMA.check_match() above should have validated 'scheme'.
       # This is a defensive check check..
       else:  # pragma: no cover
-        raise securesystemslib.exceptions.UnsupportedAlgorithmError('Unsupported'
+        raise exceptions.UnsupportedAlgorithmError('Unsupported'
             ' signature scheme is specified: ' + repr(signature_scheme))
 
       return True
@@ -489,7 +489,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
 
   # Raised by load_pem_public_key().
   except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as e:
-    raise securesystemslib.exceptions.CryptoError('The PEM could not be'
+    raise exceptions.CryptoError('The PEM could not be'
         ' decoded successfully, or contained an unsupported key type: ' + str(e))
 
 
@@ -540,7 +540,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # This check will ensure 'private_key' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
@@ -557,7 +557,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
       private_key = load_pem_private_key(private_key.encode('utf-8'),
           password=None, backend=default_backend())
     except ValueError:
-      raise securesystemslib.exceptions.CryptoError('The private key'
+      raise exceptions.CryptoError('The private key'
           ' (in PEM format) could not be deserialized.')
 
   else:
@@ -645,7 +645,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Does 'encryped_pem' have the correct format?
   # This check will ensure 'pem' has the appropriate number
@@ -677,7 +677,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     # Raise 'securesystemslib.exceptions.CryptoError' and pyca/cryptography's
     # exception message.  Avoid propogating pyca/cryptography's exception trace
     # to avoid revealing sensitive error.
-    raise securesystemslib.exceptions.CryptoError('RSA (public, private) tuple'
+    raise exceptions.CryptoError('RSA (public, private) tuple'
       ' cannot be generated from the encrypted PEM string: ' + str(e))
 
   # Export the public and private halves of the pyca/cryptography RSA key
@@ -768,7 +768,7 @@ def encrypt_key(key_object, password):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Do the arguments have the correct format?
   # Ensure the arguments have the appropriate number of objects and object
@@ -781,8 +781,7 @@ def encrypt_key(key_object, password):
 
   # Ensure the private portion of the key is included in 'key_object'.
   if 'private' not in key_object['keyval'] or not key_object['keyval']['private']:
-    raise securesystemslib.exceptions.FormatError('Key object does not contain'
-      ' a private part.')
+    raise exceptions.FormatError('Key object does not contain a private part.')
 
   # Derive a key (i.e., an appropriate encryption key and not the
   # user's password) from the given 'password'.  Strengthen 'password' with
@@ -873,7 +872,7 @@ def decrypt_key(encrypted_key, password):
   """
 
   if not CRYPTO: # pragma: no cover
-    raise securesystemslib.exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
+    raise exceptions.UnsupportedLibraryError(NO_CRYPTO_MSG)
 
   # Do the arguments have the correct format?
   # Ensure the arguments have the appropriate number of objects and object
@@ -1028,7 +1027,7 @@ def _decrypt(file_contents, password):
       file_contents.split(_ENCRYPTION_DELIMITER)
 
   except ValueError:
-    raise securesystemslib.exceptions.CryptoError('Invalid encrypted file.')
+    raise exceptions.CryptoError('Invalid encrypted file.')
 
   # Ensure we have the expected raw data for the delimited cryptographic data.
   salt = binascii.unhexlify(salt.encode('utf-8'))
@@ -1054,7 +1053,7 @@ def _decrypt(file_contents, password):
 
 
   if not securesystemslib.util.digests_are_equal(generated_hmac.decode(), read_hmac):
-    raise securesystemslib.exceptions.CryptoError('Decryption failed.')
+    raise exceptions.CryptoError('Decryption failed.')
 
   # Construct a Cipher object, with the key and iv.
   decryptor = Cipher(algorithms.AES(symmetric_key), modes.CTR(iv),

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -72,7 +72,8 @@ try:
   from cryptography.hazmat.backends import default_backend
 
   # Import Exception classes need to catch pyca/cryptography exceptions.
-  import cryptography.exceptions
+  from cryptography.exceptions import (
+      InvalidSignature, UnsupportedAlgorithm)
 
   # 'cryptography.hazmat.primitives.asymmetric' (i.e., pyca/cryptography's
   # public-key cryptography modules) supports algorithms like the Digital
@@ -369,7 +370,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
   # serialized key is of a type that is not supported by the backend, or if
   # the key is encrypted with a symmetric cipher that is not supported by
   # the backend.
-  except cryptography.exceptions.UnsupportedAlgorithm:  # pragma: no cover
+  except UnsupportedAlgorithm:  # pragma: no cover
     raise exceptions.CryptoError('The private key is'
         ' encrypted with an unsupported algorithm.')
 
@@ -481,11 +482,11 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
 
       return True
 
-    except cryptography.exceptions.InvalidSignature:
+    except InvalidSignature:
       return False
 
   # Raised by load_pem_public_key().
-  except (ValueError, cryptography.exceptions.UnsupportedAlgorithm) as e:
+  except (ValueError, UnsupportedAlgorithm) as e:
     raise exceptions.CryptoError('The PEM could not be'
         ' decoded successfully, or contained an unsupported key type: ' + str(e))
 
@@ -670,7 +671,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
   # Or if the key was encrypted but no password was supplied.
   # UnsupportedAlgorithm: If the private key (or if the key is encrypted with
   # an unsupported symmetric cipher) is not supported by the backend.
-  except (ValueError, TypeError, cryptography.exceptions.UnsupportedAlgorithm) as e:
+  except (ValueError, TypeError, UnsupportedAlgorithm) as e:
     # Raise 'securesystemslib.exceptions.CryptoError' and pyca/cryptography's
     # exception message.  Avoid propogating pyca/cryptography's exception trace
     # to avoid revealing sensitive error.

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -122,7 +122,7 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import formats
-import securesystemslib.hash
+from securesystemslib.hash import digest_from_rsa_scheme
 import securesystemslib.util
 
 # Extract/reference the cryptography library settings.
@@ -329,8 +329,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
     private_key_object = load_pem_private_key(private_key.encode('utf-8'),
         password=None, backend=default_backend())
 
-    digest_obj = securesystemslib.hash.digest_from_rsa_scheme(scheme,
-        'pyca_crypto')
+    digest_obj = digest_from_rsa_scheme(scheme, 'pyca_crypto')
 
     if scheme.startswith('rsassa-pss'):
       # Generate an RSSA-PSS signature.  Raise
@@ -459,8 +458,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
     public_key_object = serialization.load_pem_public_key(
         public_key.encode('utf-8'), backend=default_backend())
 
-    digest_obj = securesystemslib.hash.digest_from_rsa_scheme(signature_scheme,
-        'pyca_crypto')
+    digest_obj = digest_from_rsa_scheme(signature_scheme, 'pyca_crypto')
 
     # verify() raises 'cryptography.exceptions.InvalidSignature' if the
     # signature is invalid. 'salt_length' is set to the digest size of the

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -123,8 +123,8 @@ except ImportError:
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib import settings
+from securesystemslib import util
 from securesystemslib.hash import digest_from_rsa_scheme
-import securesystemslib.util
 
 
 # Recommended RSA key sizes:
@@ -887,7 +887,7 @@ def decrypt_key(encrypted_key, password):
   # Raise 'securesystemslib.exceptions.Error' if 'json_data' cannot be
   # deserialized to a valid 'securesystemslib.formats.ANYKEY_SCHEMA' key
   # object.
-  key_object = securesystemslib.util.load_json_string(json_data.decode())
+  key_object = util.load_json_string(json_data.decode())
 
   return key_object
 
@@ -1049,7 +1049,7 @@ def _decrypt(file_contents, password):
   generated_hmac = binascii.hexlify(generated_hmac_object.finalize())
 
 
-  if not securesystemslib.util.digests_are_equal(generated_hmac.decode(), read_hmac):
+  if not util.digests_are_equal(generated_hmac.decode(), read_hmac):
     raise exceptions.CryptoError('Decryption failed.')
 
   # Construct a Cipher object, with the key and iv.

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -122,11 +122,10 @@ except ImportError:
 
 from securesystemslib import exceptions
 from securesystemslib import formats
+from securesystemslib import settings
 from securesystemslib.hash import digest_from_rsa_scheme
 import securesystemslib.util
 
-# Extract/reference the cryptography library settings.
-import securesystemslib.settings
 
 # Recommended RSA key sizes:
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
@@ -158,7 +157,7 @@ _SALT_SIZE = 16
 # derived key+PBDKF2 combination if the key is loaded and re-saved, overriding
 # any previous iteration setting used by the old '<keyid>.key'.
 # https://en.wikipedia.org/wiki/PBKDF2
-_PBKDF2_ITERATIONS = securesystemslib.settings.PBKDF2_ITERATIONS
+_PBKDF2_ITERATIONS = settings.PBKDF2_ITERATIONS
 
 
 

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -55,7 +55,7 @@ import sys
 
 import six
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 
 
 class Schema:
@@ -77,7 +77,7 @@ class Schema:
 
     try:
       self.check_match(object)
-    except securesystemslib.exceptions.FormatError:
+    except exceptions.FormatError:
       return False
     else:
       return True
@@ -152,7 +152,7 @@ class String(Schema):
 
   def __init__(self, string):
     if not isinstance(string, six.string_types):
-      raise securesystemslib.exceptions.FormatError('Expected a string but'
+      raise exceptions.FormatError('Expected a string but'
           ' got ' + repr(string))
 
     self._string = string
@@ -160,7 +160,7 @@ class String(Schema):
 
   def check_match(self, object):
     if self._string != object:
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Expected ' + repr(self._string) + ' got ' + repr(object))
 
 
@@ -201,7 +201,7 @@ class AnyString(Schema):
 
   def check_match(self, object):
     if not isinstance(object, six.string_types):
-      raise securesystemslib.exceptions.FormatError('Expected a string'
+      raise exceptions.FormatError('Expected a string'
           ' but got ' + repr(object))
 
 
@@ -241,7 +241,7 @@ class AnyNonemptyString(AnyString):
     AnyString.check_match(self, object)
 
     if object == "":
-        raise securesystemslib.exceptions.FormatError('Expected a string'
+        raise exceptions.FormatError('Expected a string'
             ' with at least one character but got ' + repr(object))
 
 
@@ -279,7 +279,7 @@ class AnyBytes(Schema):
 
   def check_match(self, object):
     if not isinstance(object, six.binary_type):
-      raise securesystemslib.exceptions.FormatError('Expected a byte string'
+      raise exceptions.FormatError('Expected a byte string'
           ' but got ' + repr(object))
 
 
@@ -310,7 +310,7 @@ class LengthString(Schema):
     if isinstance(length, bool) or not isinstance(length, six.integer_types):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Got ' + repr(length) + ' instead of an integer.')
 
     self._string_length = length
@@ -318,11 +318,11 @@ class LengthString(Schema):
 
   def check_match(self, object):
     if not isinstance(object, six.string_types):
-      raise securesystemslib.exceptions.FormatError('Expected a string but'
+      raise exceptions.FormatError('Expected a string but'
           ' got ' + repr(object))
 
     if len(object) != self._string_length:
-      raise securesystemslib.exceptions.FormatError('Expected a string of'
+      raise exceptions.FormatError('Expected a string of'
           ' length ' + repr(self._string_length))
 
 
@@ -354,7 +354,7 @@ class LengthBytes(Schema):
     if isinstance(length, bool) or not isinstance(length, six.integer_types):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Got ' + repr(length) + ' instead of an integer.')
 
     self._bytes_length = length
@@ -362,11 +362,11 @@ class LengthBytes(Schema):
 
   def check_match(self, object):
     if not isinstance(object, six.binary_type):
-      raise securesystemslib.exceptions.FormatError('Expected a byte but'
+      raise exceptions.FormatError('Expected a byte but'
           ' got ' + repr(object))
 
     if len(object) != self._bytes_length:
-      raise securesystemslib.exceptions.FormatError('Expected a byte of'
+      raise exceptions.FormatError('Expected a byte of'
           ' length ' + repr(self._bytes_length))
 
 
@@ -404,12 +404,12 @@ class OneOf(Schema):
   def __init__(self, alternatives):
     # Ensure each item of the list contains the expected object type.
     if not isinstance(alternatives, list):
-      raise securesystemslib.exceptions.FormatError('Expected a list but'
+      raise exceptions.FormatError('Expected a list but'
           ' got ' + repr(alternatives))
 
     for alternative in alternatives:
       if not isinstance(alternative, Schema):
-        raise securesystemslib.exceptions.FormatError('List contains an'
+        raise exceptions.FormatError('List contains an'
             ' invalid item ' + repr(alternative))
 
     self._alternatives = alternatives
@@ -421,7 +421,7 @@ class OneOf(Schema):
     for alternative in self._alternatives:
       if alternative.matches(object):
         return
-    raise securesystemslib.exceptions.FormatError('Object did not match a'
+    raise exceptions.FormatError('Object did not match a'
         ' recognized alternative.')
 
 
@@ -451,12 +451,12 @@ class AllOf(Schema):
   def __init__(self, required_schemas):
     # Ensure each item of the list contains the expected object type.
     if not isinstance(required_schemas, list):
-      raise securesystemslib.exceptions.FormatError('Expected a list but'
+      raise exceptions.FormatError('Expected a list but'
           ' got' + repr(required_schemas))
 
     for schema in required_schemas:
       if not isinstance(schema, Schema):
-        raise securesystemslib.exceptions.FormatError('List contains an'
+        raise exceptions.FormatError('List contains an'
             ' invalid item ' + repr(schema))
 
     self._required_schemas = required_schemas[:]
@@ -494,7 +494,7 @@ class Boolean(Schema):
 
   def check_match(self, object):
     if not isinstance(object, bool):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Got ' + repr(object) + ' instead of a boolean.')
 
 
@@ -552,7 +552,7 @@ class ListOf(Schema):
 
     if not isinstance(schema, Schema):
       message = 'Expected Schema type but got '+repr(schema)
-      raise securesystemslib.exceptions.FormatError(message)
+      raise exceptions.FormatError(message)
 
     self._schema = schema
     self._min_count = min_count
@@ -562,7 +562,7 @@ class ListOf(Schema):
 
   def check_match(self, object):
     if not isinstance(object, (list, tuple)):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Expected object of type {} but got type {}'.format(
             self._list_name, type(object).__name__))
 
@@ -573,14 +573,14 @@ class ListOf(Schema):
       try:
         self._schema.check_match(item)
 
-      except securesystemslib.exceptions.FormatError as e:
-        raise securesystemslib.exceptions.FormatError(
+      except exceptions.FormatError as e:
+        raise exceptions.FormatError(
             str(e) + ' in ' + repr(self._list_name))
 
     # Raise exception if the number of items in the list is
     # not within the expected range.
     if not (self._min_count <= len(object) <= self._max_count):
-        raise securesystemslib.exceptions.FormatError(
+        raise exceptions.FormatError(
             'Length of ' + repr(self._list_name) + ' out of range.')
 
 
@@ -631,12 +631,12 @@ class Integer(Schema):
     if isinstance(object, bool) or not isinstance(object, six.integer_types):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Got ' + repr(object) + ' instead of an integer.')
 
     elif not (self._lo <= object <= self._hi):
       int_range = '[' + repr(self._lo) + ', ' + repr(self._hi) + '].'
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           repr(object) + ' not in range ' + int_range)
 
 
@@ -681,11 +681,11 @@ class DictOf(Schema):
     """
 
     if not isinstance(key_schema, Schema):
-      raise securesystemslib.exceptions.FormatError('Expected Schema but'
+      raise exceptions.FormatError('Expected Schema but'
           ' got ' + repr(key_schema))
 
     if not isinstance(value_schema, Schema):
-      raise securesystemslib.exceptions.FormatError('Expected Schema but'
+      raise exceptions.FormatError('Expected Schema but'
           ' got ' + repr(value_schema))
 
     self._key_schema = key_schema
@@ -694,7 +694,7 @@ class DictOf(Schema):
 
   def check_match(self, object):
     if not isinstance(object, dict):
-      raise securesystemslib.exceptions.FormatError('Expected a dict but'
+      raise exceptions.FormatError('Expected a dict but'
           ' got ' + repr(object))
 
     for key, value in six.iteritems(object):
@@ -733,7 +733,7 @@ class Optional(Schema):
 
   def __init__(self, schema):
     if not isinstance(schema, Schema):
-      raise securesystemslib.exceptions.FormatError('Expected Schema, but'
+      raise exceptions.FormatError('Expected Schema, but'
           ' got ' + repr(schema))
     self._schema = schema
 
@@ -784,7 +784,7 @@ class Object(Schema):
     # Ensure valid arguments.
     for key, schema in six.iteritems(required):
       if not isinstance(schema, Schema):
-        raise securesystemslib.exceptions.FormatError('Expected Schema but'
+        raise exceptions.FormatError('Expected Schema but'
             ' got ' + repr(schema))
 
     self._object_name = object_name
@@ -793,7 +793,7 @@ class Object(Schema):
 
   def check_match(self, object):
     if not isinstance(object, dict):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Wanted a ' + repr(self._object_name) + '.')
 
     # (key, schema) = (a, AnyString()) = (a=AnyString())
@@ -806,7 +806,7 @@ class Object(Schema):
       except KeyError:
         # If not an Optional schema, raise an exception.
         if not isinstance(schema, Optional):
-          raise securesystemslib.exceptions.FormatError(
+          raise exceptions.FormatError(
               'Missing key ' + repr(key) + ' in ' + repr(self._object_name))
 
       # Check that 'object's schema matches Object()'s schema for this
@@ -815,8 +815,8 @@ class Object(Schema):
         try:
           schema.check_match(item)
 
-        except securesystemslib.exceptions.FormatError as e:
-          raise securesystemslib.exceptions.FormatError(
+        except exceptions.FormatError as e:
+          raise exceptions.FormatError(
               str(e) + ' in ' + self._object_name + '.' + key)
 
 
@@ -896,12 +896,12 @@ class Struct(Schema):
 
     # Ensure each item of the list contains the expected object type.
     if not isinstance(sub_schemas, (list, tuple)):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Expected Schema but got ' + repr(sub_schemas))
 
     for schema in sub_schemas:
       if not isinstance(schema, Schema):
-        raise securesystemslib.exceptions.FormatError('Expected Schema but'
+        raise exceptions.FormatError('Expected Schema but'
             ' got ' + repr(schema))
 
     self._sub_schemas = sub_schemas + optional_schemas
@@ -912,15 +912,15 @@ class Struct(Schema):
 
   def check_match(self, object):
     if not isinstance(object, (list, tuple)):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Expected ' + repr(self._struct_name) + '; but got ' + repr(object))
 
     elif len(object) < self._min:
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Too few fields in ' + self._struct_name)
 
     elif len(object) > len(self._sub_schemas) and not self._allow_more:
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           'Too many fields in ' + self._struct_name)
 
     # Iterate through the items of 'object', checking against each schema in
@@ -977,12 +977,12 @@ class RegularExpression(Schema):
 
     if not isinstance(pattern, six.string_types):
       if pattern is not None:
-        raise securesystemslib.exceptions.FormatError(
+        raise exceptions.FormatError(
             repr(pattern) + ' is not a string.')
 
     if re_object is None:
       if pattern is None:
-        raise securesystemslib.exceptions.FormatError(
+        raise exceptions.FormatError(
             'Cannot compare against an unset regular expression')
 
       if not pattern.endswith('$'):
@@ -1001,7 +1001,7 @@ class RegularExpression(Schema):
 
   def check_match(self, object):
     if not isinstance(object, six.string_types) or not self._re_object.match(object):
-      raise securesystemslib.exceptions.FormatError(
+      raise exceptions.FormatError(
           repr(object) + ' did not match ' + repr(self._re_name))
 
 

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -26,7 +26,7 @@ import shutil
 
 import six
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ class FilesystemBackend(StorageBackendInterface):
         self.file_object = open(self.filepath, 'rb')
         return self.file_object
       except (FileNotFoundError, IOError):
-        raise securesystemslib.exceptions.StorageError(
+        raise exceptions.StorageError(
             "Can't open %s" % self.filepath)
 
 
@@ -247,7 +247,7 @@ class FilesystemBackend(StorageBackendInterface):
         destination_file.flush()
         os.fsync(destination_file.fileno())
     except (OSError, IOError):
-      raise securesystemslib.exceptions.StorageError(
+      raise exceptions.StorageError(
           "Can't write file %s" % filepath)
 
 
@@ -255,7 +255,7 @@ class FilesystemBackend(StorageBackendInterface):
     try:
       os.remove(filepath)
     except (FileNotFoundError, PermissionError, OSError):  # pragma: no cover
-      raise securesystemslib.exceptions.StorageError(
+      raise exceptions.StorageError(
           "Can't remove file %s" % filepath)
 
 
@@ -263,7 +263,7 @@ class FilesystemBackend(StorageBackendInterface):
     try:
       return os.path.getsize(filepath)
     except OSError:
-      raise securesystemslib.exceptions.StorageError(
+      raise exceptions.StorageError(
           "Can't access file %s" % filepath)
 
 
@@ -277,10 +277,10 @@ class FilesystemBackend(StorageBackendInterface):
       if e.errno == errno.EEXIST:
         pass
       elif e.errno == errno.ENOENT and not filepath:
-        raise securesystemslib.exceptions.StorageError(
+        raise exceptions.StorageError(
             "Can't create a folder with an empty filepath!")
       else:
-        raise securesystemslib.exceptions.StorageError(
+        raise exceptions.StorageError(
             "Can't create folder at %s" % filepath)
 
 
@@ -288,5 +288,5 @@ class FilesystemBackend(StorageBackendInterface):
     try:
       return os.listdir(filepath)
     except FileNotFoundError:
-      raise securesystemslib.exceptions.StorageError(
+      raise exceptions.StorageError(
           "Can't list folder at %s" % filepath)

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -31,7 +31,6 @@ import logging
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib.hash import digest_fileobject
-import securesystemslib.settings
 import securesystemslib.storage
 
 logger = logging.getLogger(__name__)

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -31,7 +31,7 @@ import logging
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib.hash import digest_fileobject
-import securesystemslib.storage
+from securesystemslib.storage import FilesystemBackend
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def get_file_details(filepath, hash_algorithms=['sha256'],
   formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   file_length = get_file_length(filepath, storage_backend)
   file_hashes = get_file_hashes(filepath, hash_algorithms, storage_backend)
@@ -119,7 +119,7 @@ def get_file_hashes(filepath, hash_algorithms=['sha256'],
   formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   file_hashes = {}
 
@@ -163,7 +163,7 @@ def get_file_length(filepath, storage_backend=None):
   formats.PATH_SCHEMA.check_match(filepath)
 
   if storage_backend is None:
-      storage_backend = securesystemslib.storage.FilesystemBackend()
+      storage_backend = FilesystemBackend()
 
   return storage_backend.getsize(filepath)
 
@@ -200,7 +200,7 @@ def persist_temp_file(temp_file, persist_path, storage_backend=None,
   """
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   storage_backend.put(temp_file, persist_path)
 
@@ -243,7 +243,7 @@ def ensure_parent_dir(filename, storage_backend=None):
   formats.PATH_SCHEMA.check_match(filename)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   # Split 'filename' into head and tail, check if head exists.
   directory = os.path.split(filename)[0]
@@ -421,7 +421,7 @@ def load_json_file(filepath, storage_backend=None):
   formats.PATH_SCHEMA.check_match(filepath)
 
   if storage_backend is None:
-    storage_backend = securesystemslib.storage.FilesystemBackend()
+    storage_backend = FilesystemBackend()
 
   deserialized_object = None
   with storage_backend.get(filepath) as file_obj:

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -29,9 +29,9 @@ import os
 import logging
 
 from securesystemslib import exceptions
+from securesystemslib import formats
 import securesystemslib.settings
 import securesystemslib.hash
-import securesystemslib.formats
 import securesystemslib.storage
 
 logger = logging.getLogger(__name__)
@@ -70,8 +70,8 @@ def get_file_details(filepath, hash_algorithms=['sha256'],
 
   # Making sure that the format of 'filepath' is a path string.
   # 'securesystemslib.exceptions.FormatError' is raised on incorrect format.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
-  securesystemslib.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
+  formats.PATH_SCHEMA.check_match(filepath)
+  formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
 
   if storage_backend is None:
     storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -116,8 +116,8 @@ def get_file_hashes(filepath, hash_algorithms=['sha256'],
 
   # Making sure that the format of 'filepath' is a path string.
   # 'securesystemslib.exceptions.FormatError' is raised on incorrect format.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
-  securesystemslib.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
+  formats.PATH_SCHEMA.check_match(filepath)
+  formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
 
   if storage_backend is None:
     storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -132,7 +132,7 @@ def get_file_hashes(filepath, hash_algorithms=['sha256'],
 
   # Performing a format check to ensure 'file_hash' corresponds HASHDICT_SCHEMA.
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-  securesystemslib.formats.HASHDICT_SCHEMA.check_match(file_hashes)
+  formats.HASHDICT_SCHEMA.check_match(file_hashes)
 
   return file_hashes
 
@@ -161,7 +161,7 @@ def get_file_length(filepath, storage_backend=None):
 
   # Making sure that the format of 'filepath' is a path string.
   # 'securesystemslib.exceptions.FormatError' is raised on incorrect format.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   if storage_backend is None:
       storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -241,7 +241,7 @@ def ensure_parent_dir(filename, storage_backend=None):
 
   # Ensure 'filename' corresponds to 'PATH_SCHEMA'.
   # Raise 'securesystemslib.exceptions.FormatError' on a mismatch.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filename)
+  formats.PATH_SCHEMA.check_match(filename)
 
   if storage_backend is None:
     storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -279,8 +279,8 @@ def file_in_confined_directories(filepath, confined_directories):
 
   # Do the arguments have the correct format?
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
-  securesystemslib.formats.NAMES_SCHEMA.check_match(confined_directories)
+  formats.PATH_SCHEMA.check_match(filepath)
+  formats.NAMES_SCHEMA.check_match(confined_directories)
 
   for confined_directory in confined_directories:
     # The empty string (arbitrarily chosen) signifies the client is confined
@@ -419,7 +419,7 @@ def load_json_file(filepath, storage_backend=None):
 
   # Making sure that the format of 'filepath' is a path string.
   # securesystemslib.exceptions.FormatError is raised on incorrect format.
-  securesystemslib.formats.PATH_SCHEMA.check_match(filepath)
+  formats.PATH_SCHEMA.check_match(filepath)
 
   if storage_backend is None:
     storage_backend = securesystemslib.storage.FilesystemBackend()
@@ -466,8 +466,8 @@ def digests_are_equal(digest1, digest2):
   # Ensure the arguments have the appropriate number of objects and object
   # types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-  securesystemslib.formats.HEX_SCHEMA.check_match(digest1)
-  securesystemslib.formats.HEX_SCHEMA.check_match(digest2)
+  formats.HEX_SCHEMA.check_match(digest1)
+  formats.HEX_SCHEMA.check_match(digest2)
 
   if len(digest1) != len(digest2):
     return False

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -28,7 +28,7 @@ from __future__ import unicode_literals
 import os
 import logging
 
-import securesystemslib.exceptions
+from securesystemslib import exceptions
 import securesystemslib.settings
 import securesystemslib.hash
 import securesystemslib.formats
@@ -377,11 +377,11 @@ def load_json_string(data):
 
   except TypeError:
     message = 'Invalid JSON string: ' + repr(data)
-    raise securesystemslib.exceptions.Error(message)
+    raise exceptions.Error(message)
 
   except ValueError:
     message = 'Cannot deserialize to a Python object: ' + repr(data)
-    raise securesystemslib.exceptions.Error(message)
+    raise exceptions.Error(message)
 
   else:
     return deserialized_object
@@ -432,7 +432,7 @@ def load_json_file(filepath, storage_backend=None):
       deserialized_object = json.loads(raw_data)
 
     except (ValueError, TypeError):
-      raise securesystemslib.exceptions.Error('Cannot deserialize to a'
+      raise exceptions.Error('Cannot deserialize to a'
           ' Python object: ' + filepath)
 
     else:

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -30,8 +30,8 @@ import logging
 
 from securesystemslib import exceptions
 from securesystemslib import formats
+from securesystemslib.hash import digest_fileobject
 import securesystemslib.settings
-import securesystemslib.hash
 import securesystemslib.storage
 
 logger = logging.getLogger(__name__)
@@ -127,7 +127,7 @@ def get_file_hashes(filepath, hash_algorithms=['sha256'],
   with storage_backend.get(filepath) as fileobj:
     # Obtaining hash of the file.
     for algorithm in hash_algorithms:
-      digest_object = securesystemslib.hash.digest_fileobject(fileobj, algorithm)
+      digest_object = digest_fileobject(fileobj, algorithm)
       file_hashes.update({algorithm: digest_object.hexdigest()})
 
   # Performing a format check to ensure 'file_hash' corresponds HASHDICT_SCHEMA.


### PR DESCRIPTION
This is a sister PR for https://github.com/theupdateframework/tuf/pull/1261: it modifies all imports in securesystemlibs to be compatible with vendoring tool (see TUF PR for explanation).

Notes
* Multiple solutions were used, but usually the module was directly imported into scope (so instead of referring to `securesystemslib.settings` code now refers to `settings`). In some cases this individual items from the module are imported instead
* I've tried very hard to ensure no namespace conflicts happen by grepping for every new top level name
* This is still a draft: I have yet to test that vendoring actually works with this
* The change is surprisingly large, >500 lines