### PR TITLE
CI: Limit build-on-push to master branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Run Securesystemslib tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Dependabot pushes to main repository and ends up triggering two builds
every time (one for PR, one for push): limit the rule for build-on-push
to apply to master branch only.

If release branches are used later on they should be added to list here.

---

This was already done in TUF: we can wait for dependabot to react to the daily cryptography release (sigh) to see if the TUF version works correctly before merging this...