### PR TITLE
Start to drop Python 2.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,3 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: cryptography
-    versions:
-    - 3.4.1
-    - 3.4.3
-    - 3.4.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,12 @@ jobs:
       fail-fast: false
       # Run tests on each OS/Python combination
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         # TODO: Add windows-latest when gpg issues are solved
         os: [ubuntu-latest, macos-latest]
         toxenv: [py]
 
         include:
-          - python-version: 2.7
-            os: ubuntu-latest
-            toxenv: purepy27
-          - python-version: 2.7
-            os: ubuntu-latest
-            toxenv: py27-no-gpg
           - python-version: 3.8
             os: ubuntu-latest
             toxenv: purepy38

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,3 +1,2 @@
 # Minimal runtime requirements (see 'install_requires' in setup.py)
 six
-subprocess32; python_version < '3'

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,10 +1,6 @@
 cffi==1.14.5              # via cryptography, pynacl
 colorama==0.4.4
-cryptography==3.3.2       ; python_version < "3" # cryptography < 3.4 for python2 compat
-cryptography==3.4.7       ; python_version >= "3"
-enum34==1.1.10            ; python_version < "3" # via cryptography
-ipaddress==1.0.23         ; python_version < "3" # via cryptography
+cryptography==3.4.7
 pycparser==2.20           # via cffi
 pynacl==1.4.0
 six==1.15.0
-subprocess32==3.5.4       ; python_version < "3"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,2 @@
-# test runtime dependencies  (see 'tests_require' field in setup.py)
-mock; python_version < "3.3"
-
 # additional test tools
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,6 @@
 #    `rm requirements-?.?.txt`
 #
 cryptography >= 3.3.2; python_version >= '3'
-cryptography >= 3.3.2, < 3.4; python_version < '3'
 pynacl
 colorama
 six
-subprocess32; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # 1. Use this script to create a pinned requirements file for each Python
 #    version
 # ```
-# for v in 2.7 3.6 3.7 3.8 3.9; do
+# for v in 3.6 3.7 3.8 3.9; do
 #   mkvirtualenv sslib-env-${v} -p python${v};
 #   pip install pip-tools;
 #   pip-compile --no-header -o requirements-${v}.txt requirements.txt;

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,6 @@ setup(
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
@@ -103,7 +101,7 @@ setup(
     'Source': 'https://github.com/secure-systems-lab/securesystemslib',
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
-  python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
+  python_requires = "~=3.6",
   install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],

--- a/setup.py
+++ b/setup.py
@@ -102,13 +102,11 @@ setup(
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
   python_requires = "~=3.6",
-  install_requires = ['six>=1.11.0', 'subprocess32; python_version < "3"'],
+  install_requires = ['six>=1.11.0'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],
-      'crypto:python_version < "3"': ['cryptography>=3.3.2,<3.5'],
-      'crypto:python_version >= "3"': ['cryptography>=3.3.2'],
+      'crypto': ['cryptography>=3.3.2'],
       'pynacl': ['pynacl>1.2.0']},
-  tests_require = 'mock; python_version < "3.3"',
   packages = find_packages(exclude=['tests', 'debian']),
   scripts = []
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36, py37, py38, py39, purepy27, purepy38, py27-no-gpg, py38-no-gpg
+envlist = py36, py37, py38, py39, purepy38, py38-no-gpg
 skipsdist = True
 
 [testenv]
@@ -19,26 +19,12 @@ commands =
     coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 97
 
-[testenv:purepy27]
-deps =
-    -r{toxinidir}/requirements-min.txt
-    -r{toxinidir}/requirements-test.txt
-
-commands =
-    python -m tests.check_public_interfaces
-
 [testenv:purepy38]
 deps =
     -r{toxinidir}/requirements-min.txt
 
 commands =
     python -m tests.check_public_interfaces
-
-[testenv:py27-no-gpg]
-setenv =
-    GNUPG = nonexisting-gpg-for-testing
-commands =
-    python -m tests.check_public_interfaces_gpg
 
 [testenv:py38-no-gpg]
 setenv =


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #

### Description of the changes being introduced by the pull request:

This is a first PR towards removing Python 2.7 from the code base, it is not sufficient but it does remove enough pieces that people will not be tempted to think we are still supporting Python 2.7 **and** starts getting us newer versions of cryptography via dependabot.

For more detail on what else needs to be removed, see https://github.com/secure-systems-lab/securesystemslib/issues/344

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


