### PR TITLE
Add Tor project copyright notice to two files

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -12,6 +12,9 @@
   Refactored April 30, 2012. -vladimir.v.diaz
 
 <Copyright>
+  2008-2011 The Tor Project, Inc
+  2012-2016 New York University and the TUF contributors
+  2016-2021 Securesystemslib contributors
   See LICENSE for licensing information.
 
 <Purpose>

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -12,6 +12,9 @@
   Refactored April 30, 2012 (previously named checkjson.py). -Vlad
 
 <Copyright>
+  2008-2011 The Tor Project, Inc
+  2012-2016 New York University and the TUF contributors
+  2016-2021 Securesystemslib contributors
   See LICENSE for licensing information.
 
 <Purpose>


### PR DESCRIPTION
formats.py and schema.py include code that is derivative of Thandy
projects source code. The code has now been licensed as MIT+Apache2.0
(and we're using it as MIT in Securesystemslib). To fulfill the license
requirements, let's make sure the copyright notices are correct.

Add Tor project copyright notice, and while we're at it add the other
relevant copyright notices (based on the history of the files in
question).

See also https://github.com/theupdateframework/tuf/issues/1491

Fixes #365 
