### PR TITLE
Prepare v0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
 # Changelog
+
+## securesystemslib v0.26.0
+
+### Added
+* Private key URI schemes for signer instantiation (#456)
+* Public key container class for signature verification (#456)
+* Post-quantum sphincs+ signing scheme (#427)
+* Hardware Security Module (HSM) signing (#472)
+* Google Cloud KMS signing (#442, #480)
+
+### Changed
+* Use pyproject.toml for build configuration (#253)
+* Use hatchling as build backend (#484)
+* Auto-format and lint all code (#439, #490)
+* Various CI and build improvements (#459, #460, #476, #493, #464)
+
+### Removed
+* Drop colorama optional dependency and colorized output support (#443)
+
+### Fixed
+* Don't shell out to gpg on import (#437)
+* Fix metaclass definition (#473)
+* Make GPGSigner signatures specification compliant (#486)
+
+
 ## securesystemslib v0.25.0
 
 ### Changed

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import logging
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
- bump version in __init__.py
- add changelog entry

----

Closes #475

This release should not break `in-toto` or `python-tuf` implementations, based on maintainer judgement and running their respective test suites against this release.

It does, however, require two updates in in-toto tests ([patch available](https://github.com/in-toto/in-toto/pull/529)) and DataDog integrations, as [discussed](https://github.com/secure-systems-lab/securesystemslib/pull/437#pullrequestreview-1147072331) and [agreed upon ](https://github.com/secure-systems-lab/securesystemslib/pull/437#issuecomment-1284111257) with corresponding maintainers.  cc @trishankatdatadog, @ofek 