### PR TITLE
Correct public_key annotation

### DIFF
--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -153,7 +153,7 @@ class SSlibSigner(Signer):
     def from_priv_key_uri(
         cls,
         priv_key_uri: str,
-        public_key: Key,
+        public_key: SSlibKey,
         secrets_handler: Optional[SecretsHandler] = None,
     ) -> "SSlibSigner":
         """Constructor for Signer to call


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

Correct public_key annotation in SSlibSigner.from_priv_key_uri() as of right now, the "public_key"  argument is defined as a "Key" type, but then on line 166 it's validated that it's actually of an "SSlibKey" type.

This can lead to confusion as to whether other "Key" types can be used as the "public_key" value.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

<!-- Please fill in the fields below to submit a pull request.  The more information
that is provided, the better. -->

<!-- Insert issue number here. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more info. -->

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


