### PR TITLE
Add unrecognized fields support for Signature

### DIFF
--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -61,9 +61,13 @@ class TestSSlibSigner(unittest.TestCase):
     def test_signature_from_to_dict(self):
         signature_dict = {
             "sig": "30460221009342e4566528fcecf6a7a5d53ebacdb1df151e242f55f8775883469cb01dbc6602210086b426cc826709acfa2c3f9214610cb0a832db94bbd266fd7c5939a48064a851",
-            "keyid": "11fa391a0ed7a447cbfeb4b2667e286fc248f64d5e6d0eeed2e5e23f97f9f714"
+            "keyid": "11fa391a0ed7a447cbfeb4b2667e286fc248f64d5e6d0eeed2e5e23f97f9f714",
+            "foo": "bar" # unrecognized_field
         }
-        sig_obj = Signature.from_dict(signature_dict)
+        sig_obj = Signature.from_dict(copy.copy(signature_dict))
+
+        # Verify that unrecognized fields are stored correctly.
+        self.assertEqual(sig_obj.unrecognized_fields, {"foo": "bar"})
 
         self.assertDictEqual(signature_dict, sig_obj.to_dict())
 


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

The TUF specification says the following regarding unknown fields:
"All of the formats described below include the ability to add more
attribute-value fields to objects for backward-compatible format
changes. Implementers who encounter undefined attribute-value pairs in
the format must include the data when calculating hashes or verifying
signatures and must preserve the data when re-serializing."
From: https://theupdateframework.github.io/specification/latest/#document-formats

This section is the reason [ADR0008]( https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0008-accept-unrecognised-fields.md) was accepted inside `python-tuf`
and we have added support for unrecognized fields for all fields
inside the SIGNED portion of the metadata.
However, this limits what the citation implies or that everywhere there
inside the metadata files including signatures we should accept
unrecognized fields. That's why I made these changes.
These changes have the approval of the community see:
- https://github.com/theupdateframework/specification/issues/203
- https://github.com/theupdateframework/python-tuf/issues/1802

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


