### PR TITLE
Create backwards-compatible RSA PSS sigs by default

### DIFF
--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -237,7 +237,8 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
 
 
 
-def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
+def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256',
+                         salt_length=padding.PSS.DIGEST_LENGTH):
   """
   <Purpose>
     Generate a 'scheme' signature.  The signature, and the signature scheme
@@ -269,6 +270,13 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
 
     scheme:
       The signature scheme used to generate the signature.
+
+    salt_length:
+      The salt length (int) used to to generate the signature.
+      By default, this is set to padding.PSS.DIGEST_LENGTH,
+      so as to be backwards-compatible with previous verifiers.
+      Override this to set your own salt length
+      (e.g., padding.PSS.MAX_LENGTH).
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'private_key' is improperly
@@ -330,7 +338,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
       # the maximum length available.
       signature = private_key_object.sign(
           data, padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-          salt_length=padding.PSS.MAX_LENGTH), digest_obj.algorithm)
+          salt_length=salt_length), digest_obj.algorithm)
 
     elif scheme.startswith('rsa-pkcs1v15'):
       # Generate an RSA-PKCS1v15 signature.  Raise
@@ -373,7 +381,8 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256'):
 
 
 
-def verify_rsa_signature(signature, signature_scheme, public_key, data):
+def verify_rsa_signature(signature, signature_scheme, public_key, data,
+                         salt_length=padding.PSS.AUTO):
   """
   <Purpose>
     Determine whether the corresponding private key of 'public_key' produced
@@ -405,6 +414,14 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
     data:
       Data used by securesystemslib.keys.create_signature() to generate
       'signature'.  'data' (a string) is needed here to verify 'signature'.
+
+    salt_length:
+      The salt length (int) used to to generate the signature.
+      By default, this is set to padding.PSS.AUTO,
+      so that it can automatically verify signatures
+      w/o specifying the salt length.
+      Override this to fix your own salt length
+      (e.g., padding.PSS.DIGEST_LENGTH).
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'signature',
@@ -460,7 +477,7 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data):
       if signature_scheme.startswith('rsassa-pss'):
         public_key_object.verify(signature, data,
             padding.PSS(mgf=padding.MGF1(digest_obj.algorithm),
-            salt_length=padding.PSS.AUTO),
+            salt_length=salt_length),
             digest_obj.algorithm)
 
       elif signature_scheme.startswith('rsa-pkcs1v15'):

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -89,6 +89,12 @@ try:
   # https://tools.ietf.org/html/rfc3447#section-8.1
   # The 'padding' module is needed for PSS signatures.
   from cryptography.hazmat.primitives.asymmetric import padding
+  # By default, the PSS signing salt length is set so as
+  # to be backwards-compatible with previous verifiers.
+  _SIGN_SALT_LENGTH = padding.PSS.DIGEST_LENGTH
+  # By default, the PSS verification salt length is set so as to
+  # automatically verify signatures w/o specifying the salt length.
+  _VERIFY_SALT_LENGTH = padding.PSS.AUTO
 
   # Import pyca/cryptography's Key Derivation Function (KDF) module.
   # 'securesystemslib.keys.py' needs this module to derive a secret key according
@@ -112,6 +118,8 @@ try:
   from cryptography.hazmat.primitives.ciphers import modes
 except ImportError:
   CRYPTO = False
+  _SIGN_SALT_LENGTH = None
+  _VERIFY_SALT_LENGTH = None
 
 from securesystemslib import exceptions
 from securesystemslib import formats
@@ -238,7 +246,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
 
 
 def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256',
-                         salt_length=padding.PSS.DIGEST_LENGTH):
+                         salt_length=_SIGN_SALT_LENGTH):
   """
   <Purpose>
     Generate a 'scheme' signature.  The signature, and the signature scheme
@@ -273,8 +281,6 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256',
 
     salt_length:
       The salt length (int) used to to generate the signature.
-      By default, this is set to padding.PSS.DIGEST_LENGTH,
-      so as to be backwards-compatible with previous verifiers.
       Override this to set your own salt length
       (e.g., padding.PSS.MAX_LENGTH).
 
@@ -382,7 +388,7 @@ def create_rsa_signature(private_key, data, scheme='rsassa-pss-sha256',
 
 
 def verify_rsa_signature(signature, signature_scheme, public_key, data,
-                         salt_length=padding.PSS.AUTO):
+                         salt_length=_VERIFY_SALT_LENGTH):
   """
   <Purpose>
     Determine whether the corresponding private key of 'public_key' produced
@@ -417,9 +423,6 @@ def verify_rsa_signature(signature, signature_scheme, public_key, data,
 
     salt_length:
       The salt length (int) used to to generate the signature.
-      By default, this is set to padding.PSS.AUTO,
-      so that it can automatically verify signatures
-      w/o specifying the salt length.
       Override this to fix your own salt length
       (e.g., padding.PSS.DIGEST_LENGTH).
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -149,6 +149,14 @@ class TestPublicInterfaces(unittest.TestCase):
         securesystemslib.interface.import_ecdsa_privatekey_from_file(
             path, password='pw')
 
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.rsa_keys.create_rsa_signature(None, None)
+
+    with self.assertRaises(
+          securesystemslib.exceptions.UnsupportedLibraryError):
+      securesystemslib.rsa_keys.verify_rsa_signature(None, None, None, None)
+
 
   def test_keys(self):
     with self.assertRaises(

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -159,34 +159,34 @@ class TestRSA_keys(unittest.TestCase):
     rsa_scheme = 'rsassa-pss-sha256'
     data = 'The ancients say the longer the salt, the more provable the security'.encode('utf-8')
 
-    # Old-style signature: use the hash length as the salt length.
-    old_signature, _ = securesystemslib.rsa_keys.create_rsa_signature(private_rsa, data)
+    # Default signature: use the digest length as the salt length.
+    def_sig, _ = securesystemslib.rsa_keys.create_rsa_signature(private_rsa, data)
 
-    # New-style signature: use the maximum salt length.
-    new_signature, _ = securesystemslib.rsa_keys.create_rsa_signature(private_rsa, data,
-                                                                      salt_length=padding.PSS.MAX_LENGTH)
+    # "Max" signature: use the maximum salt length.
+    max_sig, _ = securesystemslib.rsa_keys.create_rsa_signature(private_rsa, data,
+                                                                salt_length=padding.PSS.MAX_LENGTH)
 
-    # Test that old verifiers can verify the old-style signature.
-    old_sign_old_ver = securesystemslib.rsa_keys.verify_rsa_signature(old_signature, rsa_scheme,
-                                                                      public_rsa, data,
-                                                                      salt_length=padding.PSS.DIGEST_LENGTH)
-    self.assertTrue(old_sign_old_ver)
-
-    # Test that new verifiers can also automatically verify the old-style signature.
-    old_sig_new_ver = securesystemslib.rsa_keys.verify_rsa_signature(old_signature, rsa_scheme,
-                                                                     public_rsa, data)
-    self.assertTrue(old_sig_new_ver)
-
-    # Test that old verifiers cannot automatically verify new-style signatures.
-    new_sig_old_ver = securesystemslib.rsa_keys.verify_rsa_signature(new_signature, rsa_scheme,
+    # Test that *old* verifiers can verify the *default* signature.
+    def_sig_old_ver = securesystemslib.rsa_keys.verify_rsa_signature(def_sig, rsa_scheme,
                                                                      public_rsa, data,
                                                                      salt_length=padding.PSS.DIGEST_LENGTH)
-    self.assertFalse(new_sig_old_ver)
+    self.assertTrue(def_sig_old_ver)
 
-    # Test that new verifiers can verify new-style signatures.
-    new_sig_new_ver = securesystemslib.rsa_keys.verify_rsa_signature(new_signature, rsa_scheme,
+    # Test that *new* verifiers can also automatically verify the *default* signature.
+    def_sig_new_ver = securesystemslib.rsa_keys.verify_rsa_signature(def_sig, rsa_scheme,
                                                                      public_rsa, data)
-    self.assertTrue(new_sig_new_ver)
+    self.assertTrue(def_sig_new_ver)
+
+    # Test that *old* verifiers *cannot* automatically verify the *max* signature.
+    max_sig_old_ver = securesystemslib.rsa_keys.verify_rsa_signature(max_sig, rsa_scheme,
+                                                                     public_rsa, data,
+                                                                     salt_length=padding.PSS.DIGEST_LENGTH)
+    self.assertFalse(max_sig_old_ver)
+
+    # Test that *new* verifiers can verify the *max* signatures.
+    max_sig_new_ver = securesystemslib.rsa_keys.verify_rsa_signature(max_sig, rsa_scheme,
+                                                                     public_rsa, data)
+    self.assertTrue(max_sig_new_ver)
 
 
   def test_create_rsa_encrypted_pem(self):

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -25,9 +25,7 @@ import securesystemslib.keys
 import securesystemslib.rsa_keys
 import securesystemslib.hash
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import padding
-from cryptography.hazmat.primitives.serialization import load_pem_private_key, load_pem_public_key
 
 public_rsa, private_rsa = securesystemslib.rsa_keys.generate_rsa_public_and_private()
 FORMAT_ERROR_MSG = 'securesystemslib.exceptions.FormatError raised.  Check object\'s format.'


### PR DESCRIPTION
Fixes: #430 

### Description of the changes being introduced by the pull request:

This PR fixes #430 by creating RSA PSS signatures with a salt length that _defaults_ to size of the output of the hash function used in the signature. End-user libraries/applications such as [python-tuf](https://github.com/theupdateframework/python-tuf) and [python-in-toto](https://github.com/in-toto/in-toto) are able to override this default if so desired.

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


