### PR TITLE
Prepare Debian downstream release 0.22.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+python-securesystemslib (0.22.0-1) unstable; urgency=medium
+
+  * New upstream release includes among other things:
+    - bug fix in the Signer abstract base class (#348)
+    - machinery for static type checking with mypy (#361)
+    - type annotations for a few modules (progress tracked in #358)
+    - enhancements in the Signature class (#383, #387)
+
+  * d/control:
+    - bump standards version to 4.6.0.1
+
+ -- Lukas Puehringer <lukas.puehringer@nyu.edu>  Mon, 21 Feb 2022 12:52:17 +0100
+
 python-securesystemslib (0.20.0-1) unstable; urgency=medium
 
   * New upstream release includes among other things:

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends:
  python3-colorama,
  python3-mock,
  gnupg2,
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0.1
 Rules-Requires-Root: no
 Homepage: https://ssl.engineering.nyu.edu
 Vcs-Git: https://github.com/secure-systems-lab/securesystemslib.git -b debian


### PR DESCRIPTION
Built package on https://mentors.debian.net/package/python-securesystemslib/

### Description of the changes being introduced by the pull request:

* New upstream release includes among other things:
  - bug fix in the Signer abstract base class (#348)
  - machinery for static type checking with mypy (#361)
  - type annotations for a few modules (progress tracked in #358)
  - enhancements in the Signature class (#383, #387)

* d/control:
  - bump standards version to 4.6.0.1

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


