### PR TITLE
Prepare Debian downstream release 0.23.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+python-securesystemslib (0.23.0-1) unstable; urgency=medium
+
+  * New upstream release includes among other things:
+    - fix race condition in gpg test cleanup function (Closes: #1008349)
+
+ -- Lukas Puehringer <lukas.puehringer@nyu.edu>  Tue, 26 Apr 2022 12:19:30 +0200
+
 python-securesystemslib (0.22.0-1) unstable; urgency=medium
 
   * New upstream release includes among other things:


### PR DESCRIPTION
Build available on https://mentors.debian.net/package/python-securesystemslib/


### Description of the changes being introduced by the pull request:
* New upstream release includes among other things:
  - fix race condition in gpg test cleanup function (Closes: [#1008349](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008349))

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


