### PR TITLE
Double-check that GPG tests run where expected.

### DIFF
--- a/tests/check_gpg_available.py
+++ b/tests/check_gpg_available.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  check_gpg_available.py
+
+<Author>
+  Zack Newman <zjn@chainguard.dev>
+
+<Started>
+  September 30, 2022.
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  The test suite passes even if GPG is not available, because GPG-dependent
+  tests are skipped if GPG is not present.
+
+  This file asserts the availability of GPG, so CI environments that expect GPG
+  will notice if it goes away unexpectedly rather than silently skipping the GPG
+  tests.
+
+  NOTE: the filename is purposefully check_ rather than test_ so that test
+  discovery doesn't find this unittest and the tests within are only run
+  when explicitly invoked.
+"""
+
+import unittest
+
+import securesystemslib.gpg.constants
+
+
+class TestGpgAvailable(unittest.TestCase):
+  """Test that securesystemslib finds some GPG executable in the environment."""
+
+  def test_gpg_available(self):
+    """Test that GPG is available."""
+    self.assertTrue(securesystemslib.gpg.constants.HAVE_GPG)
+
+if __name__ == "__main__":
+  unittest.main(verbosity=1, buffer=True)

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     -r{toxinidir}/requirements-test.txt
 
 commands =
+    python -m tests.check_gpg_available
     coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 97
 
@@ -23,6 +24,7 @@ commands =
 deps = 
 
 commands =
+    python -m tests.check_gpg_available
     python -m tests.check_public_interfaces
 
 [testenv:py38-no-gpg]


### PR DESCRIPTION
The test suite passes even if GPG is not available, because GPG-dependent tests are skipped if GPG is not present.

This change asserts the availability of GPG, so CI environments that expect GPG will notice if it goes away unexpectedly rather than silently skipping the GPG tests.

Signed-off-by: Zachary Newman <z@znewman.net>


Addresses (does not fix): #428 



### Please verify and check that the pull request fulfils the following requirements:

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [X] Tests have been added for the bug fix or new feature
- [X] Docs have been added for the bug fix or new feature


