### PR TITLE
Remove broken Dependabot badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ Secure Systems Library
 .. image:: https://github.com/secure-systems-lab/securesystemslib/workflows/Run%20Securesystemslib%20tests/badge.svg
    :target: https://github.com/secure-systems-lab/securesystemslib/actions?query=workflow%3A%22Run+Securesystemslib+tests%22+branch%3Amaster
 
-.. image:: https://api.dependabot.com/badges/status?host=github&repo=secure-systems-lab/securesystemslib
-   :target: https://api.dependabot.com/badges/status?host=github&repo=secure-systems-lab/securesystemslib
 
 
 A library that provides cryptographic and general-purpose functions for Secure


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:
The Dependabot status badge no longer works, since the switch from stand-alone to GitHub native.

The issue is tracked upstream in dependabot/dependabot-core#1912


### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


