### PR TITLE
Fix RSA PSS salt lengths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,6 @@
 # 3. Use this command to remove per-version files
 #    `rm requirements-?.?.txt`
 #
-cryptography >= 3.3.2; python_version >= '3'
+cryptography >= 37.0.0; python_version >= '3'
 pynacl
 colorama

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -326,10 +326,11 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
     if scheme.startswith('rsassa-pss'):
       # Generate an RSSA-PSS signature.  Raise
       # 'securesystemslib.exceptions.CryptoError' for any of the expected
-      # exceptions raised by pyca/cryptography.
+      # exceptions raised by pyca/cryptography. 'salt_length' is set to
+      # the maximum length available.
       signature = private_key_object.sign(
           data, padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-          salt_length=digest_obj.algorithm.digest_size), digest_obj.algorithm)
+          salt_length=padding.PSS.MAX_LENGTH), digest_obj.algorithm)
 
     elif scheme.startswith('rsa-pkcs1v15'):
       # Generate an RSA-PKCS1v15 signature.  Raise
@@ -453,13 +454,13 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
     digest_obj = digest_from_rsa_scheme(signature_scheme, 'pyca_crypto')
 
     # verify() raises 'cryptography.exceptions.InvalidSignature' if the
-    # signature is invalid. 'salt_length' is set to the digest size of the
-    # hashing algorithm.
+    # signature is invalid. 'salt_length' is automatically
+    # determined when verifying the signature.
     try:
       if signature_scheme.startswith('rsassa-pss'):
         public_key_object.verify(signature, data,
             padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-            salt_length=digest_obj.algorithm.digest_size),
+            salt_length=padding.PSS.AUTO),
             digest_obj.algorithm)
 
       elif signature_scheme.startswith('rsa-pkcs1v15'):

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
   python_requires = "~=3.7",
   extras_require = {
       'colors': ['colorama>=0.3.9'],
-      'crypto': ['cryptography>=3.3.2'],
+      'crypto': ['cryptography>=37.0.0'],
       'pynacl': ['pynacl>1.2.0']},
   packages = find_packages(exclude=['tests', 'debian']),
   scripts = []


### PR DESCRIPTION
Fixes: #421 

### Description of the changes being introduced by the pull request:

This PR does two things:
1. Use the _maximum_ salt length by default when _creating_ RSA PSS signatures.
1. Use the _automatic_ salt length inferred from RSA PSS signatures when _verifying_ them.

This should be the simplest, most backwards-compatible, and yet most secure way to verify cross-platform RSA PSS signatures.

### Missing tests
- [x] Can automatically verify RSA PSS signatures regardless of the input salt length

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature