### PR TITLE
Pin cryptography 3.3.x on python2

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,6 +1,6 @@
 cffi==1.14.4              # via cryptography, pynacl
 colorama==0.4.4
-cryptography==3.3.1
+cryptography==3.4.3
 enum34==1.1.10            ; python_version < "3" # via cryptography
 ipaddress==1.0.23         ; python_version < "3" # via cryptography
 pycparser==2.20           # via cffi

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,6 +1,7 @@
 cffi==1.14.4              # via cryptography, pynacl
 colorama==0.4.4
-cryptography==3.4.3
+cryptography==3.3.2       ; python_version < "3"
+cryptography==3.4.3       ; python_version >= "3"
 enum34==1.1.10            ; python_version < "3" # via cryptography
 ipaddress==1.0.23         ; python_version < "3" # via cryptography
 pycparser==2.20           # via cffi

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,7 +1,7 @@
 cffi==1.14.4              # via cryptography, pynacl
 colorama==0.4.4
-cryptography==3.3.2       ; python_version < "3"
-cryptography==3.4.3       ; python_version >= "3"
+cryptography==3.3.2       ; python_version < "3" # cryptography < 3.4 for python2 compat
+cryptography==3.4.4       ; python_version >= "3"
 enum34==1.1.10            ; python_version < "3" # via cryptography
 ipaddress==1.0.23         ; python_version < "3" # via cryptography
 pycparser==2.20           # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@
 # 3. Use this command to remove per-version files
 #    `rm requirements-?.?.txt`
 #
-cryptography
+cryptography; python_version >= '3'
+cryptography < 3.4; python_version < '3'
 pynacl
 colorama
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@
 # 3. Use this command to remove per-version files
 #    `rm requirements-?.?.txt`
 #
-cryptography; python_version >= '3'
-cryptography < 3.4; python_version < '3'
+cryptography >= 3.3.2; python_version >= '3'
+cryptography >= 3.3.2, < 3.4; python_version < '3'
 pynacl
 colorama
 six

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ setup(
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],
-      'crypto': ['cryptography>=2.6'],
+      'crypto:python_version < "3"': ['cryptography>=2.6,<3.4'],
+      'crypto:python_version >= "3"': ['cryptography>=2.6'],
       'pynacl': ['pynacl>1.2.0']},
   tests_require = 'mock; python_version < "3.3"',
   packages = find_packages(exclude=['tests', 'debian']),

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,8 @@ setup(
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],
-      'crypto:python_version < "3"': ['cryptography>=2.6,<3.4'],
-      'crypto:python_version >= "3"': ['cryptography>=2.6'],
+      'crypto:python_version < "3"': ['cryptography>=3.3.2,<3.4'],
+      'crypto:python_version >= "3"': ['cryptography>=3.3.2'],
       'pynacl': ['pynacl>1.2.0']},
   tests_require = 'mock; python_version < "3.3"',
   packages = find_packages(exclude=['tests', 'debian']),


### PR DESCRIPTION
cryptography no longer supports python2: Before we drop python2 support let's pin the cryptography version -- but only for python2.

This includes #321.

I have no idea what dependabot really does when it runs so **don't know if this could break dependabot or not** -- the example script in requirements.txt does not seem to quite match what dependabot must be doing as pip-compile now produces multiline annotations which breaks the sorting in the example script...

Is there a way to test dependabot somehow?