### PR TITLE
Made internal keyids consistent

### DIFF
--- a/securesystemslib/ecdsa_keys.py
+++ b/securesystemslib/ecdsa_keys.py
@@ -155,12 +155,12 @@ def generate_public_and_private(scheme="ecdsa-sha2-nistp256"):
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
-    )
+    ).strip()
 
     public_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    ).strip()
 
     return public_pem.decode("utf-8"), private_pem.decode("utf-8")
 
@@ -438,12 +438,12 @@ def create_ecdsa_public_and_private_from_pem(pem, password=None):
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
-    )
+    ).strip()
 
     public = public.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    ).strip()
 
     return public.decode("utf-8"), private.decode("utf-8")
 
@@ -510,7 +510,7 @@ def create_ecdsa_encrypted_pem(private_pem, passphrase):
         encryption_algorithm=serialization.BestAvailableEncryption(
             passphrase.encode("utf-8")
         ),
-    )
+    ).strip()
 
     return encrypted_private_pem
 

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -220,7 +220,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
-    )
+    ).strip()
 
     # Need to generate the public pem from the private key before serialization
     # to PEM.
@@ -228,7 +228,7 @@ def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
     public_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    ).strip()
 
     return public_pem.decode("utf-8"), private_pem.decode("utf-8")
 
@@ -582,7 +582,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
         encryption_algorithm=serialization.BestAvailableEncryption(
             passphrase.encode("utf-8")
         ),
-    )
+    ).strip()
 
     return encrypted_pem.decode()
 
@@ -705,7 +705,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
-    )
+    ).strip()
 
     # Need to generate the public key from the private one before serializing
     # to PEM format.
@@ -713,7 +713,7 @@ def create_rsa_public_and_private_from_pem(pem, passphrase=None):
     public_pem = public_key.public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    ).strip()
 
     return public_pem.decode(), private_pem.decode()
 


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:
It was noticed that internal keyids for ECDSA keys get inconsistent when imported from PEM because `hazmat` either adds nonsignificant whitespaces or not. `securesystemlib` currently forms internal keyids by hashing PEM representations (which is IMHO incorrect), so the keyids are affected by nonsignificant changes. This PR just strips the PEM representations of trailing whitespaces. The proper solution to the problem is to generate the keyids from significant portions of keys only and to make them compatible to other impls, but it is not my job.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature - not my job, the lib was undertested initially
- [x] Docs have been added for the bug fix or new feature - not needed, no API changes


