### PR TITLE
Ed25519: Update expected hash

### DIFF
--- a/securesystemslib/_vendor/test-ed25519-upstream.sh
+++ b/securesystemslib/_vendor/test-ed25519-upstream.sh
@@ -12,7 +12,7 @@ set -eu
 # This commit matches our securesystemslib/_vendor/ed25519/ content.
 # If upstream changes, we should review the changes, vendor them,
 # and update the hash here
-pyca_ed25519_expected="62249780f252036a6d494cd15d0390957115f011"
+pyca_ed25519_expected="f98354b09ffde8444a04c71f8e3ac7b948c89a02"
 pyca_ed25519_git_url="https://github.com/pyca/ed25519.git"
 
 pyca_ed25519_main_head=$(git ls-remote "$pyca_ed25519_git_url" main | cut -f1)


### PR DESCRIPTION
Only infrastructure changes, vendored copy does not change.

Fixes #411
