### PR TITLE
CI: Add a name to ed25519 check workflow

### DIFF
--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -1,8 +1,9 @@
+name: Look for changes in ed25519 upstream
+
 on:
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
-
 
 jobs:
   check-ed25519-upstream:


### PR DESCRIPTION
Now that there are multiple workflows, a name is useful in the UI.
