### PR TITLE
WIP: Fix implementation of abstract base classes (ABCs) to use Python3 syntax

### DIFF
--- a/securesystemslib/signer.py
+++ b/securesystemslib/signer.py
@@ -5,7 +5,7 @@ signing implementations and a couple of example implementations.
 
 """
 
-import abc
+from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Mapping, Optional
 
 import securesystemslib.gpg.functions as gpg
@@ -137,12 +137,10 @@ class GPGSignature(Signature):
         }
 
 
-class Signer:
+class Signer(metaclass=ABCMeta):
     """Signer interface created to support multiple signing implementations."""
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
+    @abstractmethod
     def sign(self, payload: bytes) -> Signature:
         """Signs a given payload by the key assigned to the Signer instance.
 

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -15,12 +15,12 @@
   Provides an interface for filesystem interactions, StorageBackendInterface.
 """
 
-import abc
 import errno
 import logging
 import os
 import shutil
 import stat
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from typing import IO, BinaryIO, Iterator, List, Optional
 
@@ -29,16 +29,14 @@ from securesystemslib import exceptions
 logger = logging.getLogger(__name__)
 
 
-class StorageBackendInterface:
+class StorageBackendInterface(metaclass=ABCMeta):
     """
     <Purpose>
     Defines an interface for abstract storage operations which can be implemented
     for a variety of storage solutions, such as remote and local filesystems.
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
+    @abstractmethod
     @contextmanager
     def get(self, filepath: str) -> Iterator[BinaryIO]:
         """
@@ -64,7 +62,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def put(
         self, fileobj: IO, filepath: str, restrict: Optional[bool] = False
     ) -> None:
@@ -96,7 +94,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def remove(self, filepath: str) -> None:
         """
         <Purpose>
@@ -114,7 +112,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def getsize(self, filepath: str) -> int:
         """
         <Purpose>
@@ -133,7 +131,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def create_folder(self, filepath: str) -> None:
         """
         <Purpose>
@@ -155,7 +153,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def list_folder(self, filepath: str) -> List[str]:
         """
         <Purpose>


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #463 

### Description of the changes being introduced by the pull request:

Update the `Signer` and `StorageBackendInterface` bases classes to be abstract base classes. Due to the removal of the `__metaclass__` attribute in Python 3 the current implementations are standard classes which can be instantiated.

The correct way to specify a metaclass in Python 3 is the metaclasss keyword argument: https://peps.python.org/pep-3115/

**NOTE:** this is marked as draft because I have not yet tested any securesystemslib dependents with this change.

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


