### PR TITLE
Add support for Signature class instances

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -613,17 +613,17 @@ def create_signature(key_dict, data):
     >>> ed25519_key = generate_ed25519_key()
     >>> data = 'The quick brown fox jumps over the lazy dog'
     >>> signature = create_signature(ed25519_key, data)
-    >>> securesystemslib.formats.SIGNATURE_SCHEMA.matches(signature)
+    >>> isinstance(signature, securesystemslib.signer.Signature)
     True
     >>> len(signature['sig'])
     128
     >>> rsa_key = generate_rsa_key(2048)
     >>> signature = create_signature(rsa_key, data)
-    >>> securesystemslib.formats.SIGNATURE_SCHEMA.matches(signature)
+    >>> isinstance(signature, securesystemslib.signer.Signature)
     True
     >>> ecdsa_key = generate_ecdsa_key()
     >>> signature = create_signature(ecdsa_key, data)
-    >>> securesystemslib.formats.SIGNATURE_SCHEMA.matches(signature)
+    >>> isinstance(signature, securesystemslib.signer.Signature)
     True
 
   <Arguments>
@@ -662,8 +662,7 @@ def create_signature(key_dict, data):
     actual signing routine.
 
   <Returns>
-    A signature dictionary conformant to
-    'securesystemslib_format.SIGNATURE_SCHEMA'.
+    A "securesystemslib.singer.Signature" class instance.
   """
 
   # Does 'key_dict' have the correct format?
@@ -762,11 +761,12 @@ def verify_signature(key_dict, signature, data):
       The public and private keys are strings in PEM format.
 
     signature:
-      The signature dictionary produced by one of the key generation functions.
-      'signature' has the form:
+      The securesystemslib.signer.Signature class instance produced by one
+      of the key generation functions.
+      'signature' has two attributes:
 
-      {'keyid': 'f30a0870d026980100c0573bd557394f8c1bbd6...',
-       'sig': sig}.
+      keyid = 'f30a0870d026980100c0573bd557394f8c1bbd6...',
+      sig = sig
 
       Conformant to 'securesystemslib.formats.SIGNATURE_SCHEMA'.
 

--- a/securesystemslib/signer.py
+++ b/securesystemslib/signer.py
@@ -158,5 +158,5 @@ class SSlibSigner(Signer):
             Returns a "Signature" class instance.
         """
 
-        sig_dict = sslib_keys.create_signature(self.key_dict, payload)
-        return Signature(**sig_dict)
+        signature = sslib_keys.create_signature(self.key_dict, payload)
+        return signature

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -48,6 +48,7 @@ import securesystemslib.gpg.functions
 import securesystemslib.gpg.util
 import securesystemslib.interface
 import securesystemslib.keys
+import securesystemslib.signer
 
 
 
@@ -187,8 +188,10 @@ class TestPublicInterfaces(unittest.TestCase):
 
     keydict['keytype'] = 'ecdsa'
     keydict['scheme'] = 'ecdsa-sha2-nistp256'
-    sig = {'keyid': 'f00',
-           'sig': 'cfbce8e23eef478975a4339036de2335002d57c7b1632dd01e526a3bc52a5b261508ad50b9e25f1b819d61017e7347e912db1af019bf47ee298cc58bbdef9703'}
+    sig = securesystemslib.signer.Signature(
+      keyid='f00',
+      sig='cfbce8e23eef478975a4339036de2335002d57c7b1632dd01e526a3bc52a5b261508ad50b9e25f1b819d61017e7347e912db1af019bf47ee298cc58bbdef9703'
+    )
     # NOTE: we don't test ed25519 keys as they can be verified in pure python
     with self.assertRaises(
           securesystemslib.exceptions.UnsupportedLibraryError):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -24,6 +24,7 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.keys
 import securesystemslib.ecdsa_keys
+import securesystemslib.signer
 
 KEYS = securesystemslib.keys
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError was raised!' + \
@@ -238,12 +239,8 @@ class TestKeys(unittest.TestCase):
     ed25519_signature = KEYS.create_signature(self.ed25519key_dict, DATA)
 
     # Check format of output.
-    self.assertEqual(None,
-        securesystemslib.formats.SIGNATURE_SCHEMA.check_match(rsa_signature),
-        FORMAT_ERROR_MSG)
-    self.assertEqual(None,
-        securesystemslib.formats.SIGNATURE_SCHEMA.check_match(ed25519_signature),
-        FORMAT_ERROR_MSG)
+    self.assertIsInstance(rsa_signature, securesystemslib.signer.Signature)
+    self.assertIsInstance(ed25519_signature, securesystemslib.signer.Signature)
 
     # Test for invalid signature scheme.
     args = (self.rsakey_dict, DATA)
@@ -270,9 +267,7 @@ class TestKeys(unittest.TestCase):
     ecdsa_signature = KEYS.create_signature(self.ecdsakey_dict, DATA)
 
     # Check format of output.
-    self.assertEqual(None,
-        securesystemslib.formats.SIGNATURE_SCHEMA.check_match(ecdsa_signature),
-        FORMAT_ERROR_MSG)
+    self.assertIsInstance(ecdsa_signature, securesystemslib.signer.Signature)
 
     # Removing private key from 'ecdsakey_dict' - should raise a TypeError.
     private = self.ecdsakey_dict['keyval']['private']
@@ -383,7 +378,7 @@ class TestKeys(unittest.TestCase):
     ecdsa_key = KEYS.generate_ecdsa_key()
     ecdsa_key['keyval']['public'] = 'abcd'
     # sig is not important as long as keyid is the same as the one in ecdsa_key
-    sig = {'keyid': ecdsa_key['keyid'], 'sig': 'bb'}
+    sig = securesystemslib.signer.Signature(keyid=ecdsa_key['keyid'], sig='bb')
     with self.assertRaises(securesystemslib.exceptions.FormatError):
         KEYS.verify_signature(ecdsa_key, sig, b'data')
 
@@ -392,7 +387,7 @@ class TestKeys(unittest.TestCase):
     ed25519['keyval']['public'] = \
         '-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----\n'
     # sig is not important as long as keyid is the same as the one in ed25519
-    sig = {'keyid': ed25519['keyid'], 'sig': 'bb'}
+    sig = securesystemslib.signer.Signature(keyid=ed25519['keyid'], sig='bb')
     with self.assertRaises(securesystemslib.exceptions.FormatError):
         KEYS.verify_signature(ed25519, sig, b'data')
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -33,7 +33,7 @@ class TestSSlibSigner(unittest.TestCase):
             sig_obj = sslib_signer.sign(self.DATA)
 
             # Verify signature
-            verified = KEYS.verify_signature(scheme_dict, sig_obj.to_dict(),
+            verified = KEYS.verify_signature(scheme_dict, sig_obj,
                     self.DATA)
             self.assertTrue(verified, "Incorrect signature.")
 


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #360

### Description of the changes being introduced by the pull request:
Currently, `verify_siganture()` method takes a signature dictionary as parameter and there is no implementation for `Signature` class present in `securesystemslib.signer`. This Pull Request adds support for `Signature` class object in `create_signature()` and `verify_signature()` methods.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


