### PR TITLE
Quick round of CI improvements

### DIFF
--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - name: Test if ed25519 upstream master HEAD is what we expect
       id: test_ed25519
       run: |
@@ -22,7 +22,7 @@ jobs:
           echo "::set-output name=output::$output"
         fi
     - name: Create issue (unless one is open already)
-      uses: actions/github-script@v3
+      uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
       if: ${{ steps.test_ed25519.outputs.result == '1' }}
       with:
         script: |

--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-ed25519-upstream:
     name: Open an issue if upstream ed25519 has new commits

--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -16,10 +16,10 @@ jobs:
       id: test_ed25519
       run: |
         if output=$(securesystemslib/_vendor/test-ed25519-upstream.sh); then
-          echo "::set-output name=result::0"
+          echo "result=0" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=result::1"
-          echo "::set-output name=output::$output"
+          echo "result=1" >> $GITHUB_OUTPUT
+          echo "output=$output" >> $GITHUB_OUTPUT
         fi
     - name: Create issue (unless one is open already)
       uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
       fail-fast: false
       # Run tests on each OS/Python combination
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         # TODO: Add windows-latest when gpg issues are solved
         os: [ubuntu-latest, macos-latest]
         toxenv: [py]
 
         include:
-          - python-version: 3.8
+          - python-version: "3.11"
             os: ubuntu-latest
-            toxenv: purepy38
-          - python-version: 3.8
+            toxenv: purepy311
+          - python-version: "3.11"
             os: ubuntu-latest
-            toxenv: py38-no-gpg
-          - python-version: 3.8
+            toxenv: py311-no-gpg
+          - python-version: "3.8"
             os: ubuntu-latest
             toxenv: lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout securesystemslib
-        uses: actions/checkout@v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=dir::$(pip cache dir)"
 
       - name: pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           # Use the os dependent pip cache directory found above
           path: ${{ steps.pip-cache.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,8 @@ jobs:
         uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Find pip cache dir
-        id: pip-cache
-        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
-      - name: pip cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          # Use the os dependent pip cache directory found above
-          path: ${{ steps.pip-cache.outputs.dir }}
-          # A match with 'key' counts as cache hit
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          # A match with 'restore-keys' is used as fallback
-          restore-keys: ${{ runner.os }}-pip-
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Find pip cache dir
         id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: pip cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint, py37, py38, py39, py310, purepy38, py38-no-gpg, py38-test-gpg-fails
+envlist = lint, py37, py38, py39, py310, py311, purepy311, py311-no-gpg, py311-test-gpg-fails
 skipsdist = True
 
 [testenv]
@@ -20,14 +20,14 @@ commands =
     coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 97
 
-[testenv:purepy38]
+[testenv:purepy311]
 deps =
 
 commands =
     python -m tests.check_gpg_available
     python -m tests.check_public_interfaces
 
-[testenv:py38-no-gpg]
+[testenv:py311-no-gpg]
 setenv =
     GNUPG = nonexisting-gpg-for-testing
 commands =
@@ -35,7 +35,7 @@ commands =
 
 # This checks that importing securesystemslib.gpg.constants doesn't shell out on
 # import.
-[testenv:py38-test-gpg-fails]
+[testenv:py311-test-gpg-fails]
 setenv =
     GNUPG = false
 commands =


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #455 

### Description of the changes being introduced by the pull request:

* Pin GitHub Actions by digest (#455)
* Remove use of deprecated `set-output` command
* Include latest Python 3.11 in the test matrix
* Switch more of our tox environments to run on the latest Python (but not the linter, see https://github.com/secure-systems-lab/securesystemslib/issues/458)
* Drop permissions for each workflow (h/t @jku)

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


