### PR TITLE
Don't install pre-release packages in tox environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - python-version: "3.11"
             os: ubuntu-latest
             toxenv: py311-test-gpg-fails
-          - python-version: "3.8"
+          - python-version: "3.11"
             os: ubuntu-latest
             toxenv: lint
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skipsdist = True
 
 [testenv]
 install_command =
-    pip install --pre {opts} {packages}
+    pip install {opts} {packages}
 
 deps =
     -r{toxinidir}/requirements-pinned.txt


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #458

### Description of the changes being introduced by the pull request:

- Removes the argument to pip during tox environment setup which tells pip to install pre-release versions of packages.
- Updates the lint tox environment to use latest (3.11) version of Python

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


