### PR TITLE
Add Sphincs+ To Signer Interface

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -48,3 +48,6 @@ notes=TODO
 
 [STRING]
 check-quote-consistency=yes
+
+[TYPECHECK]
+generated-members=shake_128s.*

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -3,3 +3,4 @@ cryptography==38.0.2
 pycparser==2.21           # via cffi
 pynacl==1.5.0
 six==1.16.0               # via pynacl
+PySPX==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@
 #
 cryptography >= 37.0.0; python_version >= '3'
 pynacl
+PySPX

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -291,19 +291,16 @@ ECDSAKEY_SCHEMA = SCHEMA.Object(
 # An ED25519 raw public key, which must be 32 bytes.
 ED25519PUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
 
-# An SPHINCS raw public key, which must be 32 bytes.
 SPHINCSPUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
 
 # An ED25519 raw seed key, which must be 32 bytes.
 ED25519SEED_SCHEMA = SCHEMA.LengthBytes(32)
 
-# An SPHINCS raw public key, which must be 32 bytes.
 SPHINCSPRIVATE_SCHEMA = SCHEMA.LengthBytes(64)
 
 # An ED25519 raw signature, which must be 64 bytes.
 ED25519SIGNATURE_SCHEMA = SCHEMA.LengthBytes(64)
 
-# An SPHINCS raw signature, which must be 64 bytes.
 SPHINCSSIGNATURE_SCHEMA = SCHEMA.LengthBytes(7_856)
 
 # An ECDSA signature.

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -210,7 +210,7 @@ KEYTYPE_SCHEMA = SCHEMA.OneOf(
         SCHEMA.String("ed25519"),
         SCHEMA.String("ecdsa"),
         SCHEMA.RegularExpression(r"ecdsa-sha2-nistp(256|384)"),
-        SCHEMA.String('sphincs-shake-128s')
+        SCHEMA.String('sphincs')
     ]
 )
 

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -210,7 +210,7 @@ KEYTYPE_SCHEMA = SCHEMA.OneOf(
         SCHEMA.String("ed25519"),
         SCHEMA.String("ecdsa"),
         SCHEMA.RegularExpression(r"ecdsa-sha2-nistp(256|384)"),
-        SCHEMA.String('sphincs')
+        SCHEMA.String("sphincs"),
     ]
 )
 
@@ -310,7 +310,7 @@ ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
 # supported.
 ED25519_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String("ed25519")])
 
-SPHINCS_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String('sphincs-shake-128s')])
+SPHINCS_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String("sphincs-shake-128s")])
 
 # An ed25519 key.
 ED25519KEY_SCHEMA = SCHEMA.Object(

--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -210,6 +210,7 @@ KEYTYPE_SCHEMA = SCHEMA.OneOf(
         SCHEMA.String("ed25519"),
         SCHEMA.String("ecdsa"),
         SCHEMA.RegularExpression(r"ecdsa-sha2-nistp(256|384)"),
+        SCHEMA.String('sphincs-shake-128s')
     ]
 )
 
@@ -290,11 +291,20 @@ ECDSAKEY_SCHEMA = SCHEMA.Object(
 # An ED25519 raw public key, which must be 32 bytes.
 ED25519PUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
 
+# An SPHINCS raw public key, which must be 32 bytes.
+SPHINCSPUBLIC_SCHEMA = SCHEMA.LengthBytes(32)
+
 # An ED25519 raw seed key, which must be 32 bytes.
 ED25519SEED_SCHEMA = SCHEMA.LengthBytes(32)
 
+# An SPHINCS raw public key, which must be 32 bytes.
+SPHINCSPRIVATE_SCHEMA = SCHEMA.LengthBytes(64)
+
 # An ED25519 raw signature, which must be 64 bytes.
 ED25519SIGNATURE_SCHEMA = SCHEMA.LengthBytes(64)
+
+# An SPHINCS raw signature, which must be 64 bytes.
+SPHINCSSIGNATURE_SCHEMA = SCHEMA.LengthBytes(7_856)
 
 # An ECDSA signature.
 ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
@@ -302,6 +312,8 @@ ECDSASIGNATURE_SCHEMA = SCHEMA.AnyBytes()
 # Ed25519 signature schemes.  The vanilla Ed25519 signature scheme is currently
 # supported.
 ED25519_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String("ed25519")])
+
+SPHINCS_SIG_SCHEMA = SCHEMA.OneOf([SCHEMA.String('sphincs-shake-128s')])
 
 # An ed25519 key.
 ED25519KEY_SCHEMA = SCHEMA.Object(

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -351,6 +351,14 @@ def generate_ed25519_key(scheme="ed25519"):
 
 
 def generate_sphincs_key(scheme="sphincs-shake-128s"):
+    """Generate a SPHINCS+ key pair.
+    Arguments:
+          scheme (str): Name of the scheme as defined in formats.py.
+    Returns:
+        dict: A dictionary containing the ED25519 keys.
+    Raises:
+        UnsupportedLibraryError: In case pyspx is not available.
+    """
     formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
 
     sphincs_key = {}

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -55,11 +55,11 @@ import logging
 from securesystemslib import (
     ecdsa_keys,
     ed25519_keys,
-    sphincs_keys,
     exceptions,
     formats,
     rsa_keys,
     settings,
+    sphincs_keys,
     util,
 )
 from securesystemslib.hash import digest
@@ -350,24 +350,21 @@ def generate_ed25519_key(scheme="ed25519"):
     return ed25519_key
 
 
-def generate_sphincs_key(scheme='sphincs-shake-128s'):
+def generate_sphincs_key(scheme="sphincs-shake-128s"):
     formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
 
     sphincs_key = {}
-    keytype = 'sphincs'
+    keytype = "sphincs"
     public, private = sphincs_keys.generate_public_and_private()
 
-    key_value = {
-      'public': public.hex(),
-      'private': private.hex()
-    }
+    key_value = {"public": public.hex(), "private": private.hex()}
     keyid = _get_keyid(keytype, scheme, key_value)
 
-    sphincs_key['keytype'] = keytype
-    sphincs_key['scheme'] = scheme
-    sphincs_key['keyid'] = keyid
-    sphincs_key['keyid_hash_algorithms'] = settings.HASH_ALGORITHMS
-    sphincs_key['keyval'] = key_value
+    sphincs_key["keytype"] = keytype
+    sphincs_key["scheme"] = scheme
+    sphincs_key["keyid"] = keyid
+    sphincs_key["keyid_hash_algorithms"] = settings.HASH_ALGORITHMS
+    sphincs_key["keyval"] = key_value
 
     return sphincs_key
 
@@ -719,11 +716,11 @@ def create_signature(key_dict, data):
     # for backwards compatibility with older securesystemslib releases
     elif keytype in ["ecdsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384"]:
         sig, scheme = ecdsa_keys.create_signature(public, private, data, scheme)
-      
+
     elif keytype == "sphincs":
         sig, scheme = sphincs_keys.create_signature(
             bytes.fromhex(public), bytes.fromhex(private), data, scheme
-          )
+        )
 
     # 'securesystemslib.formats.ANYKEY_SCHEMA' should have detected invalid key
     # types.  This is a defensive check against an invalid key type.
@@ -887,11 +884,12 @@ def verify_signature(
     elif keytype == "sphincs":
         if scheme == "sphincs-shake-128s":
             valid_signature = sphincs_keys.verify_signature(
-              bytes.fromhex(public), scheme, sig, data
+                bytes.fromhex(public), scheme, sig, data
             )
         else:
-            raise exceptions.UnsupportedAlgorithmError('Unsupported'
-              ' signature scheme is specified: ' + repr(scheme))
+            raise exceptions.UnsupportedAlgorithmError(
+                "Unsupported" " signature scheme is specified: " + repr(scheme)
+            )
 
     # 'securesystemslib.formats.ANYKEY_SCHEMA' should have detected invalid key
     # types.  This is a defensive check against an invalid key type.

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -355,7 +355,7 @@ def generate_sphincs_key(scheme="sphincs-shake-128s"):
     Arguments:
           scheme (str): Name of the scheme as defined in formats.py.
     Returns:
-        dict: A dictionary containing the ED25519 keys.
+        dict: A dictionary containing the SPHINCS+ keys.
     Raises:
         UnsupportedLibraryError: In case pyspx is not available.
     """

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -885,9 +885,13 @@ def verify_signature(
                 "Unsupported" " signature scheme is specified: " + repr(scheme)
             )
     elif keytype == "sphincs-shake-128s":
-        valid_signature = sphincs_keys.verify_signature(
-          bytes.fromhex(public), scheme, sig, data
-        )
+        if scheme == "sphincs-shake-128s":
+            valid_signature = sphincs_keys.verify_signature(
+              bytes.fromhex(public), scheme, sig, data
+            )
+        else:
+            raise exceptions.UnsupportedAlgorithmError('Unsupported'
+              ' signature scheme is specified: ' + repr(scheme))
 
     # 'securesystemslib.formats.ANYKEY_SCHEMA' should have detected invalid key
     # types.  This is a defensive check against an invalid key type.

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -354,7 +354,7 @@ def generate_sphincs_key(scheme='sphincs-shake-128s'):
     formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
 
     sphincs_key = {}
-    keytype = 'sphincs-shake-128s'
+    keytype = 'sphincs'
     public, private = sphincs_keys.generate_public_and_private()
 
     key_value = {
@@ -720,7 +720,7 @@ def create_signature(key_dict, data):
     elif keytype in ["ecdsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384"]:
         sig, scheme = ecdsa_keys.create_signature(public, private, data, scheme)
       
-    elif keytype == "sphincs-shake-128s":
+    elif keytype == "sphincs":
         sig, scheme = sphincs_keys.create_signature(
             bytes.fromhex(public), bytes.fromhex(private), data, scheme
           )
@@ -884,7 +884,7 @@ def verify_signature(
             raise exceptions.UnsupportedAlgorithmError(
                 "Unsupported" " signature scheme is specified: " + repr(scheme)
             )
-    elif keytype == "sphincs-shake-128s":
+    elif keytype == "sphincs":
         if scheme == "sphincs-shake-128s":
             valid_signature = sphincs_keys.verify_signature(
               bytes.fromhex(public), scheme, sig, data

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -18,6 +18,13 @@ _SHAKE_SEED_LEN = 48
 
 
 def generate_public_and_private():
+    """Generates spx public and private key.
+
+    Returns:
+        tuple: Containing the (public, private) keys.
+    Raises:
+        UnsupportedLibraryError: In case pyspx is not available.
+    """
     if not _SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     seed = os.urandom(_SHAKE_SEED_LEN)
@@ -26,6 +33,17 @@ def generate_public_and_private():
 
 
 def create_signature(public_key, private_key, data, scheme):
+    """Signs data with the private key.
+      Arguments:
+            public_key (bytes): The public key. Not used so far.
+            private_key (bytes): The private key.
+            data (bytes): The data to be signed.
+            scheme (str): The name of the scheme as defined in formats.py.
+      Returns:
+          tuple: Containing the values (signature, scheme).
+      Raises:
+          UnsupportedLibraryError: In case pyspx is not available.
+    """
     if not _SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
@@ -38,6 +56,17 @@ def create_signature(public_key, private_key, data, scheme):
 
 
 def verify_signature(public_key, scheme, signature, data):
+    """Verify a signature using the public key.
+      Arguments:
+            public_key (bytes): The public key used for verification.
+            scheme (str): The name of the scheme as defined in formats.py.
+            signature (bytes): The sphincs+ signature as generated with create_signature.
+            data (bytes): The data that was signed.
+      Returns:
+          bool: True if the signature was valid, False otherwise.
+      Raises:
+          UnsupportedLibraryError: In case pyspx is not available.
+    """
     if not _SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -3,8 +3,7 @@
 # http://docs.python.org/2/library/os.html#miscellaneous-functions
 import os
 
-from securesystemslib import exceptions
-from securesystemslib import formats
+from securesystemslib import exceptions, formats
 
 _SPX_AVAIL = True
 NO_SPX_MSG = "spinhcs+ key support requires the pyspx library"
@@ -34,15 +33,15 @@ def generate_public_and_private():
 
 def create_signature(public_key, private_key, data, scheme):
     """Signs data with the private key.
-      Arguments:
-            public_key (bytes): The public key. Not used so far.
-            private_key (bytes): The private key.
-            data (bytes): The data to be signed.
-            scheme (str): The name of the scheme as defined in formats.py.
-      Returns:
-          tuple: Containing the values (signature, scheme).
-      Raises:
-          UnsupportedLibraryError: In case pyspx is not available.
+    Arguments:
+          public_key (bytes): The public key. Not used so far.
+          private_key (bytes): The private key.
+          data (bytes): The data to be signed.
+          scheme (str): The name of the scheme as defined in formats.py.
+    Returns:
+        tuple: Containing the values (signature, scheme).
+    Raises:
+        UnsupportedLibraryError: In case pyspx is not available.
     """
     if not _SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
@@ -57,15 +56,15 @@ def create_signature(public_key, private_key, data, scheme):
 
 def verify_signature(public_key, scheme, signature, data):
     """Verify a signature using the public key.
-      Arguments:
-            public_key (bytes): The public key used for verification.
-            scheme (str): The name of the scheme as defined in formats.py.
-            signature (bytes): The sphincs+ signature as generated with create_signature.
-            data (bytes): The data that was signed.
-      Returns:
-          bool: True if the signature was valid, False otherwise.
-      Raises:
-          UnsupportedLibraryError: In case pyspx is not available.
+    Arguments:
+          public_key (bytes): The public key used for verification.
+          scheme (str): The name of the scheme as defined in formats.py.
+          signature (bytes): The sphincs+ signature as generated with create_signature.
+          data (bytes): The data that was signed.
+    Returns:
+        bool: True if the signature was valid, False otherwise.
+    Raises:
+        UnsupportedLibraryError: In case pyspx is not available.
     """
     if not _SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -1,0 +1,47 @@
+# 'os' required to generate OS-specific randomness (os.urandom) suitable for
+# cryptographic use.
+# http://docs.python.org/2/library/os.html#miscellaneous-functions
+import os
+
+from pyspx import shake_128s
+
+from securesystemslib import exceptions
+from securesystemslib import formats
+
+_SHAKE_SEED_LEN = 48
+
+
+def generate_public_and_private():
+    seed = os.urandom(_SHAKE_SEED_LEN)
+    public, private = shake_128s.generate_keypair(seed)
+    return public, private
+
+
+def create_signature(public_key, private_key, data, scheme):
+    formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
+    formats.SPHINCSPRIVATE_SCHEMA.check_match(private_key)
+    formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
+
+    signature = shake_128s.sign(data, private_key)
+
+    return signature, scheme
+
+
+def verify_signature(public_key, scheme, signature, data):
+    formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
+
+    # Is 'scheme' properly formatted?
+    formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
+
+    # Is 'signature' properly formatted?
+    formats.SPHINCSSIGNATURE_SCHEMA.check_match(signature)
+
+    return shake_128s.verify(data, signature, public_key)
+
+
+if __name__ == '__main__':
+    # The interactive sessions of the documentation strings can
+    # be tested by running 'ed25519_keys.py' as a standalone module.
+    # python -B ed25519_keys.py
+    import doctest
+    doctest.testmod()

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -78,11 +78,3 @@ def verify_signature(public_key, scheme, signature, data):
     formats.SPHINCSSIGNATURE_SCHEMA.check_match(signature)
 
     return shake_128s.verify(data, signature, public_key)
-
-
-if __name__ == '__main__':
-    # The interactive sessions of the documentation strings can
-    # be tested by running 'ed25519_keys.py' as a standalone module.
-    # python -B ed25519_keys.py
-    import doctest
-    doctest.testmod()

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -1,3 +1,19 @@
+"""
+<Program Name>
+  sphincs_keys.py
+
+<Author>
+  Ruben Gonzalez <mail@ruben-gonzalez.de>
+
+<Started>
+  Otober 12, 2022.
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  The goal of this module is to include SPHINCS+ post-quantum signature support.
+ """
 # 'os' required to generate OS-specific randomness (os.urandom) suitable for
 # cryptographic use.
 # http://docs.python.org/2/library/os.html#miscellaneous-functions
@@ -5,13 +21,13 @@ import os
 
 from securesystemslib import exceptions, formats
 
-_SPX_AVAIL = True
+SPX_AVAIL = True
 NO_SPX_MSG = "spinhcs+ key support requires the pyspx library"
 
 try:
     from pyspx import shake_128s
 except ImportError:
-    _SPX_AVAIL = False
+    SPX_AVAIL = False
 
 _SHAKE_SEED_LEN = 48
 
@@ -24,7 +40,7 @@ def generate_public_and_private():
     Raises:
         UnsupportedLibraryError: In case pyspx is not available.
     """
-    if not _SPX_AVAIL:
+    if not SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     seed = os.urandom(_SHAKE_SEED_LEN)
     public, private = shake_128s.generate_keypair(seed)
@@ -43,7 +59,7 @@ def create_signature(public_key, private_key, data, scheme):
     Raises:
         UnsupportedLibraryError: In case pyspx is not available.
     """
-    if not _SPX_AVAIL:
+    if not SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
     formats.SPHINCSPRIVATE_SCHEMA.check_match(private_key)
@@ -66,7 +82,7 @@ def verify_signature(public_key, scheme, signature, data):
     Raises:
         UnsupportedLibraryError: In case pyspx is not available.
     """
-    if not _SPX_AVAIL:
+    if not SPX_AVAIL:
         raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
 

--- a/securesystemslib/sphincs_keys.py
+++ b/securesystemslib/sphincs_keys.py
@@ -3,21 +3,31 @@
 # http://docs.python.org/2/library/os.html#miscellaneous-functions
 import os
 
-from pyspx import shake_128s
-
 from securesystemslib import exceptions
 from securesystemslib import formats
+
+_SPX_AVAIL = True
+NO_SPX_MSG = "spinhcs+ key support requires the pyspx library"
+
+try:
+    from pyspx import shake_128s
+except ImportError:
+    _SPX_AVAIL = False
 
 _SHAKE_SEED_LEN = 48
 
 
 def generate_public_and_private():
+    if not _SPX_AVAIL:
+        raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     seed = os.urandom(_SHAKE_SEED_LEN)
     public, private = shake_128s.generate_keypair(seed)
     return public, private
 
 
 def create_signature(public_key, private_key, data, scheme):
+    if not _SPX_AVAIL:
+        raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
     formats.SPHINCSPRIVATE_SCHEMA.check_match(private_key)
     formats.SPHINCS_SIG_SCHEMA.check_match(scheme)
@@ -28,6 +38,8 @@ def create_signature(public_key, private_key, data, scheme):
 
 
 def verify_signature(public_key, scheme, signature, data):
+    if not _SPX_AVAIL:
+        raise exceptions.UnsupportedLibraryError(NO_SPX_MSG)
     formats.SPHINCSPUBLIC_SCHEMA.check_match(public_key)
 
     # Is 'scheme' properly formatted?

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
     extras_require={
         "crypto": ["cryptography>=37.0.0"],
         "pynacl": ["pynacl>1.2.0"],
+        "PySPX": ["PySPX==0.5.0"],
     },
     packages=find_packages(exclude=["tests", "debian"]),
     scripts=[],

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -204,6 +204,13 @@ class TestPublicInterfaces(
         ):
             securesystemslib.keys.create_signature(keydict, data)
 
+        keydict["keytype"] = "sphincs"
+        keydict["scheme"] = "sphincs-shake-128s"
+        with self.assertRaises(
+            securesystemslib.exceptions.UnsupportedLibraryError
+        ):
+            securesystemslib.keys.create_signature(keydict, data)
+
         keydict["keytype"] = "ecdsa"
         keydict["scheme"] = "ecdsa-sha2-nistp256"
         with self.assertRaises(
@@ -225,6 +232,18 @@ class TestPublicInterfaces(
             "sig": "cfbce8e23eef478975a4339036de2335002d57c7b1632dd01e526a3bc52a5b261508ad50b9e25f1b819d61017e7347e912db1af019bf47ee298cc58bbdef9703",
         }
         # NOTE: we don't test ed25519 keys as they can be verified in pure python
+        with self.assertRaises(
+            securesystemslib.exceptions.UnsupportedLibraryError
+        ):
+            securesystemslib.keys.verify_signature(keydict, sig, data)
+
+        SPX_KEY_LEN = 7_856
+        keydict["keytype"] = "sphincs"
+        keydict["scheme"] = "sphincs-shake-128s"
+        sig = {
+            "keyid": "f00",
+            "sig": "A" * SPX_KEY_LEN,
+        }
         with self.assertRaises(
             securesystemslib.exceptions.UnsupportedLibraryError
         ):

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -237,12 +237,11 @@ class TestPublicInterfaces(
         ):
             securesystemslib.keys.verify_signature(keydict, sig, data)
 
-        SPX_KEY_LEN = 7_856
         keydict["keytype"] = "sphincs"
         keydict["scheme"] = "sphincs-shake-128s"
         sig = {
             "keyid": "f00",
-            "sig": "A" * SPX_KEY_LEN,
+            "sig": "A" * 7_856,
         }
         with self.assertRaises(
             securesystemslib.exceptions.UnsupportedLibraryError

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -296,7 +296,7 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
             securesystemslib.formats.SIGNATURE_SCHEMA.check_match(
                 sphincs_signature
             ),
-            FORMAT_ERROR_MSG
+            FORMAT_ERROR_MSG,
         )
 
         # Test for invalid signature scheme.
@@ -382,16 +382,16 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
         self.assertTrue(verified, "Incorrect signature.")
 
         # Verify that an invalid sphincs signature scheme is rejected.
-        valid_scheme = self.sphincskey_dict['scheme']
-        self.sphincskey_dict['scheme'] = 'invalid_scheme'
+        valid_scheme = self.sphincskey_dict["scheme"]
+        self.sphincskey_dict["scheme"] = "invalid_scheme"
         self.assertRaises(
             securesystemslib.exceptions.UnsupportedAlgorithmError,
             KEYS.verify_signature,
             self.sphincskey_dict,
-            sphincs_signature, 
-            DATA
+            sphincs_signature,
+            DATA,
         )
-        self.sphincskey_dict['scheme'] = valid_scheme
+        self.sphincskey_dict["scheme"] = valid_scheme
 
         # Verifying the 'ecdsa_signature' of 'DATA'.
         verified = KEYS.verify_signature(
@@ -493,7 +493,9 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
 
         # Verify that sphincs fails if PySPX is not installed
         KEYS.sphincs_keys._SPX_AVAIL = False  # Monkey patch availability
-        with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+        with self.assertRaises(
+            securesystemslib.exceptions.UnsupportedLibraryError
+        ):
             KEYS.verify_signature(self.sphincskey_dict, sphincs_signature, DATA)
         KEYS.sphincs_keys._SPX_AVAIL = True
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -40,6 +40,7 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
         cls.rsakey_dict = KEYS.generate_rsa_key()
         cls.ed25519key_dict = KEYS.generate_ed25519_key()
         cls.ecdsakey_dict = KEYS.generate_ecdsa_key()
+        cls.sphincskey_dict = KEYS.generate_sphincs_key()
 
     def test_generate_rsa_key(self):
         _rsakey_dict = KEYS.generate_rsa_key()  # pylint: disable=invalid-name
@@ -273,6 +274,7 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
         # Creating a signature for 'DATA'.
         rsa_signature = KEYS.create_signature(self.rsakey_dict, DATA)
         ed25519_signature = KEYS.create_signature(self.ed25519key_dict, DATA)
+        sphincs_signature = KEYS.create_signature(self.sphincskey_dict, DATA)
 
         # Check format of output.
         self.assertEqual(
@@ -288,6 +290,13 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
                 ed25519_signature
             ),
             FORMAT_ERROR_MSG,
+        )
+        self.assertEqual(
+            None,
+            securesystemslib.formats.SIGNATURE_SCHEMA.check_match(
+                sphincs_signature
+            ),
+            FORMAT_ERROR_MSG
         )
 
         # Test for invalid signature scheme.
@@ -342,6 +351,7 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
         rsa_signature = KEYS.create_signature(self.rsakey_dict, DATA)
         ed25519_signature = KEYS.create_signature(self.ed25519key_dict, DATA)
         ecdsa_signature = KEYS.create_signature(self.ecdsakey_dict, DATA)
+        sphincs_signature = KEYS.create_signature(self.sphincskey_dict, DATA)
 
         # Verifying the 'signature' of 'DATA'.
         verified = KEYS.verify_signature(self.rsakey_dict, rsa_signature, DATA)
@@ -364,6 +374,24 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
             DATA,
         )
         self.ed25519key_dict["scheme"] = valid_scheme
+
+        # Verifying the 'sphincs_signature' of 'DATA'.
+        verified = KEYS.verify_signature(
+            self.sphincskey_dict, sphincs_signature, DATA
+        )
+        self.assertTrue(verified, "Incorrect signature.")
+
+        # Verify that an invalid sphincs signature scheme is rejected.
+        valid_scheme = self.sphincskey_dict['scheme']
+        self.sphincskey_dict['scheme'] = 'invalid_scheme'
+        self.assertRaises(
+            securesystemslib.exceptions.UnsupportedAlgorithmError,
+            KEYS.verify_signature,
+            self.sphincskey_dict,
+            sphincs_signature, 
+            DATA
+        )
+        self.sphincskey_dict['scheme'] = valid_scheme
 
         # Verifying the 'ecdsa_signature' of 'DATA'.
         verified = KEYS.verify_signature(
@@ -407,6 +435,11 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
 
         verified = KEYS.verify_signature(
             self.ed25519key_dict, ed25519_signature, _DATA
+        )
+        self.assertFalse(verified, "Returned 'True' on an incorrect signature.")
+
+        verified = KEYS.verify_signature(
+            self.sphincskey_dict, sphincs_signature, _DATA
         )
         self.assertFalse(verified, "Returned 'True' on an incorrect signature.")
 
@@ -457,6 +490,12 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
             self.ed25519key_dict, ed25519_signature, DATA
         )
         self.assertTrue(verified, "Incorrect signature.")
+
+        # Verify that sphincs fails if PySPX is not installed
+        KEYS.sphincs_keys._SPX_AVAIL = False  # Monkey patch availability
+        with self.assertRaises(securesystemslib.exceptions.UnsupportedLibraryError):
+            KEYS.verify_signature(self.sphincskey_dict, sphincs_signature, DATA)
+        KEYS.sphincs_keys._SPX_AVAIL = True
 
         # Verify ecdsa key with HEX encoded keyval instead of PEM encoded keyval
         ecdsa_key = KEYS.generate_ecdsa_key()

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -492,12 +492,12 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
         self.assertTrue(verified, "Incorrect signature.")
 
         # Verify that sphincs fails if PySPX is not installed
-        KEYS.sphincs_keys._SPX_AVAIL = False  # Monkey patch availability
+        KEYS.sphincs_keys.SPX_AVAIL = False  # Monkey patch availability
         with self.assertRaises(
             securesystemslib.exceptions.UnsupportedLibraryError
         ):
             KEYS.verify_signature(self.sphincskey_dict, sphincs_signature, DATA)
-        KEYS.sphincs_keys._SPX_AVAIL = True
+        KEYS.sphincs_keys.SPX_AVAIL = True
 
         # Verify ecdsa key with HEX encoded keyval instead of PEM encoded keyval
         ecdsa_key = KEYS.generate_ecdsa_key()

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -37,7 +37,12 @@ class TestSSlibSigner(
         ).encode("utf-8")
 
     def test_sslib_sign(self):
-        dicts = [self.rsakey_dict, self.ecdsakey_dict, self.ed25519key_dict, self.sphincskey_dict]
+        dicts = [
+            self.rsakey_dict,
+            self.ecdsakey_dict,
+            self.ed25519key_dict,
+            self.sphincskey_dict,
+        ]
         for scheme_dict in dicts:
             # Test generation of signatures.
             sslib_signer = SSlibSigner(scheme_dict)

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -30,13 +30,14 @@ class TestSSlibSigner(
         cls.rsakey_dict = KEYS.generate_rsa_key()
         cls.ed25519key_dict = KEYS.generate_ed25519_key()
         cls.ecdsakey_dict = KEYS.generate_ecdsa_key()
+        cls.sphincskey_dict = KEYS.generate_sphincs_key()
         cls.DATA_STR = "SOME DATA REQUIRING AUTHENTICITY."
         cls.DATA = securesystemslib.formats.encode_canonical(
             cls.DATA_STR
         ).encode("utf-8")
 
     def test_sslib_sign(self):
-        dicts = [self.rsakey_dict, self.ecdsakey_dict, self.ed25519key_dict]
+        dicts = [self.rsakey_dict, self.ecdsakey_dict, self.ed25519key_dict, self.sphincskey_dict]
         for scheme_dict in dicts:
             # Test generation of signatures.
             sslib_signer = SSlibSigner(scheme_dict)


### PR DESCRIPTION
Fixes: 
Updates: #169

### Description of the changes being introduced by the pull request:
The PRs #160 and #169  tried to include the PQC scheme [SPHINCS+](https://sphincs.org/), which is about to be NIST [standardized](https://csrc.nist.gov/News/2022/pqc-candidates-to-be-standardized-and-round-4).
However, work has stalled as people were busy with other stuff.

After talking to @lukpueh we decided to directly include SPHINCS+ into the "new" Signer API.

I welcome feedback and additional TODOs.


