### PR TITLE
Add CryptoError info in keys.create_signature

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -651,6 +651,9 @@ def create_signature(key_dict, data):
     securesystemslib.exceptions.UnsupportedAlgorithmError, if 'key_dict'
     specifies an unsupported key type or signing scheme.
 
+    securesystemslib.exceptions.CryptoError, if the signature cannot be
+    generated.
+
     TypeError, if 'key_dict' contains an invalid keytype.
 
   <Side Effects>


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

Add CryptoError info in `securesystemslib.keys.create_signature()`
as three of the functions it calls `rsa_keys.create_rsa_signature()`,
`ed25519_keys.create_signature()` and `ecdsa_keys.create_signature()`
can throw `securesystemslib.exceptions.CryptoError`.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


