### PR TITLE
Prepare Debian downstream release 0.18.0-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+python-securesystemslib (0.18.0-2) unstable; urgency=medium
+
+  Fix misc lintian warnings and other Debian metadata changes:
+
+  * d/watch:
+    - update to latest version 4 (fix older-debian-watch-file-standard)
+    - add missing trailing newline
+  * d/patches/01_use_python3_interpreter_in_tests.diff:
+    - add "Forwarded: not-needed" header field for downstream-only patch
+      (fix patch-not-forwarded-upstream)
+  * d/control:
+    - specify upstream tracking branch for downstream-related changes
+    - use correct section according to package name, i.e. "python"
+      (fix wrong-section-according-to-package-name)
+  * d/upstream/metadata:
+    - add basic metadata file (fix upstream-metadata-file-is-missing)
+  * d/copyright:
+    - add Upstream-Contact field
+    - remove duplicate License field
+    - use lower-maintenance first publication date instead of date range
+  * d/changelog:
+    - amend 0.18.0-1 entry to mention upstream signing key change
+
+ -- Lukas Puehringer <lukas.puehringer@nyu.edu>  Tue, 02 Feb 2021 10:55:52 +0200
+
 python-securesystemslib (0.18.0-1) unstable; urgency=medium
 
   * New upstream release includes among other things:
@@ -9,6 +34,8 @@ python-securesystemslib (0.18.0-1) unstable; urgency=medium
     - remove obsolete python-dateutil dependency,
     - bump standards version to 4.5.1,
     - and compat to 13.
+
+  * Update d/upstream/signing-key.asc
 
  -- Lukas Puehringer <lukas.puehringer@nyu.edu>  Wed, 09 Dec 2020 08:44:34 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: python-securesystemslib
-Section: utils
+Section: python
 Priority: optional
 Maintainer: NYU Secure Systems Lab <securesystemslib-dev@googlegroups.com>
 Uploaders:
@@ -21,7 +21,7 @@ Build-Depends:
 Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Homepage: https://ssl.engineering.nyu.edu
-Vcs-Git: https://github.com/secure-systems-lab/securesystemslib.git
+Vcs-Git: https://github.com/secure-systems-lab/securesystemslib.git -b debian
 Vcs-Browser: https://github.com/secure-systems-lab/securesystemslib/
 
 Package: python3-securesystemslib

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,11 +1,10 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: securesystemslib
+Upstream-Contact: NYU Secure Systems Lab <securesystemslib-dev@googlegroups.com>
 Source: https://github.com/secure-systems-lab/securesystemslib
 
 Files: *
-Copyright: 2015-2017 New York University 
-License: MIT
-
+Copyright: 2016 New York University
 License: MIT
  .
  The MIT License (MIT)

--- a/debian/patches/01_use_python3_interpreter_in_tests.diff
+++ b/debian/patches/01_use_python3_interpreter_in_tests.diff
@@ -4,6 +4,7 @@ Description: Use python3 in tests
  available during build and thus makes those tests fail. This patch replaces
  "python" with "python3" where applicable.
 Author: Lukas Puehringer <lukas.puehringer@nyu.edu>
+Forwarded: not-needed
 
 --- python-securesystemslib-0.16.0.orig/tests/test_process.py
 +++ python-securesystemslib-0.16.0/tests/test_process.py

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,6 @@
+Bug-Database: https://github.com/secure-systems-lab/securesystemslib/issues
+Bug-Submit: https://github.com/secure-systems-lab/securesystemslib/issues
+Changelog: https://github.com/secure-systems-lab/securesystemslib/blob/master/CHANGELOG.md
+Documentation: https://github.com/secure-systems-lab/securesystemslib/blob/master/README.rst
+Repository: https://github.com/secure-systems-lab/securesystemslib.git
+Repository-Browse: https://github.com/secure-systems-lab/securesystemslib

--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
-version=3
+version=4
 opts=uversionmangle=s/(rc|a|b|c)/~$1/,pgpsigurlmangle=s/$/.asc/ \
 https://pypi.debian.net/securesystemslib/securesystemslib-(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))


### PR DESCRIPTION
  Fix misc lintian warnings and other Debian metadata changes:

  * d/watch:
    - update to latest version 4 (fix older-debian-watch-file-standard)
    - add missing trailing newline
  * d/patches/01_use_python3_interpreter_in_tests.diff:
    - add "Forwarded: not-needed" header field for downstream-only patch
      (fix patch-not-forwarded-upstream)
  * d/control:
    - specify upstream tracking branch for downstream-related changes
    - use correct section according to package name, i.e. "python"
      (fix wrong-section-according-to-package-name)
  * d/upstream/metadata:
    - add basic metadata file (fix upstream-metadata-file-is-missing)
  * d/copyright:
    - add Upstream-Contact field
    - remove duplicate License field
    - use lower-maintenance first publication date instead of date range
  * d/changelog:
    - amend 0.18.0-1 entry to mention upstream signing key change

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>


