### PR TITLE
Catch timeouts on import of gpg.constants

### DIFF
--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -28,7 +28,7 @@ def is_available_gnupg(gnupg):
   try:
     process.run(gpg_version_cmd, stdout=process.PIPE, stderr=process.PIPE)
     return True
-  except OSError:
+  except (OSError, subprocess.TimeoutExpired):
     return False
 
 


### PR DESCRIPTION
Sometimes, in some systems, not pointing any fingers but Windows, just finding out that there's no `gpg` available takes >3 seconds.

In that case, we now just assume that there's no GPG because a binary that takes 3 seconds even to start isn't any better than no binary at all.

Fixes #428.

Signed-off-by: Zachary Newman <z@znewman.net>

