### PR TITLE
Convert `StorageBackendInterface` to `typing.Protocol`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ classifiers = [
     "Topic :: Software Development",
 ]
 requires-python = "~=3.7"
+dependencies = [
+    "typing-extensions; python_version<'3.8'"
+]
 dynamic = ["version"]
 
 [project.urls]

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -4,3 +4,4 @@ pycparser==2.21           # via cffi
 pynacl==1.5.0
 six==1.16.0               # via pynacl
 PySPX==0.5.0
+typing-extensions==4.4.0 ; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@
 cryptography >= 37.0.0; python_version >= '3'
 pynacl
 PySPX
+typing-extensions; python_version < '3.8'

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -22,9 +22,9 @@ import os
 import shutil
 import stat
 import sys
-
 from contextlib import contextmanager
 from typing import IO, BinaryIO, Iterator, List, Optional
+
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
@@ -98,7 +98,6 @@ class StorageBackendInterface(Protocol):
           None
         """
         raise NotImplementedError  # pragma: no cover
-
 
     def remove(self, filepath: str) -> None:
         """
@@ -176,7 +175,7 @@ class StorageBackendInterface(Protocol):
         raise NotImplementedError  # pragma: no cover
 
 
-class FilesystemBackend():
+class FilesystemBackend:
     """
     <Purpose>
       A concrete implementation of StorageBackendInterface which interacts with

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -12,7 +12,8 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  Provides an interface for filesystem interactions, StorageBackendInterface.
+  Provides an interface, `StorageBackendInterface(typing.Protocol)` for storage
+  system interactions.
 """
 
 import errno
@@ -20,23 +21,28 @@ import logging
 import os
 import shutil
 import stat
-from abc import ABCMeta, abstractmethod
+import sys
+
 from contextlib import contextmanager
 from typing import IO, BinaryIO, Iterator, List, Optional
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
 
 from securesystemslib import exceptions
 
 logger = logging.getLogger(__name__)
 
 
-class StorageBackendInterface(metaclass=ABCMeta):
+class StorageBackendInterface(Protocol):
     """
     <Purpose>
-    Defines an interface for abstract storage operations which can be implemented
-    for a variety of storage solutions, such as remote and local filesystems.
+    Defines an interface for abstract storage operations which can be
+    implemented for a variety of storage solutions, such as remote and local
+    filesystems.
     """
 
-    @abstractmethod
     @contextmanager
     def get(self, filepath: str) -> Iterator[BinaryIO]:
         """
@@ -62,7 +68,6 @@ class StorageBackendInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abstractmethod
     def put(
         self, fileobj: IO, filepath: str, restrict: Optional[bool] = False
     ) -> None:
@@ -94,7 +99,7 @@ class StorageBackendInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abstractmethod
+
     def remove(self, filepath: str) -> None:
         """
         <Purpose>
@@ -112,7 +117,6 @@ class StorageBackendInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abstractmethod
     def getsize(self, filepath: str) -> int:
         """
         <Purpose>
@@ -131,7 +135,6 @@ class StorageBackendInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abstractmethod
     def create_folder(self, filepath: str) -> None:
         """
         <Purpose>
@@ -153,7 +156,6 @@ class StorageBackendInterface(metaclass=ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abstractmethod
     def list_folder(self, filepath: str) -> List[str]:
         """
         <Purpose>
@@ -174,7 +176,7 @@ class StorageBackendInterface(metaclass=ABCMeta):
         raise NotImplementedError  # pragma: no cover
 
 
-class FilesystemBackend(StorageBackendInterface):
+class FilesystemBackend():
     """
     <Purpose>
       A concrete implementation of StorageBackendInterface which interacts with

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -15,12 +15,12 @@
   Provides an interface for filesystem interactions, StorageBackendInterface.
 """
 
-import abc
 import errno
 import logging
 import os
 import shutil
 import stat
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from typing import IO, BinaryIO, Iterator, List, Optional
 
@@ -29,16 +29,14 @@ from securesystemslib import exceptions
 logger = logging.getLogger(__name__)
 
 
-class StorageBackendInterface:
+class StorageBackendInterface(metaclass=ABCMeta):
     """
     <Purpose>
     Defines an interface for abstract storage operations which can be implemented
     for a variety of storage solutions, such as remote and local filesystems.
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
+    @abstractmethod
     @contextmanager
     def get(self, filepath: str) -> Iterator[BinaryIO]:
         """
@@ -64,7 +62,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def put(
         self, fileobj: IO, filepath: str, restrict: Optional[bool] = False
     ) -> None:
@@ -96,7 +94,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def remove(self, filepath: str) -> None:
         """
         <Purpose>
@@ -114,7 +112,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def getsize(self, filepath: str) -> int:
         """
         <Purpose>
@@ -133,7 +131,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def create_folder(self, filepath: str) -> None:
         """
         <Purpose>
@@ -155,7 +153,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def list_folder(self, filepath: str) -> List[str]:
         """
         <Purpose>


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #

### Description of the changes being introduced by the pull request:

As reported in #463 the `__metaclass__` attribute no longer works in Python 3. Furthermore, as proposed in https://github.com/secure-systems-lab/securesystemslib/issues/463#issuecomment-1330338153 `typing.Protocol` is a better fit for places we use `AbstractBaseClass` to define interfaces without any attached implementation.

This PR first fixes the ABC use in storage.py to match Python3 syntax, then in a follow-on commit changes from using an ABC to a Protocol as the base class for `StorageBackendInterface`.

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


