### PR TITLE
ci: run py311-test-gpg-fails tox env in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - python-version: "3.11"
             os: ubuntu-latest
             toxenv: py311-no-gpg
+          - python-version: "3.11"
+            os: ubuntu-latest
+            toxenv: py311-test-gpg-fails
           - python-version: "3.8"
             os: ubuntu-latest
             toxenv: lint
@@ -51,4 +54,3 @@ jobs:
 
       - name: Run tox
         run: tox -e ${{ matrix.toxenv }}
-


### PR DESCRIPTION
Only tox envs that are in the format `py<MAJOR><MINOR>` are run automatically in CI, all others need to be enabled explicitly.

In #437 a new tox env 'py311-test-gpg-fails' was added but not enabled in CI, this is changed in this patch.
