### PR TITLE
Improve handling of errors in securesystemslib.keys.vertify_signature()

### DIFF
--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -311,8 +311,11 @@ def verify_signature(public_key, scheme, signature, data):
   formats.ECDSA_SCHEME_SCHEMA.check_match(scheme)
   formats.ECDSASIGNATURE_SCHEMA.check_match(signature)
 
-  ecdsa_key = load_pem_public_key(public_key.encode('utf-8'),
-      backend=default_backend())
+  try:
+    ecdsa_key = load_pem_public_key(public_key.encode('utf-8'),
+        backend=default_backend())
+  except ValueError as e:
+    raise exceptions.FormatError(f'Failed to load PEM key {public_key}') from e
 
   if not isinstance(ecdsa_key, ec.EllipticCurvePublicKey):
     raise exceptions.FormatError('Invalid ECDSA public'

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -838,7 +838,12 @@ def verify_signature(key_dict, signature, data):
 
   elif keytype == 'ed25519':
     if scheme == 'ed25519':
-      public = binascii.unhexlify(public.encode('utf-8'))
+      try:
+        public = binascii.unhexlify(public.encode('utf-8'))
+      except binascii.Error as e:
+        raise exceptions.FormatError(
+          f'Failed to parse key {public} as hex'
+        ) from e
       valid_signature = ed25519_keys.verify_signature(public,
           scheme, sig, data)
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -379,6 +379,13 @@ class TestKeys(unittest.TestCase):
         ed25519_signature, DATA)
     self.assertTrue(verified, "Incorrect signature.")
 
+    # Verify ecdsa key with HEX encoded keyval instead of PEM encoded keyval
+    ecdsa_key = KEYS.generate_ecdsa_key()
+    ecdsa_key['keyval']['public'] = 'abcd'
+    # sig is not important as long as keyid is the same as the one in ecdsa_key
+    sig = {'keyid': ecdsa_key['keyid'], 'sig': 'bb'}
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+        KEYS.verify_signature(ecdsa_key, sig, b'data')
 
 
   def test_create_rsa_encrypted_pem(self):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -387,6 +387,15 @@ class TestKeys(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
         KEYS.verify_signature(ecdsa_key, sig, b'data')
 
+    # Verify ed25519 key with PEM encoded keyval instead of HEX encoded keyval
+    ed25519 = KEYS.generate_ed25519_key()
+    ed25519['keyval']['public'] = \
+        '-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----\n'
+    # sig is not important as long as keyid is the same as the one in ed25519
+    sig = {'keyid': ed25519['keyid'], 'sig': 'bb'}
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+        KEYS.verify_signature(ed25519, sig, b'data')
+
 
   def test_create_rsa_encrypted_pem(self):
     # Test valid arguments.


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:
Together with @jku we have found two cases when calling `securesystemslib.keys.verify_signatures()` 
with malformed `key_dict` argument results to an exception from a third-party library:
1) when the `key_dict` represents an `ecdsa` key and `key_dict["keyval"]["public"]` is invalid (e.g. key_dict["keyval"]["public"] are raw bytes encoded in HEX instead of PEM format). This results in:
```
ValueError: ('Could not deserialize key data. The data may be in an incorrect format, it may be encrypted with an unsupported algorithm, or it may be an unsupported key type (e.g. EC curves with explicit parameters).', [_OpenSSLErrorWithText(code=151584876, lib=9, reason=108, reason_text=b'error:0909006C:PEM routines:get_name:no start line')])
```
2) when the `key_dict` represents an `ed25519 ` key and `key_dict["keyval"]["public"]`  is invalid (e.g. key_dict["keyval"]["public"] are raw bytes encoded in PEM instead of HEX format). This results in:
```
"binascii.Error: Non-hexadecimal digit found" 
```

This doesn't look good considering securesystemslib actively replaces errors related to malformed arguments with `FormatError`, so in order to be consistent it's good we do the same here.

_This pr is initiated by an issue found by @jku inside `python-tuf`: https://github.com/theupdateframework/python-tuf/issues/1866_

PS: If someone wants to reproduce the issue inside a terminal here are exemplary commands:

```python
import securesystemslib.keys as keys
ecdsa = keys.generate_ecdsa_key()
ecdsa["keyval"]["public"]="abcd" # break key value
sig={"keyid": ecdsa["keyid"], "sig": "bb"}
keys.verify_signature(ecdsa, sig, "data")
```

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


