### PR TITLE
signer: Add self to abstract method signature

### DIFF
--- a/securesystemslib/signer.py
+++ b/securesystemslib/signer.py
@@ -66,7 +66,7 @@ class Signer:
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def sign(payload: bytes) -> "Signature":
+    def sign(self, payload: bytes) -> "Signature":
         """Signs a given payload by the key assigned to the Signer instance.
 
         Arguments:


### PR DESCRIPTION
The actual implementation is correct, the abc is missing 'self'.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


