### PR TITLE
Drop python3.6 and make simplifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       # Run tests on each OS/Python combination
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         # TODO: Add windows-latest when gpg issues are solved
         os: [ubuntu-latest, macos-latest]
         toxenv: [py]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # 1. Use this script to create a pinned requirements file for each Python
 #    version
 # ```
-# for v in 3.6 3.7 3.8 3.9; do
+# for v in 3.7 3.8 3.9; do
 #   mkvirtualenv sslib-env-${v} -p python${v};
 #   pip install pip-tools;
 #   pip-compile --no-header -o requirements-${v}.txt requirements.txt;

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -101,7 +100,7 @@ setup(
     'Source': 'https://github.com/secure-systems-lab/securesystemslib',
     'Issues': 'https://github.com/secure-systems-lab/securesystemslib/issues',
   },
-  python_requires = "~=3.6",
+  python_requires = "~=3.7",
   extras_require = {
       'colors': ['colorama>=0.3.9'],
       'crypto': ['cryptography>=3.3.2'],

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -45,9 +45,6 @@ class TestHash(unittest.TestCase):
     if algorithm in blake_algos:
       if library == 'pyca_crypto':
         return False
-      # hashlib does not support blake2* if < 3.6
-      elif library == 'hashlib' and sys.version_info[:2] < (3, 6):
-        return False
     return True
 
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -9,18 +9,7 @@ import unittest
 import securesystemslib.formats
 import securesystemslib.keys as KEYS
 from securesystemslib.exceptions import FormatError, UnsupportedAlgorithmError
-
-# TODO: Remove case handling when fully dropping support for versions < 3.6
-IS_PY_VERSION_SUPPORTED = sys.version_info >= (3, 6)
-
-# Use setUpModule to tell unittest runner to skip this test module gracefully.
-def setUpModule():
-    if not IS_PY_VERSION_SUPPORTED:
-        raise unittest.SkipTest("requires Python 3.6 or higher")
-
-# Since setUpModule is called after imports we need to import conditionally.
-if IS_PY_VERSION_SUPPORTED:
-    from securesystemslib.signer import Signature, SSlibSigner
+from securesystemslib.signer import Signature, SSlibSigner
 
 
 class TestSSlibSigner(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = mypy, py36, py37, py38, py39, py310, purepy38, py38-no-gpg
+envlist = mypy, py37, py38, py39, py310, purepy38, py38-no-gpg
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

Python version 3.6 was supported until December 23-rd 2021
(see https://endoflife.date/python) meaning its end of life has expired
before more than 20 days.
Dropping support for python version 3.6 will allow us to make some
small cleanups.

`python-tuf` dropped support for python3.6 as well:
https://github.com/theupdateframework/python-tuf/pull/1783


Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

### Please verify and check that the pull request fulfills the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


