### PR TITLE
Fix tests failing in GitHub Actions

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -118,8 +118,8 @@ class Test_Process(unittest.TestCase):
   def test_run_duplicate_streams_timeout(self):
     """Test raise TimeoutExpired. """
     with self.assertRaises(securesystemslib.process.subprocess.TimeoutExpired):
-      securesystemslib.process.run_duplicate_streams(sys.executable + " --version",
-          timeout=-1)
+      securesystemslib.process.run_duplicate_streams(sys.executable +
+        " -c \"while True: pass\"", timeout=-1)
 
 
   def test__default_timeout(self):


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:
Test `test_run_duplicate_streams_timeout` fails sometimes, and after
some investigations it is found that the process used in the test
exits before considered for a Timeout.

To fix the test, the command is now replaced with another command.

Also, I consider testing this Pull Request multiple time using GitHub Actions
before merging to make sure the problem is now solved.

A failed test: https://github.com/secure-systems-lab/securesystemslib/runs/7280432273

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


