### PR TITLE
Strip public key pem value

### DIFF
--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1725,7 +1725,7 @@ def import_ecdsakey_from_private_pem(
     # information is not included in the generation of the 'keyid' identifier.
     # Convert any '\r\n' (e.g., Windows) newline characters to '\n' so that a
     # consistent keyid is generated.
-    key_value = {"public": public.replace("\r\n", "\n"), "private": ""}
+    key_value = {"public": public.replace("\r\n", "\n").strip(), "private": ""}
     keyid = _get_keyid(keytype, scheme, key_value)
 
     # Build the 'ecdsakey_dict' dictionary.  Update 'key_value' with the ECDSA

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -770,6 +770,10 @@ class TestKeys(unittest.TestCase):  # pylint: disable=missing-class-docstring
             private_ecdsakey, KEYS.import_ecdsakey_from_pem(private_pem + "\n")
         )
 
+        self.assertEqual(
+            public_ecdsakey["keyid"], private_ecdsakey["keyid"]
+        )
+
         # Supplying a 'bad_pem' argument.
         self.assertRaises(
             securesystemslib.exceptions.FormatError,


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->


### Description of the changes being introduced by the pull request:
This commit adds a call to strip the public key pem value in `import_ecdsakey_from_private_pem`.

The motivation for this that a later call to `import_ecdsakey_from_public_pem` will otherwise cause an incorrect `keyid` to be generated. This is because the call to `extract_pem` will strip any new line character from the public pem, which will then be used to generate the `keyid`, but this will be a different value than the keyid generated earlier due to the removal of the new line character.


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


