### PR TITLE
Prepare v0.23.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## securesystemslib v0.23.0
+
+### Fixed
+* Race condition in gpg test cleanup function (#397)
+
+### Changed
+* Consistently raise custom `FormatError` in `keys.verify_signature()` (#391)
+* Bumped dependencies: cryptography (#396), ed25519 (#394, #398)
+* Updated Debian packaging metadata (#392)
+
+
 ## securesystemslib v0.22.0
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst') as file_object:
 
 setup(
   name = 'securesystemslib',
-  version = '0.22.0',
+  version = '0.23.0',
   description = 'A library that provides cryptographic and general-purpose'
       ' routines for Secure Systems Lab projects at NYU',
   license = 'MIT',


### PR DESCRIPTION
Bump version in setup.py and populate CHANGELOG.md with summarised
changes since the last release.