### PR TITLE
Remove the use of six and __future__ 

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Build-Depends:
  python3-cryptography,
  python3-colorama,
  python3-mock,
- python3-six,
  gnupg2,
 Standards-Version: 4.5.1
 Rules-Requires-Root: no

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,2 +1,0 @@
-# Minimal runtime requirements (see 'install_requires' in setup.py)
-six

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -3,4 +3,3 @@ colorama==0.4.4
 cryptography==3.4.7
 pycparser==2.20           # via cffi
 pynacl==1.4.0
-six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,3 @@
 cryptography >= 3.3.2; python_version >= '3'
 pynacl
 colorama
-six

--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -28,14 +28,6 @@
   be viewed as an easy-to-use public interface.
  """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 
 # Import cryptography modules to support ecdsa keys and signatures.

--- a/securesystemslib/ed25519_keys.py
+++ b/securesystemslib/ed25519_keys.py
@@ -43,14 +43,6 @@
   listed above can be viewed as an easy-to-use public interface.
  """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 # 'os' required to generate OS-specific randomness (os.urandom) suitable for
 # cryptographic use.
 # http://docs.python.org/2/library/os.html#miscellaneous-functions

--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -17,16 +17,6 @@
   'Error' (except where there is a good reason not to).
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
-
-
 class Error(Exception):
   """Indicate a generic error."""
   pass

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -63,14 +63,6 @@
   signable_object = make_signable(unsigned_object)
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import binascii
 import calendar
 import re

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -68,7 +68,6 @@ import calendar
 import re
 import datetime
 import time
-import six
 
 from securesystemslib import exceptions
 from securesystemslib import schema as SCHEMA
@@ -573,7 +572,7 @@ def parse_base64(base64_string):
     'base64_string'.
   """
 
-  if not isinstance(base64_string, six.string_types):
+  if not isinstance(base64_string, str):
     message = 'Invalid argument: '+repr(base64_string)
     raise exceptions.FormatError(message)
 
@@ -620,7 +619,7 @@ def _encode_canonical(object, output_function):
   # Helper for encode_canonical.  Older versions of json.encoder don't
   # even let us replace the separators.
 
-  if isinstance(object, six.string_types):
+  if isinstance(object, str):
     output_function(_canonical_string_encoder(object))
   elif object is True:
     output_function("true")
@@ -628,7 +627,7 @@ def _encode_canonical(object, output_function):
     output_function("false")
   elif object is None:
     output_function("null")
-  elif isinstance(object, six.integer_types):
+  elif isinstance(object, int):
     output_function(str(object))
   elif isinstance(object, (tuple, list)):
     output_function("[")
@@ -641,7 +640,7 @@ def _encode_canonical(object, output_function):
   elif isinstance(object, dict):
     output_function("{")
     if len(object):
-      items = sorted(six.iteritems(object))
+      items = sorted(object.items())
       for key, value in items[:-1]:
         output_function(_canonical_string_encoder(key))
         output_function(":")

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -24,8 +24,6 @@
 
 import hashlib
 
-import six
-
 from securesystemslib import exceptions
 from securesystemslib import formats
 from securesystemslib.storage import FilesystemBackend
@@ -297,7 +295,7 @@ def digest_fileobject(file_object, algorithm=DEFAULT_HASH_ALGORITHM,
           .replace(b'\r', b'\n')
       )
 
-    if not isinstance(data, six.binary_type):
+    if not isinstance(data, bytes):
       digest_object.update(data.encode('utf-8'))
 
     else:

--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -22,14 +22,6 @@
   pyca/cryptography support will be added in the future.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import hashlib
 
 import six

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -20,14 +20,6 @@
   'securesystemslib/README' for the complete guide to using 'interface.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import sys
 import getpass

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -47,14 +47,6 @@
   key (i.e., rsakey['keyid']).
  """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 # Required for hexadecimal conversions.  Signatures and public/private keys are
 # hexlified.
 import binascii

--- a/securesystemslib/process.py
+++ b/securesystemslib/process.py
@@ -16,7 +16,6 @@
 <Purpose>
   Provide a common interface for Python's subprocess module to:
 
-  - require the Py3 subprocess backport `subprocess32` on Python2,
   - namespace subprocess constants (DEVNULL, PIPE) and
   - provide a custom `subprocess.run` wrapper
   - provide a special `run_duplicate_streams` function
@@ -29,12 +28,7 @@ import tempfile
 import logging
 import time
 import shlex
-import six
-
-if six.PY2:
-  import subprocess32 as subprocess # pragma: no cover pylint: disable=import-error
-else: # pragma: no cover
-  import subprocess
+import subprocess
 
 from securesystemslib import formats
 from securesystemslib import settings
@@ -111,7 +105,7 @@ def run(cmd, check=True, timeout=_default_timeout(), **kwargs):
 
   """
   # Make list of command passed as string for convenience
-  if isinstance(cmd, six.string_types):
+  if isinstance(cmd, str):
     cmd = shlex.split(cmd)
   else:
     formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
@@ -170,7 +164,7 @@ def run_duplicate_streams(cmd, timeout=_default_timeout()):
     contents.
 
   """
-  if isinstance(cmd, six.string_types):
+  if isinstance(cmd, str):
     cmd = shlex.split(cmd)
   else:
     formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -50,14 +50,6 @@
   Key Derivation Function 1 (PBKF1) + MD5.
  """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import binascii
 import json

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -42,14 +42,6 @@
   objects and their formats can be found in 'formats.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import re
 import sys
 

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -45,8 +45,6 @@
 import re
 import sys
 
-import six
-
 from securesystemslib import exceptions
 
 
@@ -143,7 +141,7 @@ class String(Schema):
   """
 
   def __init__(self, string):
-    if not isinstance(string, six.string_types):
+    if not isinstance(string, str):
       raise exceptions.FormatError('Expected a string but'
           ' got ' + repr(string))
 
@@ -192,7 +190,7 @@ class AnyString(Schema):
 
 
   def check_match(self, object):
-    if not isinstance(object, six.string_types):
+    if not isinstance(object, str):
       raise exceptions.FormatError('Expected a string'
           ' but got ' + repr(object))
 
@@ -270,7 +268,7 @@ class AnyBytes(Schema):
 
 
   def check_match(self, object):
-    if not isinstance(object, six.binary_type):
+    if not isinstance(object, bytes):
       raise exceptions.FormatError('Expected a byte string'
           ' but got ' + repr(object))
 
@@ -299,7 +297,7 @@ class LengthString(Schema):
   """
 
   def __init__(self, length):
-    if isinstance(length, bool) or not isinstance(length, six.integer_types):
+    if isinstance(length, bool) or not isinstance(length, int):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
       raise exceptions.FormatError(
@@ -309,7 +307,7 @@ class LengthString(Schema):
 
 
   def check_match(self, object):
-    if not isinstance(object, six.string_types):
+    if not isinstance(object, str):
       raise exceptions.FormatError('Expected a string but'
           ' got ' + repr(object))
 
@@ -343,7 +341,7 @@ class LengthBytes(Schema):
   """
 
   def __init__(self, length):
-    if isinstance(length, bool) or not isinstance(length, six.integer_types):
+    if isinstance(length, bool) or not isinstance(length, int):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
       raise exceptions.FormatError(
@@ -353,7 +351,7 @@ class LengthBytes(Schema):
 
 
   def check_match(self, object):
-    if not isinstance(object, six.binary_type):
+    if not isinstance(object, bytes):
       raise exceptions.FormatError('Expected a byte but'
           ' got ' + repr(object))
 
@@ -620,7 +618,7 @@ class Integer(Schema):
 
 
   def check_match(self, object):
-    if isinstance(object, bool) or not isinstance(object, six.integer_types):
+    if isinstance(object, bool) or not isinstance(object, int):
       # We need to check for bool as a special case, since bool
       # is for historical reasons a subtype of int.
       raise exceptions.FormatError(
@@ -689,7 +687,7 @@ class DictOf(Schema):
       raise exceptions.FormatError('Expected a dict but'
           ' got ' + repr(object))
 
-    for key, value in six.iteritems(object):
+    for key, value in object.items():
       self._key_schema.check_match(key)
       self._value_schema.check_match(value)
 
@@ -774,7 +772,7 @@ class Object(Schema):
     """
 
     # Ensure valid arguments.
-    for key, schema in six.iteritems(required):
+    for key, schema in required.items():
       if not isinstance(schema, Schema):
         raise exceptions.FormatError('Expected Schema but'
             ' got ' + repr(schema))
@@ -967,7 +965,7 @@ class RegularExpression(Schema):
       re_name: Identifier for the regular expression object.
     """
 
-    if not isinstance(pattern, six.string_types):
+    if not isinstance(pattern, str):
       if pattern is not None:
         raise exceptions.FormatError(
             repr(pattern) + ' is not a string.')
@@ -992,7 +990,7 @@ class RegularExpression(Schema):
 
 
   def check_match(self, object):
-    if not isinstance(object, six.string_types) or not self._re_object.match(object):
+    if not isinstance(object, str) or not self._re_object.match(object):
       raise exceptions.FormatError(
           repr(object) + ' did not match ' + repr(self._re_name))
 

--- a/securesystemslib/settings.py
+++ b/securesystemslib/settings.py
@@ -17,15 +17,6 @@
   Store all crypto-related settings used by securesystemslib.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
-
 # Set a directory that should be used for all temporary files. If this
 # is None, then the system default will be used. The system default
 # will also be used if a directory path set here is invalid or

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -21,15 +21,9 @@ import logging
 import os
 import shutil
 
-import six
-
 from securesystemslib import exceptions
 
 logger = logging.getLogger(__name__)
-
-if six.PY2:
-  FileNotFoundError = OSError # pragma: no cover
-
 
 
 class StorageBackendInterface():

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -15,9 +15,6 @@
   Provides an interface for filesystem interactions, StorageBackendInterface.
 """
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import abc
 import errno
 import logging

--- a/securesystemslib/unittest_toolbox.py
+++ b/securesystemslib/unittest_toolbox.py
@@ -17,14 +17,6 @@
   Specifically, Modified_TestCase is a derived class from unittest.TestCase.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import shutil
 import unittest

--- a/securesystemslib/util.py
+++ b/securesystemslib/util.py
@@ -17,14 +17,6 @@
   that tries to import a working json module, load_json_* functions, etc.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
   python_requires = "~=3.6",
-  install_requires = ['six>=1.11.0'],
   extras_require = {
       'colors': ['colorama>=0.3.9'],
       'crypto': ['cryptography>=3.3.2'],

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -23,14 +23,6 @@
   'securesystemslib/tests'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import sys
 import unittest
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -29,9 +29,6 @@
   when explicitly invoked.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 import inspect
 import json
 import os

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -23,6 +23,7 @@
   run when explicitly invoked.
 
 """
+
 import unittest
 from securesystemslib.gpg.constants import HAVE_GPG, NO_GPG_MSG
 from securesystemslib.gpg.util import get_version

--- a/tests/test_ecdsa_keys.py
+++ b/tests/test_ecdsa_keys.py
@@ -17,14 +17,6 @@
   Test cases for test_ecdsa_keys.py.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import os
 

--- a/tests/test_ed25519_keys.py
+++ b/tests/test_ed25519_keys.py
@@ -17,14 +17,6 @@
   Test cases for test_ed25519_keys.py.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import os
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,14 +17,6 @@
   Test cases for exceptions.py (mainly the exceptions defined there).
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import logging
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -23,8 +23,6 @@ import datetime
 import securesystemslib.formats
 import securesystemslib.schema
 
-import six
-
 
 class TestFormats(unittest.TestCase):
   def setUp(self):
@@ -170,7 +168,7 @@ class TestFormats(unittest.TestCase):
 
     # Iterate 'valid_schemas', ensuring each 'valid_schema' correctly matches
     # its respective 'schema_type'.
-    for schema_name, (schema_type, valid_schema) in six.iteritems(valid_schemas):
+    for schema_name, (schema_type, valid_schema) in valid_schemas.items():
       if not schema_type.matches(valid_schema):
         print('bad schema: ' + repr(valid_schema))
 
@@ -179,7 +177,7 @@ class TestFormats(unittest.TestCase):
     # Test conditions for invalid schemas.
     # Set the 'valid_schema' of 'valid_schemas' to an invalid
     # value and test that it does not match 'schema_type'.
-    for schema_name, (schema_type, valid_schema) in six.iteritems(valid_schemas):
+    for schema_name, (schema_type, valid_schema) in valid_schemas.items():
       invalid_schema = 0xBAD
 
       if isinstance(schema_type, securesystemslib.schema.Integer):
@@ -234,7 +232,7 @@ class TestFormats(unittest.TestCase):
     self.assertEqual('dXBkYXRlZnJhbWV3b3Jr',
         securesystemslib.formats.format_base64(data))
     self.assertTrue(isinstance(securesystemslib.formats.format_base64(data),
-        six.string_types))
+        str))
 
     # Test conditions for invalid arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,
@@ -251,7 +249,7 @@ class TestFormats(unittest.TestCase):
     self.assertEqual(b'updateframework',
         securesystemslib.formats.parse_base64(base64))
     self.assertTrue(isinstance(securesystemslib.formats.parse_base64(base64),
-        six.binary_type))
+        bytes))
 
     # Test conditions for invalid arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -17,14 +17,6 @@
   Unit test for 'formats.py'
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import datetime
 

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -30,7 +30,6 @@ if sys.version_info >= (3, 3):
 else:
   from mock import patch # pylint: disable=import-error
 
-from six import string_types
 from copy import deepcopy
 from collections import OrderedDict
 
@@ -65,7 +64,7 @@ class TestUtil(unittest.TestCase):
   """Test util functions. """
   def test_version_utils_return_types(self):
     """Run dummy tests for coverage. """
-    self.assertTrue(isinstance(get_version(), string_types))
+    self.assertTrue(isinstance(get_version(), str))
     self.assertTrue(isinstance(is_version_fully_supported(), bool))
 
   def test_get_hashing_class(self):

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -18,6 +18,7 @@
   Unit test for 'hash.py'.
 """
 
+import io
 import os
 import logging
 import sys
@@ -26,8 +27,6 @@ import unittest
 
 import securesystemslib.exceptions
 import securesystemslib.hash
-
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +250,7 @@ class TestHash(unittest.TestCase):
 
   def _do_update_file_obj(self, library, algorithm):
     data = 'abcdefgh' * 4096
-    file_obj = six.StringIO()
+    file_obj = io.StringIO()
     file_obj.write(data)
     digest_object_truth = securesystemslib.hash.digest(algorithm, library)
     digest_object_truth.update(data.encode('utf-8'))

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -18,14 +18,6 @@
   Unit test for 'hash.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import sys

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -17,14 +17,6 @@
   Unit test for 'interface.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import datetime

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -17,14 +17,6 @@
   Test cases for test_keys.py.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import copy
 

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -17,14 +17,6 @@
   Test cases for 'rsa_keys.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 
 import securesystemslib.exceptions

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,14 +17,6 @@
   Unit test for 'schema.py'
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import re
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,14 +15,6 @@
   Unit test for 'storage.py'
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -23,8 +23,6 @@ import unittest
 import securesystemslib.exceptions
 import securesystemslib.storage
 
-import six
-
 
 class TestStorage(unittest.TestCase):
   def setUp(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,14 +17,6 @@
   Unit test for 'util.py'
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import sys
 import shutil

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,8 +30,6 @@ import securesystemslib.hash
 import securesystemslib.util
 import securesystemslib.unittest_toolbox as unittest_toolbox
 
-import six
-
 logger = logging.getLogger(__name__)
 
 
@@ -68,7 +66,7 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
         {'a': 'b'}, None]
 
     for bogus_input in bogus_inputs:
-      if isinstance(bogus_input, six.string_types):
+      if isinstance(bogus_input, str):
         self.assertRaises(securesystemslib.exceptions.Error,
             securesystemslib.util.get_file_details, bogus_input)
       else:
@@ -96,7 +94,7 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
         {'a': 'b'}, None]
 
     for bogus_input in bogus_inputs:
-      if isinstance(bogus_input, six.string_types):
+      if isinstance(bogus_input, str):
         self.assertRaises(securesystemslib.exceptions.Error,
             securesystemslib.util.get_file_hashes, bogus_input)
       else:
@@ -123,7 +121,7 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
         {'a': 'b'}, None]
 
     for bogus_input in bogus_inputs:
-      if isinstance(bogus_input, six.string_types):
+      if isinstance(bogus_input, str):
         self.assertRaises(securesystemslib.exceptions.Error,
             securesystemslib.util.get_file_length, bogus_input)
       else:
@@ -137,7 +135,7 @@ class TestUtil(unittest_toolbox.Modified_TestCase):
     non_existing_parent_dir = os.path.join(existing_parent_dir, 'a', 'b')
 
     for parent_dir in [existing_parent_dir, non_existing_parent_dir, 12, [3]]:
-      if isinstance(parent_dir, six.string_types):
+      if isinstance(parent_dir, str):
         securesystemslib.util.ensure_parent_dir(os.path.join(parent_dir, 'a.txt'))
         self.assertTrue(os.path.isdir(parent_dir))
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,7 @@ commands =
     coverage report -m --fail-under 97
 
 [testenv:purepy38]
-deps =
-    -r{toxinidir}/requirements-min.txt
+deps = 
 
 commands =
     python -m tests.check_public_interfaces


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #353 
Fixes: #354

### Description of the changes being introduced by the pull request:

Since the project no longer supports Python2, imports of `six` and `__future__` are no longer needed.


### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


