### PR TITLE
Dependabot: Enable actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "10:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Somehow this was not on for securesystemslib: many actions are likely out-of-date.

Fixes #474