### PR TITLE
Canonical encoding speedup by using str.replace

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -68,7 +68,6 @@
 
 import binascii
 import calendar
-import re
 import datetime
 import time
 
@@ -613,7 +612,7 @@ def _canonical_string_encoder(string):
     A string with the canonical-encoded 'string' embedded.
   """
 
-  string = '"%s"' % re.sub(r'(["\\])', r'\\\1', string)
+  string = '"%s"' % string.replace('\\', '\\\\').replace('"', '\\"')
 
   return string
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -283,6 +283,11 @@ class TestFormats(unittest.TestCase):
 
     self.assertEqual('{"x":3,"y":null}', encode({"x": 3, "y": None}))
 
+    # Test condition with escaping " and \
+    self.assertEqual('"\\""', encode("\""))
+    self.assertEqual('"\\\\"', encode("\\"))
+    self.assertEqual('"\\\\\\""', encode("\\\""))
+
     # Condition where 'encode()' sends the result to the callable
     # 'output'.
     self.assertEqual(None, encode([1, 2, 3], output))


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #372 

### Description of the changes being introduced by the pull request:
The `_canonical_string_encoder()` uses regex for string substitution in encoding the string to canonical form. The regex code is replaced by `str.replace` method which is faster in comparison of regex substitution. Few more test conditions are added.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


