### PR TITLE
GCPSigner import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Issues = "https://github.com/secure-systems-lab/securesystemslib/issues"
 
 [project.optional-dependencies]
 crypto = ["cryptography>=37.0.0"]
-gcpkms = ["google-cloud-kms"]
+gcpkms = ["google-cloud-kms", "cryptography>=37.0.0"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX==0.5.0"]
 asn1 = ["asn1crypto"]

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -66,7 +66,6 @@ class GCPSigner(Signer):
 
         self.hash_algorithm = self._get_hash_algorithm(public_key)
         self.gcp_keyid = gcp_keyid
-        self.priv_key_uri = f"{self.SCHEME}:{gcp_keyid}"
         self.public_key = public_key
         self.client = kms.KeyManagementServiceClient()
 

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -104,6 +104,7 @@ class GCPSigner(Signer):
 
         self.hash_algorithm = self._get_hash_algorithm(public_key)
         self.gcp_keyid = gcp_keyid
+        self.priv_key_uri = f"{self.SCHEME}:{gcp_keyid}"
         self.public_key = public_key
         self.client = kms.KeyManagementServiceClient()
 

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -114,11 +114,11 @@ class GCPSigner(Signer):
         """Return keytype and scheme for the KMS algorithm enum"""
         keytypes_and_schemes = {
             CryptoKeyVersion.CryptoKeyVersionAlgorithm.EC_SIGN_P256_SHA256: (
-                "ecdsa-sha2-nistp256",
+                "ecdsa",
                 "ecdsa-sha2-nistp256",
             ),
             CryptoKeyVersion.CryptoKeyVersionAlgorithm.EC_SIGN_P384_SHA384: (
-                "ecdsa-sha2-nistp384",
+                "ecdsa",
                 "ecdsa-sha2-nistp384",
             ),
             CryptoKeyVersion.CryptoKeyVersionAlgorithm.RSA_SIGN_PSS_2048_SHA256: (

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -36,9 +36,14 @@ class GCPSigner(Signer):
     The signer uses "ambient" credentials: typically environment var
     GOOGLE_APPLICATION_CREDENTIALS that points to a file with valid
     credentials. These will be found by google.cloud.kms, see
-    https://cloud.google.com/docs/authentication/getting-started
-    (and https://github.com/google-github-actions/auth for the relevant
-    GitHub action).
+    https://cloud.google.com/docs/authentication/getting-started.
+    Some practical authentication options include:
+    * GitHub Action: https://github.com/google-github-actions/auth
+    * gcloud CLI: https://cloud.google.com/sdk/gcloud
+
+    The specific permissions that GCPSigner needs are:
+    * roles/cloudkms.signer for sign()
+    * roles/cloudkms.publicKeyViewer for import()
 
     Arguments:
         gcp_keyid: Fully qualified GCP KMS key name, like

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -85,8 +85,12 @@ class GCPSigner(Signer):
         return cls(uri.path, public_key)
 
     @classmethod
-    def import_(cls, gcp_keyid: str):
-        """Load signer (including public key) from KMS"""
+    def import_(cls, gcp_keyid: str) -> Tuple[str, Key]:
+        """Load key and signer details from KMS
+
+        Returns the private key uri and the public key. This method should only
+        be called once per key: the uri and Key should be stored for later use.
+        """
         if GCP_IMPORT_ERROR:
             raise exceptions.UnsupportedLibraryError(GCP_IMPORT_ERROR)
 
@@ -104,7 +108,7 @@ class GCPSigner(Signer):
         keyid = _get_keyid(keytype, scheme, keyval)
         public_key = SSlibKey(keyid, keytype, scheme, keyval)
 
-        return cls(gcp_keyid, public_key)
+        return f"{cls.SCHEME}:{gcp_keyid}", public_key
 
     @staticmethod
     def _get_keytype_and_scheme(algorithm: int) -> Tuple[str, str]:

--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -191,10 +191,14 @@ class HSMSigner(Signer):
         return ECDomainParameters.load(bytes(params)), bytes(point)
 
     @classmethod
-    def pubkey_from_hsm(
+    def import_(
         cls, sslib_keyid: str, hsm_keyid: Optional[int] = None
-    ) -> SSlibKey:
-        """Export public key from HSM.
+    ) -> Tuple[str, SSlibKey]:
+        """Import public key and signer details from HSM.
+
+        Returns a private key URI (for Signer.from_priv_key_uri()) and a public
+        key. import_() should be called once and the returned URI and public
+        key should be stored for later use.
 
         Arguments:
             sslib_keyid: Key identifier that is unique within the metadata it is used in.
@@ -240,12 +244,13 @@ class HSMSigner(Signer):
             .decode()
         )
 
-        return SSlibKey(
+        key = SSlibKey(
             sslib_keyid,
             KEY_TYPE_ECDSA,
             _SCHEME_FOR_CURVE[curve],
             {"public": public_pem},
         )
+        return "hsm:", key
 
     @classmethod
     def from_priv_key_uri(

--- a/tests/check_kms_signers.py
+++ b/tests/check_kms_signers.py
@@ -18,13 +18,26 @@ GitHub Action environment because of the above requirements.
 import unittest
 
 from securesystemslib.exceptions import UnverifiedSignatureError
-from securesystemslib.signer import Key, Signer
+from securesystemslib.signer import GCPSigner, Key, Signer
 
 
 class TestKMSKeys(unittest.TestCase):
     """Test that KMS keys can be used to sign."""
 
-    def test_gcp(self):
+    pubkey = Key.from_dict(
+        "abcd",
+        {
+            "keyid": "abcd",
+            "keytype": "ecdsa",
+            "scheme": "ecdsa-sha2-nistp256",
+            "keyval": {
+                "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/ptvrXYuUc2ZaKssHhtg/IKNbO1X\ncDWlbKqLNpaK62MKdOwDz1qlp5AGHZkTY9tO09iq1F16SvVot1BQ9FJ2dw==\n-----END PUBLIC KEY-----\n"
+            },
+        },
+    )
+    gcp_id = "projects/python-tuf-kms/locations/global/keyRings/securesystemslib-tests/cryptoKeys/ecdsa-sha2-nistp256/cryptoKeyVersions/1"
+
+    def test_gcp_sign(self):
         """Test that GCP KMS key works for signing
 
         NOTE: The KMS account is setup to only accept requests from the
@@ -35,25 +48,26 @@ class TestKMSKeys(unittest.TestCase):
         """
 
         data = "data".encode("utf-8")
-        pubkey = Key.from_dict(
-            "abcd",
-            {
-                "keyid": "abcd",
-                "keytype": "ecdsa",
-                "scheme": "ecdsa-sha2-nistp256",
-                "keyval": {
-                    "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/ptvrXYuUc2ZaKssHhtg/IKNbO1X\ncDWlbKqLNpaK62MKdOwDz1qlp5AGHZkTY9tO09iq1F16SvVot1BQ9FJ2dw==\n-----END PUBLIC KEY-----\n"
-                },
-            },
-        )
-        gcp_id = "projects/python-tuf-kms/locations/global/keyRings/securesystemslib-tests/cryptoKeys/ecdsa-sha2-nistp256/cryptoKeyVersions/1"
 
-        signer = Signer.from_priv_key_uri(f"gcpkms:{gcp_id}", pubkey)
+        signer = Signer.from_priv_key_uri(f"gcpkms:{self.gcp_id}", self.pubkey)
         sig = signer.sign(data)
 
-        pubkey.verify_signature(sig, data)
+        self.pubkey.verify_signature(sig, data)
         with self.assertRaises(UnverifiedSignatureError):
-            pubkey.verify_signature(sig, b"NOT DATA")
+            self.pubkey.verify_signature(sig, b"NOT DATA")
+
+    def test_gcp_import(self):
+        """Test that GCP KMS key can be imported
+
+        NOTE: The KMS account is setup to only accept requests from the
+        Securesystemslib GitHub Action environment: test cannot pass elsewhere.
+
+        In case of problems with KMS account, please file an issue and
+        assign @jku.
+        """
+
+        signer = GCPSigner.import_(self.gcp_id)
+        self.assertEqual(self.pubkey, signer.public_key)
 
 
 if __name__ == "__main__":

--- a/tests/check_kms_signers.py
+++ b/tests/check_kms_signers.py
@@ -25,9 +25,9 @@ class TestKMSKeys(unittest.TestCase):
     """Test that KMS keys can be used to sign."""
 
     pubkey = Key.from_dict(
-        "23b650fcc538c0c6d423d0886448172fd51d81f43ef749851a0a84978cdcd8e0",
+        "218611b80052667026c221f8774249b0f6b8b310d30a5c45a3b878aa3a02f39e",
         {
-            "keytype": "ecdsa-sha2-nistp256",
+            "keytype": "ecdsa",
             "scheme": "ecdsa-sha2-nistp256",
             "keyval": {
                 "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/ptvrXYuUc2ZaKssHhtg/IKNbO1X\ncDWlbKqLNpaK62MKdOwDz1qlp5AGHZkTY9tO09iq1F16SvVot1BQ9FJ2dw==\n-----END PUBLIC KEY-----\n"

--- a/tests/check_kms_signers.py
+++ b/tests/check_kms_signers.py
@@ -65,8 +65,9 @@ class TestKMSKeys(unittest.TestCase):
         assign @jku.
         """
 
-        signer = GCPSigner.import_(self.gcp_id)
-        self.assertEqual(self.pubkey, signer.public_key)
+        uri, key = GCPSigner.import_(self.gcp_id)
+        self.assertEqual(key, self.pubkey)
+        self.assertEqual(uri, f"gcpkms:{self.gcp_id}")
 
 
 if __name__ == "__main__":

--- a/tests/check_kms_signers.py
+++ b/tests/check_kms_signers.py
@@ -25,10 +25,9 @@ class TestKMSKeys(unittest.TestCase):
     """Test that KMS keys can be used to sign."""
 
     pubkey = Key.from_dict(
-        "abcd",
+        "23b650fcc538c0c6d423d0886448172fd51d81f43ef749851a0a84978cdcd8e0",
         {
-            "keyid": "abcd",
-            "keytype": "ecdsa",
+            "keytype": "ecdsa-sha2-nistp256",
             "scheme": "ecdsa-sha2-nistp256",
             "keyval": {
                 "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/ptvrXYuUc2ZaKssHhtg/IKNbO1X\ncDWlbKqLNpaK62MKdOwDz1qlp5AGHZkTY9tO09iq1F16SvVot1BQ9FJ2dw==\n-----END PUBLIC KEY-----\n"

--- a/tests/test_hsm_signer.py
+++ b/tests/test_hsm_signer.py
@@ -139,7 +139,7 @@ class TestHSM(unittest.TestCase):
         """Test HSM key export and signing."""
 
         for hsm_keyid in [self.hsm_keyid, self.hsm_keyid_default]:
-            key = HSMSigner.pubkey_from_hsm(self.sslib_keyid, hsm_keyid)
+            _, key = HSMSigner.import_(self.sslib_keyid, hsm_keyid)
             signer = HSMSigner(hsm_keyid, key, lambda sec: self.hsm_user_pin)
             sig = signer.sign(b"DATA")
             key.verify_signature(sig, b"DATA")
@@ -150,11 +150,9 @@ class TestHSM(unittest.TestCase):
     def test_hsm_uri(self):
         """Test HSM default key export and signing from URI."""
 
-        key = HSMSigner.pubkey_from_hsm(
-            self.sslib_keyid, self.hsm_keyid_default
-        )
+        uri, key = HSMSigner.import_(self.sslib_keyid, self.hsm_keyid_default)
         signer = Signer.from_priv_key_uri(
-            "hsm:", key, lambda sec: self.hsm_user_pin
+            uri, key, lambda sec: self.hsm_user_pin
         )
         sig = signer.sign(b"DATA")
         key.verify_signature(sig, b"DATA")

--- a/tests/test_hsm_signer.py
+++ b/tests/test_hsm_signer.py
@@ -51,7 +51,6 @@ class TestHSM(unittest.TestCase):
     See .github/workflows/hsm.yml for how this can be done on Linux, macOS and Windows.
     """
 
-    sslib_keyid = "a" * 64  # Mock SSlibKey conform sha256 hex digest keyid
     hsm_keyid = 1
     hsm_keyid_default = 2
     hsm_user_pin = "123456"
@@ -139,7 +138,7 @@ class TestHSM(unittest.TestCase):
         """Test HSM key export and signing."""
 
         for hsm_keyid in [self.hsm_keyid, self.hsm_keyid_default]:
-            _, key = HSMSigner.import_(self.sslib_keyid, hsm_keyid)
+            _, key = HSMSigner.import_(hsm_keyid)
             signer = HSMSigner(hsm_keyid, key, lambda sec: self.hsm_user_pin)
             sig = signer.sign(b"DATA")
             key.verify_signature(sig, b"DATA")
@@ -150,7 +149,7 @@ class TestHSM(unittest.TestCase):
     def test_hsm_uri(self):
         """Test HSM default key export and signing from URI."""
 
-        uri, key = HSMSigner.import_(self.sslib_keyid, self.hsm_keyid_default)
+        uri, key = HSMSigner.import_(self.hsm_keyid_default)
         signer = Signer.from_priv_key_uri(
             uri, key, lambda sec: self.hsm_user_pin
         )


### PR DESCRIPTION
Implement import  (loading the whole key, including public key, from the KMS) for GCPSigner.

This is the implementation of #466 for this specific Signer -- in my opinion this can be merged: if we decide to change something in #466 that affects this Signer we can do that later.

At this point GCPSigner is fully usable: I don't think it needs anything more.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


