### PR TITLE
ed25519: Update expected upstream hash

### DIFF
--- a/securesystemslib/_vendor/test-ed25519-upstream.sh
+++ b/securesystemslib/_vendor/test-ed25519-upstream.sh
@@ -12,7 +12,7 @@ set -eu
 # This commit matches our securesystemslib/_vendor/ed25519/ content.
 # If upstream changes, we should review the changes, vendor them,
 # and update the hash here
-pyca_ed25519_expected="48599ab0bff20f2c9b9755cfc0348961cc872abf"
+pyca_ed25519_expected="533416699331674a02ec586916b78bf7f515c052"
 pyca_ed25519_git_url="https://github.com/pyca/ed25519.git"
 
 pyca_ed25519_main_head=$(git ls-remote "$pyca_ed25519_git_url" main | cut -f1)


### PR DESCRIPTION
There are no changes in our vendored sources

Fixes #374

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>