### PR TITLE
Add GPGKey and use with GPGSigner

### DIFF
--- a/securesystemslib/gpg/common.py
+++ b/securesystemslib/gpg/common.py
@@ -635,7 +635,7 @@ def get_pubkey_bundle(data, keyid):
     ):
         if public_key and public_key["keyid"].endswith(keyid.lower()):
             if idx > 1:
-                log.warning(
+                log.debug(
                     "Exporting master key '{}' including subkeys '{}' for"  # pylint: disable=logging-format-interpolation,consider-using-f-string
                     " passed keyid '{}'.".format(
                         master_public_key["keyid"],

--- a/securesystemslib/signer/__init__.py
+++ b/securesystemslib/signer/__init__.py
@@ -5,7 +5,7 @@ This module provides extensible interfaces for public keys and signers:
 Some implementations are provided by default but more can be added by users.
 """
 from securesystemslib.signer._gcp_signer import GCPSigner
-from securesystemslib.signer._gpg_signer import GPGSigner
+from securesystemslib.signer._gpg_signer import GPGKey, GPGSigner
 from securesystemslib.signer._hsm_signer import HSMSigner
 from securesystemslib.signer._key import KEY_FOR_TYPE_AND_SCHEME, Key, SSlibKey
 from securesystemslib.signer._signature import Signature
@@ -23,6 +23,7 @@ SIGNER_FOR_URI_SCHEME.update(
         SSlibSigner.FILE_URI_SCHEME: SSlibSigner,
         GCPSigner.SCHEME: GCPSigner,
         HSMSigner.SCHEME: HSMSigner,
+        GPGSigner.SCHEME: GPGSigner,
     }
 )
 
@@ -47,5 +48,8 @@ KEY_FOR_TYPE_AND_SCHEME.update(
         ("rsa", "rsa-pkcs1v15-sha384"): SSlibKey,
         ("rsa", "rsa-pkcs1v15-sha512"): SSlibKey,
         ("sphincs", "sphincs-shake-128s"): SSlibKey,
+        ("rsa", "pgp+rsa-pkcsv1.5"): GPGKey,
+        ("dsa", "pgp+dsa-fips-180-2"): GPGKey,
+        ("eddsa", "pgp+eddsa-ed25519"): GPGKey,
     }
 )

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -191,6 +191,7 @@ class GPGKey(Key):
                 )
         except (
             exceptions.FormatError,
+            exceptions.UnsupportedLibraryError,
             gpg_exceptions.KeyExpirationError,
         ) as e:
             logger.info("Key %s failed to verify sig: %s", self.keyid, str(e))
@@ -249,7 +250,7 @@ class GPGSigner(Signer):
             raise ValueError(f"GPGSigner does not support {priv_key_uri}")
 
         if secrets_handler is not None:
-            raise ValueError("GPGSigner does not support a secrets handler")
+            logger.warning("GPGSigner does not support a secrets handler")
 
         params = dict(parse.parse_qsl(uri.query))
         keyid = params.get("key")

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -268,7 +268,9 @@ class GPGSigner(Signer):
         return Signature.from_dict(sig_dict)
 
     @classmethod
-    def import_(cls, keyid: str, homedir=None) -> Tuple[str, Key]:
+    def import_(
+        cls, keyid: str, homedir: Optional[str] = None
+    ) -> Tuple[str, Key]:
         """Load key and signer details from GnuPG keyring
 
         Args:

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -1,20 +1,219 @@
 """Signer implementation for OpenPGP """
-from typing import Dict, Optional
 
-import securesystemslib.gpg.functions as gpg
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import parse
+
+from securesystemslib import exceptions
+from securesystemslib.gpg import exceptions as gpg_exceptions
+from securesystemslib.gpg import functions as gpg
 from securesystemslib.signer._key import Key
 from securesystemslib.signer._signer import SecretsHandler, Signature, Signer
+
+logger = logging.getLogger(__name__)
+
+
+class GPGKey(Key):
+    """OpenPGP Key.
+
+    *All parameters named below are not just constructor arguments but also
+    instance attributes.*
+
+    Attributes:
+        keyid: Key identifier that is unique within the metadata it is used in.
+        ketytype:  Key type, e.g. "rsa", "dsa" or "eddsa".
+        scheme: Signing schemes, e.g. "pgp+rsa-pkcsv1.5", "pgp+dsa-fips-180-2",
+                "pgp+eddsa-ed25519".
+        hashes: Hash algorithm to hash the data to be signed, e.g.  "pgp+SHA2".
+        keyval: Opaque key content.
+        creation_time: Unix timestamp when key was created.
+        validity_period: Validity of key in days.
+        subkeys: A dictionary of keyids as keys and GPGKeys as values.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by Securesystemslib
+    """
+
+    def __init__(
+        self,
+        keyid: str,
+        keytype: str,
+        scheme: str,
+        hashes: List[str],
+        keyval: Dict[str, Any],
+        creation_time: Optional[int] = None,
+        validity_period: Optional[int] = None,
+        subkeys: Optional[Dict[str, "GPGKey"]] = None,
+        unrecognized_fields: Optional[Dict[str, Any]] = None,
+    ):
+
+        super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
+
+        self.hashes = hashes
+        self.creation_time = creation_time
+        self.validity_period = validity_period
+        self.subkeys = subkeys
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, GPGKey):
+            return False
+
+        return (
+            super().__eq__(other)
+            and self.hashes == other.hashes
+            and self.creation_time == other.creation_time
+            and self.validity_period == other.validity_period
+            and self.subkeys == other.subkeys
+        )
+
+    @classmethod
+    def __from_dict(
+        cls,
+        keyid: str,
+        keytype: str,
+        scheme: str,
+        subkeys: Optional[Dict[str, "GPGKey"]],
+        key_dict: Dict[str, Any],
+    ) -> "GPGKey":
+        """Helper for common from_*dict operations."""
+
+        hashes = key_dict.pop("hashes")
+        keyval = key_dict.pop("keyval")
+        creation_time = key_dict.pop("creation_time", None)
+        validity_period = key_dict.pop("validity_period", None)
+
+        return cls(
+            keyid,
+            keytype,
+            scheme,
+            hashes,
+            keyval,
+            creation_time,
+            validity_period,
+            subkeys,
+            key_dict,
+        )
+
+    @classmethod
+    def _from_legacy_dict(cls, key_dict: Dict[str, Any]) -> "GPGKey":
+        """Create GPGKey from legacy dictionary representation."""
+
+        keyid = key_dict.pop("keyid")
+        keytype = key_dict.pop("type")
+        scheme = key_dict.pop("method")
+        subkeys = key_dict.pop("subkeys", None)
+
+        if subkeys is not None:
+            subkeys = {
+                keyid: cls._from_legacy_dict(
+                    key
+                )  # pylint: disable=protected-access
+                for (keyid, key) in subkeys.items()
+            }
+
+        return cls.__from_dict(keyid, keytype, scheme, subkeys, key_dict)
+
+    @classmethod
+    def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "GPGKey":
+        keytype = key_dict.pop("keytype")
+        scheme = key_dict.pop("scheme")
+        subkeys = key_dict.pop("subkeys", None)
+
+        if subkeys:
+            subkeys = {
+                keyid: cls.from_dict(keyid, key)
+                for (keyid, key) in subkeys.items()
+            }
+
+        return cls.__from_dict(keyid, keytype, scheme, subkeys, key_dict)
+
+    def __to_dict(self) -> Dict[str, Any]:
+        """Helper for common to_*dict operations."""
+
+        key_dict: Dict[str, Any] = {
+            "hashes": self.hashes,
+            "keyval": self.keyval,
+        }
+        if self.creation_time is not None:
+            key_dict["creation_time"] = self.creation_time
+
+        if self.validity_period is not None:
+            key_dict["validity_period"] = self.validity_period
+
+        return key_dict
+
+    def _to_legacy_dict(self) -> Dict[str, Any]:
+        """Returns legacy dictionary representation of self."""
+
+        key_dict = self.__to_dict()
+        key_dict.update(
+            {
+                "keyid": self.keyid,
+                "type": self.keytype,
+                "method": self.scheme,
+            }
+        )
+
+        if self.subkeys:
+            key_dict["subkeys"] = {
+                keyid: key._to_legacy_dict()  # pylint: disable=protected-access
+                for (keyid, key) in self.subkeys.items()
+            }
+
+        return key_dict
+
+    def to_dict(self) -> Dict[str, Any]:
+        key_dict = self.__to_dict()
+        key_dict.update(
+            {
+                "keytype": self.keytype,
+                "scheme": self.scheme,
+            }
+        )
+
+        if self.subkeys:
+            key_dict["subkeys"] = {
+                keyid: key.to_dict() for (keyid, key) in self.subkeys.items()
+            }
+
+        return key_dict
+
+    def verify_signature(self, signature: Signature, data: bytes) -> None:
+        try:
+            if not gpg.verify_signature(
+                GPGSigner._sig_to_legacy_dict(  # pylint: disable=protected-access
+                    signature
+                ),
+                self._to_legacy_dict(),
+                data,
+            ):
+                raise exceptions.UnverifiedSignatureError(
+                    f"Failed to verify signature by {self.keyid}"
+                )
+        except (
+            exceptions.FormatError,
+            gpg_exceptions.KeyExpirationError,
+        ) as e:
+            logger.info("Key %s failed to verify sig: %s", self.keyid, str(e))
+            raise exceptions.VerificationError(
+                f"Unknown failure to verify signature by {self.keyid}"
+            ) from e
 
 
 class GPGSigner(Signer):
     """OpenPGP Signer
 
-    Runs command in ``GNUPG`` environment variable to sign, fallback commands are
+    Runs command in ``GNUPG`` environment variable to sign. Fallback commands are
     ``gpg2`` and ``gpg``.
 
     Supported signing schemes are: "pgp+rsa-pkcsv1.5", "pgp+dsa-fips-180-2" and
     "pgp+eddsa-ed25519", with SHA-256 hashing.
 
+    GPGSigner can be instantiated with Signer.from_priv_key_uri(). These private key URI
+    schemes are supported:
+
+    * "gnupg:[<GnuPG homedir>][?id=<keyid>]":
+        Signs with GnuPG key identified by keyid, in the keyring in home dir. If
+        homedir is not passed, the default homedir is used.
 
     Arguments:
         keyid: GnuPG local user signing key id. If not passed, the default key is used.
@@ -22,11 +221,17 @@ class GPGSigner(Signer):
 
     """
 
+    SCHEME = "gnupg"
+
     def __init__(
-        self, keyid: Optional[str] = None, homedir: Optional[str] = None
+        self,
+        public_key: Key,
+        keyid: Optional[str] = None,
+        homedir: Optional[str] = None,
     ):
         self.keyid = keyid
         self.homedir = homedir
+        self.public_key = public_key
 
     @classmethod
     def from_priv_key_uri(
@@ -35,41 +240,78 @@ class GPGSigner(Signer):
         public_key: Key,
         secrets_handler: Optional[SecretsHandler] = None,
     ) -> "GPGSigner":
-        raise NotImplementedError("Incompatible with private key URIs")
+        if not isinstance(public_key, GPGKey):
+            raise ValueError(f"expected GPGKey for {priv_key_uri}")
+
+        uri = parse.urlparse(priv_key_uri)
+
+        if uri.scheme != cls.SCHEME:
+            raise ValueError(f"GPGSigner does not support {priv_key_uri}")
+
+        if secrets_handler is not None:
+            raise ValueError("GPGSigner does not support a secrets handler")
+
+        params = dict(parse.parse_qsl(uri.query))
+        keyid = params.get("key")
+        homedir = uri.path or None
+
+        return cls(public_key, keyid, homedir)
 
     @staticmethod
-    def _to_gpg_sig(sig: Signature) -> Dict:
-        """Helper to convert Signature -> internal gpg signature format."""
+    def _sig_to_legacy_dict(sig: Signature) -> Dict:
+        """Helper to convert Signature to internal gpg signature dict format."""
         sig_dict = sig.to_dict()
         sig_dict["signature"] = sig_dict.pop("sig")
         return sig_dict
 
     @staticmethod
-    def _from_gpg_sig(sig_dict: Dict) -> Signature:
-        """Helper to convert internal gpg signature format -> Signature."""
+    def _sig_from_legacy_dict(sig_dict: Dict) -> Signature:
+        """Helper to convert internal gpg signature format to Signature."""
         sig_dict["sig"] = sig_dict.pop("signature")
         return Signature.from_dict(sig_dict)
 
+    @classmethod
+    def import_(cls, keyid: str, homedir=None) -> Tuple[str, Key]:
+        """Load key and signer details from GnuPG keyring
+
+        Args:
+            keyid: GnuPG local user signing key id.
+            homedir: GnuPG home directory path. If not passed, the default homedir is
+                    used.
+
+        Returns:
+            Tuple of private key uri and the public key.
+
+        """
+        uri = f"{cls.SCHEME}:{homedir or ''}{'?key=' + keyid}"
+
+        public_key = (
+            GPGKey._from_legacy_dict(  # pylint: disable=protected-access
+                gpg.export_pubkey(keyid, homedir)
+            )
+        )
+
+        return (uri, public_key)
+
     def sign(self, payload: bytes) -> Signature:
-        """Signs payload with ``gpg``.
+        """Signs payload with GnuPG.
 
         Arguments:
             payload: bytes to be signed.
 
         Raises:
-            ValueError: The gpg command failed to create a valid signature.
-            OSError: the gpg command is not present or non-executable.
-            securesystemslib.exceptions.UnsupportedLibraryError: The gpg
-                command is not available, or the cryptography library is
-                not installed.
-            securesystemslib.gpg.exceptions.CommandError: The gpg command
-                returned a non-zero exit code.
-            securesystemslib.gpg.exceptions.KeyNotFoundError: The used gpg
-                version is not fully supported.
+            ValueError: gpg command failed to create a valid signature.
+            OSError: gpg command is not present or non-executable.
+            securesystemslib.exceptions.UnsupportedLibraryError: gpg command is not
+                available, or the cryptography library is not installed.
+            securesystemslib.gpg.exceptions.CommandError: gpg command returned a
+                non-zero exit code.
+            securesystemslib.gpg.exceptions.KeyNotFoundError: gpg version is not fully
+                supported.
 
         Returns:
             Signature.
         """
-        return self._from_gpg_sig(
+        return self._sig_from_legacy_dict(
             gpg.create_signature(payload, self.keyid, self.homedir)
         )

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -249,9 +249,6 @@ class GPGSigner(Signer):
         if uri.scheme != cls.SCHEME:
             raise ValueError(f"GPGSigner does not support {priv_key_uri}")
 
-        if secrets_handler is not None:
-            logger.warning("GPGSigner does not support a secrets handler")
-
         params = dict(parse.parse_qsl(uri.query))
         keyid = params.get("key")
         homedir = uri.path or None

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -168,6 +168,7 @@ class GPGKey(Key):
             {
                 "keytype": self.keytype,
                 "scheme": self.scheme,
+                **self.unrecognized_fields,
             }
         )
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -321,9 +321,7 @@ class TestPublicInterfaces(
 
     def test_signer(self):
         """Assert generic VerificationError from UnsupportedLibraryError."""
-        key = GPGKey(
-            "aa", "rsa", "pgp+rsa-pkcsv1.5", ["pgp+SHA2"], {"public": "val"}
-        )
+        key = GPGKey("aa", "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"})
         sig = Signature("aa", "aaaaaaa", {"other_headers": "aaaaaa"})
         with self.assertRaises(VerificationError) as ctx:
             key.verify_signature(sig, b"data")

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -41,6 +41,11 @@ import securesystemslib.gpg.functions  # pylint: disable=wrong-import-position
 import securesystemslib.gpg.util  # pylint: disable=wrong-import-position
 import securesystemslib.interface  # pylint: disable=wrong-import-position
 import securesystemslib.keys  # pylint: disable=wrong-import-position
+from securesystemslib.exceptions import (
+    UnsupportedLibraryError,
+    VerificationError,
+)
+from securesystemslib.signer import GPGKey, Signature
 
 
 class TestPublicInterfaces(
@@ -313,6 +318,16 @@ class TestPublicInterfaces(
         with self.assertRaises(expected_error) as ctx:
             securesystemslib.gpg.functions.export_pubkey("f00")
         self.assertEqual(expected_error_msg, str(ctx.exception))
+
+    def test_signer(self):
+        """Assert generic VerificationError from UnsupportedLibraryError."""
+        key = GPGKey(
+            "aa", "rsa", "pgp+rsa-pkcsv1.5", ["pgp+SHA2"], {"public": "val"}
+        )
+        sig = Signature("aa", "aaaaaaa", {"other_headers": "aaaaaa"})
+        with self.assertRaises(VerificationError) as ctx:
+            key.verify_signature(sig, b"data")
+        self.assertIsInstance(ctx.exception.__cause__, UnsupportedLibraryError)
 
 
 if __name__ == "__main__":

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -34,7 +34,6 @@ from securesystemslib.gpg.functions import (
     export_pubkeys,
     verify_signature,
 )
-
 from securesystemslib.signer import GPGKey, GPGSigner, Signer
 
 
@@ -153,7 +152,7 @@ class TestPublicInterfacesGPG(
         for key, sig in key_signature_pairs:
             self.assertTrue(verify_signature(sig, key, data))
             # pylint: disable=protected-access
-            GPGKey._from_legacy_dict(key).verify_signature(
+            GPGSigner._key_from_legacy_dict(key).verify_signature(
                 GPGSigner._sig_from_legacy_dict(sig), data
             )
 

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -56,7 +56,6 @@ class TestPublicInterfacesGPG(
             "aa",
             "rsa",
             "pgp+rsa-pkcsv1.5",
-            ["pgp+SHA2"],
             {"public": {"key": "value"}},
         )
         signer = Signer.from_priv_key_uri("gnupg:?id=abcd", mock_public_key)

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -35,6 +35,8 @@ from securesystemslib.gpg.functions import (
     verify_signature,
 )
 
+from securesystemslib.signer import GPGKey, GPGSigner, Signer
+
 
 class TestPublicInterfacesGPG(
     unittest.TestCase
@@ -47,17 +49,29 @@ class TestPublicInterfacesGPG(
 
     def test_gpg_functions(self):
         """Signing, key export and util functions must raise on missing gpg."""
-        with self.assertRaises(UnsupportedLibraryError) as ctx:
-            create_signature("bar")
-        self.assertEqual(NO_GPG_MSG, str(ctx.exception))
 
-        with self.assertRaises(UnsupportedLibraryError) as ctx:
-            export_pubkey("f00")
-        self.assertEqual(NO_GPG_MSG, str(ctx.exception))
+        # Hand-crafting a GPG public key and loading a signer works w/o gpg, but
+        # signing fails (see below).
+        mock_public_key = GPGKey(
+            "aa",
+            "rsa",
+            "pgp+rsa-pkcsv1.5",
+            ["pgp+SHA2"],
+            {"public": {"key": "value"}},
+        )
+        signer = Signer.from_priv_key_uri("gnupg:?id=abcd", mock_public_key)
 
-        with self.assertRaises(UnsupportedLibraryError) as ctx:
-            export_pubkeys(["f00"])
-        self.assertEqual(NO_GPG_MSG, str(ctx.exception))
+        # Run commands that require gpg and assert error plus message
+        for fn, args in (
+            (create_signature, ("bar",)),
+            (export_pubkey, ("f00",)),
+            (export_pubkeys, (["f00"],)),
+            (GPGSigner.import_, ("keyid",)),
+            (signer.sign, (b"data",)),
+        ):
+            with self.assertRaises(UnsupportedLibraryError) as ctx:
+                fn(*args)
+            self.assertEqual(NO_GPG_MSG, str(ctx.exception))
 
     def test_gpg_verify(self):
         """Signature verification does not require gpg to be installed on the host.
@@ -139,6 +153,10 @@ class TestPublicInterfacesGPG(
 
         for key, sig in key_signature_pairs:
             self.assertTrue(verify_signature(sig, key, data))
+            # pylint: disable=protected-access
+            GPGKey._from_legacy_dict(key).verify_signature(
+                GPGSigner._sig_from_legacy_dict(sig), data
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -483,14 +483,16 @@ class TestGPGRSA(unittest.TestCase):
         legacy_fields = {"keyid", "type", "method"}
         fields = {"keytype", "scheme"}
 
-        legacy_dict = public_key._to_legacy_dict()
+        legacy_dict = GPGSigner._key_to_legacy_dict(public_key)
         for field in legacy_fields:
             self.assertIn(field, legacy_dict)
 
         for field in fields:
             self.assertNotIn(field, legacy_dict)
 
-        self.assertEqual(public_key, GPGKey._from_legacy_dict(legacy_dict))
+        self.assertEqual(
+            public_key, GPGSigner._key_from_legacy_dict(legacy_dict)
+        )
 
     def test_gpg_key__eq__(self):
         """Test GPGKey.__eq__() ."""

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -437,14 +437,17 @@ class TestGPGRSA(unittest.TestCase):
     def test_gpg_signature_data_structure(self):
         """Test custom fields and legacy data structure in gpg signatures."""
         # pylint: disable=protected-access
-        signer = GPGSigner(homedir=self.gnupg_home)
+        _, public_key = GPGSigner.import_(
+            self.signing_subkey_keyid, self.gnupg_home
+        )
+        signer = GPGSigner(public_key, homedir=self.gnupg_home)
         sig = signer.sign(self.test_data)
         self.assertIn("other_headers", sig.unrecognized_fields)
 
-        sig_dict = GPGSigner._to_gpg_sig(sig)
+        sig_dict = GPGSigner._sig_to_legacy_dict(sig)
         self.assertIn("signature", sig_dict)
         self.assertNotIn("sig", sig_dict)
-        sig2 = GPGSigner._from_gpg_sig(sig_dict)
+        sig2 = GPGSigner._sig_from_legacy_dict(sig_dict)
         self.assertEqual(sig, sig2)
 
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -448,9 +448,7 @@ class TestGPGRSA(unittest.TestCase):
 
     def test_gpg_signer_load_with_bad_scheme(self):
         """Load from priv key uri with wrong uri scheme."""
-        key = GPGKey(
-            "aa", "rsa", "pgp+rsa-pkcsv1.5", ["pgp+SHA2"], {"public": "val"}
-        )
+        key = GPGKey("aa", "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"})
         with self.assertRaises(ValueError):
             GPGSigner.from_priv_key_uri("wrong:", key)
 
@@ -494,34 +492,9 @@ class TestGPGRSA(unittest.TestCase):
 
         self.assertEqual(public_key, GPGKey._from_legacy_dict(legacy_dict))
 
-    def test_gpg_key_optional_fields(self):
-        """Test gpg public key from/to_dict with optional fields."""
-
-        keydict_base = {
-            "keytype": "rsa",
-            "scheme": "pgp+rsa-pkcsv1.5",
-            "hashes": ["pgp+SHA2"],
-            "keyval": {
-                "public": "pubkeyval",
-            },
-        }
-
-        for name, val in (
-            ("creation_time", 1),
-            ("validity_period", 1),
-            ("subkeys", {"bb": copy.deepcopy(keydict_base)}),
-        ):
-            keydict = copy.deepcopy(keydict_base)
-            keydict[name] = val
-            key = Key.from_dict("aa", copy.deepcopy(keydict))
-            self.assertIsNotNone(getattr(key, name))
-            self.assertDictEqual(keydict, key.to_dict(), name)
-
     def test_gpg_key__eq__(self):
         """Test GPGKey.__eq__() ."""
-        key1 = GPGKey(
-            "aa", "rsa", "pgp+rsa-pkcsv1.5", ["pgp+SHA2"], {"public": "val"}
-        )
+        key1 = GPGKey("aa", "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"})
         key2 = copy.deepcopy(key1)
         self.assertEqual(key1, key2)
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -401,24 +401,6 @@ class TestGPGRSA(unittest.TestCase):
         os.chdir(cls.working_dir)
         shutil.rmtree(cls.test_dir)
 
-    def test_gpg_sign_and_verify_object_with_default_key(self):
-        """Create a signature using the default key on the keyring."""
-
-        # Public key import requires a keyid, signer loading does not. Ignore the URI w/
-        # keyid returned here, and construct one w/o keyid below, to test default key.
-        _, public_key = GPGSigner.import_(
-            self.signing_subkey_keyid, self.gnupg_home
-        )
-
-        uri = f"gnupg:{self.gnupg_home}"
-        signer = Signer.from_priv_key_uri(uri, public_key)
-        sig = signer.sign(self.test_data)
-
-        public_key.verify_signature(sig, self.test_data)
-
-        with self.assertRaises(UnverifiedSignatureError):
-            public_key.verify_signature(sig, self.wrong_data)
-
     def test_gpg_sign_and_verify_object(self):
         """Create a signature using a specific key on the keyring."""
 


### PR DESCRIPTION
*EDIT 2023/01/20:  remove key id param in private key URI*

*EDIT 2023/03/06:*
  - move min code coverage back to 90%, gpg signer is at 100%, nothing more we can do for coverage in this PR
  - remove optional fields from GPGKey, we shouldn't use advanced PKI concepts from GnuPG -- subkeys, key expiration, etc.  -- in tuf/in-toto metadata, which use these concepts themselves, instead assert that passed and returned key id match on import_ and sign
  - remove obsolete "hashes" field from GPGKey (this is  static for existing schemes, and should be encoded in the scheme for other schemes)

see https://github.com/secure-systems-lab/securesystemslib/pull/488#issuecomment-1398169012 pp. and commit messages for more details

Closes #450 

Kept as draft to,
- [x] rebase on merged [#486](https://github.com/secure-systems-lab/securesystemslib/pull/486)
- [x] figure out GPGKey main/sub-key id mapping to signer (see [discussion](https://github.com/secure-systems-lab/securesystemslib/pull/456#issuecomment-1315138451))
- [x] add more tests

### Description of the changes being introduced by the pull request:

GPGKey is a regular Key with additional GnuPG specific key fields,
and verification method. It also has conversion helpers to translate
from and to a non-in-toto/tuf-spec compliant key format, which is
still used by the underlying securesystemslib.gpg subpackage.

GPGSigner is updated to:
- take a GPGKey as constructor argument, and implement
- ``from_priv_key_uri``, to load signer from `gnupg:[<GnuPG homedir>]`
- ``import_``, to import a public key from a GnuPG keyring and return it along with a uri to create the signer.



### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


