### PR TITLE
Fix metaclass usage

### DIFF
--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -1,8 +1,8 @@
 """Signer interface and the default implementations"""
 
-import abc
 import logging
 import os
+from abc import ABCMeta, abstractmethod
 from typing import Callable, Dict, Optional, Type
 from urllib import parse
 
@@ -25,7 +25,7 @@ SIGNER_FOR_URI_SCHEME: Dict[str, Type] = {}
 SecretsHandler = Callable[[str], str]
 
 
-class Signer:
+class Signer(metaclass=ABCMeta):
     """Signer interface that supports multiple signing implementations.
 
     Usage example:
@@ -71,9 +71,7 @@ class Signer:
     used.
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
+    @abstractmethod
     def sign(self, payload: bytes) -> Signature:
         """Signs a given payload by the key assigned to the Signer instance.
 
@@ -86,7 +84,7 @@ class Signer:
         raise NotImplementedError  # pragma: no cover
 
     @classmethod
-    @abc.abstractmethod
+    @abstractmethod
     def from_priv_key_uri(
         cls,
         priv_key_uri: str,

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -15,12 +15,12 @@
   Provides an interface for filesystem interactions, StorageBackendInterface.
 """
 
-import abc
 import errno
 import logging
 import os
 import shutil
 import stat
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from typing import IO, BinaryIO, Iterator, List, Optional
 
@@ -29,16 +29,14 @@ from securesystemslib import exceptions
 logger = logging.getLogger(__name__)
 
 
-class StorageBackendInterface:
+class StorageBackendInterface(metaclass=ABCMeta):
     """
     <Purpose>
     Defines an interface for abstract storage operations which can be implemented
     for a variety of storage solutions, such as remote and local filesystems.
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
+    @abstractmethod
     @contextmanager
     def get(self, filepath: str) -> Iterator[BinaryIO]:
         """
@@ -64,7 +62,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def put(
         self, fileobj: IO, filepath: str, restrict: Optional[bool] = False
     ) -> None:
@@ -96,7 +94,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def remove(self, filepath: str) -> None:
         """
         <Purpose>
@@ -114,7 +112,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def getsize(self, filepath: str) -> int:
         """
         <Purpose>
@@ -133,7 +131,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def create_folder(self, filepath: str) -> None:
         """
         <Purpose>
@@ -155,7 +153,7 @@ class StorageBackendInterface:
         """
         raise NotImplementedError  # pragma: no cover
 
-    @abc.abstractmethod
+    @abstractmethod
     def list_folder(self, filepath: str) -> List[str]:
         """
         <Purpose>


### PR DESCRIPTION
<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->
Fixes: #463

### Description of the changes being introduced by the pull request:
The __metaclass__ attribute was removed in Python3 and the correct way to specify a metaclass in Python 3 is the metaclass keyword argument: https://peps.python.org/pep-3115/

Update `storage.py` and `signer.py` to use the correct syntax.

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


