### PR TITLE
Remove colorama optional dependency

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,5 +1,4 @@
 cffi==1.15.1              # via cryptography, pynacl
-colorama==0.4.5
 cryptography==38.0.2
 pycparser==2.21           # via cffi
 pynacl==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,3 @@
 #
 cryptography >= 37.0.0; python_version >= '3'
 pynacl
-colorama

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -41,18 +41,6 @@ from securesystemslib.storage import FilesystemBackend
 
 logger = logging.getLogger(__name__)
 
-try:
-    from colorama import Fore
-
-    TERM_RED = Fore.RED
-    TERM_RESET = Fore.RESET
-except ImportError:  # pragma: no cover
-    logger.debug(
-        "Failed to find colorama module, terminal output won't be colored"
-    )
-    TERM_RED = ""
-    TERM_RESET = ""
-
 # Recommended RSA key sizes:
 # https://en.wikipedia.org/wiki/Key_size#Asymmetric_algorithm_key_lengths
 # Based on the above, RSA keys of size 3072 bits are expected to provide
@@ -115,7 +103,7 @@ def _get_key_file_encryption_password(password, prompt, path):
     if prompt:
         password = get_password(
             "enter password to encrypt private key file "
-            "'" + TERM_RED + str(path) + TERM_RESET + "' (leave empty if key "
+            "'" + str(path) + "' (leave empty if key "
             "should not be encrypted): ",
             confirm=True,
         )
@@ -162,7 +150,7 @@ def _get_key_file_decryption_password(password, prompt, path):
     if prompt:
         password = get_password(
             "enter password to decrypt private key file "
-            "'" + TERM_RED + str(path) + TERM_RESET + "' "
+            "'" + str(path) + "' "
             "(leave empty if key not encrypted): ",
             confirm=False,
         )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ setup(
     },
     python_requires="~=3.7",
     extras_require={
-        "colors": ["colorama>=0.3.9"],
         "crypto": ["cryptography>=37.0.0"],
         "pynacl": ["pynacl>1.2.0"],
     },


### PR DESCRIPTION
The coloroma library was used to optionally colorize the private key file path in a password prompt, for encryption or decryption.

Given that the feature is in a rarely used code path -- interactive calls are unlikely to be used outside of demo contexts -- and its merit it generally debatable, our broad goal to minimize dependencies weighs stronger.