### PR TITLE
Add Signature.__eq__() method

### DIFF
--- a/securesystemslib/signer.py
+++ b/securesystemslib/signer.py
@@ -7,7 +7,7 @@ signing implementations and a couple of example implementations.
 
 import abc
 import securesystemslib.keys as sslib_keys
-from typing import Dict
+from typing import Any, Dict
 
 
 class Signature:
@@ -27,6 +27,13 @@ class Signature:
     def __init__(self, keyid: str, sig: str):
         self.keyid = keyid
         self.signature = sig
+
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Signature):
+            return False
+
+        return self.keyid == other.keyid and self.signature == other.signature
 
 
     @classmethod

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -2,6 +2,7 @@
 
 """Test cases for "signer.py". """
 
+import copy
 import sys
 import unittest
 
@@ -76,6 +77,30 @@ class TestSSlibSigner(unittest.TestCase):
         sig_obj = Signature.from_dict(signature_dict)
 
         self.assertDictEqual(signature_dict, sig_obj.to_dict())
+
+
+    def test_signature_eq_(self):
+        signature_dict = {
+            "sig": "30460221009342e4566528fcecf6a7a5d53ebacdb1df151e242f55f8775883469cb01dbc6602210086b426cc826709acfa2c3f9214610cb0a832db94bbd266fd7c5939a48064a851",
+            "keyid": "11fa391a0ed7a447cbfeb4b2667e286fc248f64d5e6d0eeed2e5e23f97f9f714"
+        }
+        sig_obj = Signature.from_dict(signature_dict)
+        sig_obj_2 = copy.deepcopy(sig_obj)
+
+        self.assertEqual(sig_obj, sig_obj_2)
+
+        # Assert that changing the keyid will make the objects not equal.
+        sig_obj_2.keyid = None
+        self.assertNotEqual(sig_obj, sig_obj_2)
+        sig_obj_2.keyid = sig_obj.keyid
+
+        # Assert that changing the signature will make the objects not equal.
+        sig_obj_2.signature = None
+        self.assertNotEqual(sig_obj, sig_obj_2)
+
+        # Assert that making sig_obj_2 None will make the objects not equal.
+        sig_obj_2 = None
+        self.assertNotEqual(sig_obj, sig_obj_2)
 
 
 # Run the unit tests.


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

Add `Signature.__eq__()` method to support comparison between signature
objects.
The need for this method came when solving issue #1696 in TUF
and more precisely read: https://github.com/theupdateframework/python-tuf/issues/1696#issuecomment-1007448882

Issue #1696 in TUF is about adding validation API after metadata
object initialization and because signatures in TUF are dictionaries
whose values are Signature objects they need for Signature.__eq__()
the method became apparent.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


