### PR TITLE
Type annotate storage

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 warn_unused_configs = True
-files = securesystemslib/util.py
+files =
+    securesystemslib/util.py,
+    securesystemslib/storage.py
+
 # Supress error messages until enough modules
 # are type annotated
 follow_imports = silent

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -200,7 +200,7 @@ class FilesystemBackend(StorageBackendInterface):
     try:
       file_object = open(filepath, 'rb')
       yield file_object
-    except (FileNotFoundError, IOError):
+    except OSError:
       raise exceptions.StorageError(
           "Can't open %s" % filepath)
     finally:
@@ -221,7 +221,7 @@ class FilesystemBackend(StorageBackendInterface):
         # and the operating system's buffers.  os.fsync() should follow flush().
         destination_file.flush()
         os.fsync(destination_file.fileno())
-    except (OSError, IOError):
+    except OSError:
       raise exceptions.StorageError(
           "Can't write file %s" % filepath)
 

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -22,7 +22,7 @@ import os
 import shutil
 from contextlib import contextmanager
 from securesystemslib import exceptions
-from typing import BinaryIO, Generator, IO, List
+from typing import BinaryIO, IO, Iterator, List
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class StorageBackendInterface():
 
   @abc.abstractmethod
   @contextmanager
-  def get(self, filepath: str) -> Generator[BinaryIO, None, None]:
+  def get(self, filepath: str) -> Iterator[BinaryIO]:
     """
     <Purpose>
       A context manager for 'with' statements that is used for retrieving files
@@ -195,7 +195,7 @@ class FilesystemBackend(StorageBackendInterface):
 
 
   @contextmanager
-  def get(self, filepath:str) -> Generator[BinaryIO, None, None]:
+  def get(self, filepath:str) -> Iterator[BinaryIO]:
     file_object = None
     try:
       file_object = open(filepath, 'rb')


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Addresses #358 

### Description of the changes being introduced by the pull request:
Adds type annotations to `storage.py.`

In addition changes  `FilesystemBackend.get` to avoid  `mypy` complaining (correctly) about the following assignment:
```
  # Map our class ContextManager implementation to the function expected of the
  # securesystemslib.storage.StorageBackendInterface.get definition
  get = GetFile
```


```
securesystemslib/storage.py:224: error: Incompatible types in assignment (expression has type "Type[GetFile]", base class "StorageBackendInterface" defined the type as "Callable[[StorageBackendInterface, str], Generator[BinaryIO, None, None]]")
```



### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


