### PR TITLE
Improve gpg subprocess timeout and stop using custom process module

### DIFF
--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -24,13 +24,20 @@ from securesystemslib import process
 
 log = logging.getLogger(__name__)
 
+GPG_TIMEOUT = 10
+
 
 @functools.lru_cache(maxsize=3)
 def is_available_gnupg(gnupg: str) -> bool:
     """Returns whether gnupg points to a gpg binary."""
     gpg_version_cmd = gnupg + " --version"
     try:
-        process.run(gpg_version_cmd, stdout=process.PIPE, stderr=process.PIPE)
+        process.run(
+            gpg_version_cmd,
+            stdout=process.PIPE,
+            stderr=process.PIPE,
+            timeout=GPG_TIMEOUT,
+        )
         return True
     except (OSError, subprocess.TimeoutExpired):
         return False

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -28,7 +28,7 @@ GPG_TIMEOUT = 10
 
 
 @functools.lru_cache(maxsize=3)
-def is_available_gnupg(gnupg: str) -> bool:
+def is_available_gnupg(gnupg: str, timeout=GPG_TIMEOUT) -> bool:
     """Returns whether gnupg points to a gpg binary."""
     gpg_version_cmd = gnupg + " --version"
     try:
@@ -36,7 +36,7 @@ def is_available_gnupg(gnupg: str) -> bool:
             gpg_version_cmd,
             stdout=process.PIPE,
             stderr=process.PIPE,
-            timeout=GPG_TIMEOUT,
+            timeout=timeout,
         )
         return True
     except (OSError, subprocess.TimeoutExpired):

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -34,8 +34,7 @@ def is_available_gnupg(gnupg: str, timeout=GPG_TIMEOUT) -> bool:
     try:
         subprocess.run(  # nosec
             gpg_version_cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
             check=True,
         )

--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -32,7 +32,7 @@ def is_available_gnupg(gnupg: str, timeout=GPG_TIMEOUT) -> bool:
     """Returns whether gnupg points to a gpg binary."""
     gpg_version_cmd = shlex.split(f"{gnupg} --version")
     try:
-        subprocess.run(
+        subprocess.run(  # nosec
             gpg_version_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -130,8 +130,7 @@ def create_signature(content, keyid=None, homedir=None, timeout=GPG_TIMEOUT):
         command,
         input=content,
         check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=timeout,
     )
 
@@ -316,8 +315,7 @@ def export_pubkey(keyid, homedir=None, timeout=GPG_TIMEOUT):
     command = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
     gpg_process = subprocess.run(  # nosec
         command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=timeout,
         check=True,
     )

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -25,6 +25,7 @@ from securesystemslib.gpg.common import (
 )
 from securesystemslib.gpg.constants import (
     FULLY_SUPPORTED_MIN_VERSION,
+    GPG_TIMEOUT,
     NO_GPG_MSG,
     SHA256,
     gpg_export_pubkey_command,
@@ -127,6 +128,7 @@ def create_signature(content, keyid=None, homedir=None):
         check=False,
         stdout=process.PIPE,
         stderr=process.PIPE,
+        timeout=GPG_TIMEOUT,
     )
 
     # TODO: It's suggested to take a look at `--status-fd` for proper error
@@ -307,7 +309,9 @@ def export_pubkey(keyid, homedir=None):
     # TODO: Consider adopting command error handling from `create_signature`
     # above, e.g. in a common 'run gpg command' utility function
     command = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-    gpg_process = process.run(command, stdout=process.PIPE, stderr=process.PIPE)
+    gpg_process = process.run(
+        command, stdout=process.PIPE, stderr=process.PIPE, timeout=GPG_TIMEOUT
+    )
 
     key_packet = gpg_process.stdout
     key_bundle = get_pubkey_bundle(key_packet, keyid)

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -126,7 +126,7 @@ def create_signature(content, keyid=None, homedir=None, timeout=GPG_TIMEOUT):
 
     command = gpg_sign_command(keyarg=keyarg, homearg=homearg)
 
-    gpg_process = subprocess.run(
+    gpg_process = subprocess.run(  # nosec
         command,
         input=content,
         check=False,
@@ -314,7 +314,7 @@ def export_pubkey(keyid, homedir=None, timeout=GPG_TIMEOUT):
     # TODO: Consider adopting command error handling from `create_signature`
     # above, e.g. in a common 'run gpg command' utility function
     command = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-    gpg_process = subprocess.run(
+    gpg_process = subprocess.run(  # nosec
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/securesystemslib/gpg/functions.py
+++ b/securesystemslib/gpg/functions.py
@@ -16,9 +16,10 @@
   verifying signatures.
 """
 import logging
+import subprocess  # nosec
 import time
 
-from securesystemslib import exceptions, formats, process
+from securesystemslib import exceptions, formats
 from securesystemslib.gpg.common import (
     get_pubkey_bundle,
     parse_signature_packet,
@@ -125,12 +126,12 @@ def create_signature(content, keyid=None, homedir=None, timeout=GPG_TIMEOUT):
 
     command = gpg_sign_command(keyarg=keyarg, homearg=homearg)
 
-    gpg_process = process.run(
+    gpg_process = subprocess.run(
         command,
         input=content,
         check=False,
-        stdout=process.PIPE,
-        stderr=process.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         timeout=timeout,
     )
 
@@ -313,9 +314,12 @@ def export_pubkey(keyid, homedir=None, timeout=GPG_TIMEOUT):
     # TODO: Consider adopting command error handling from `create_signature`
     # above, e.g. in a common 'run gpg command' utility function
     command = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-
-    gpg_process = process.run(
-        command, stdout=process.PIPE, stderr=process.PIPE, timeout=timeout
+    gpg_process = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=True,
     )
 
     key_packet = gpg_process.stdout

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -221,8 +221,7 @@ class TestCommon(unittest.TestCase):
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
         proc = subprocess.run(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=GPG_TIMEOUT,
             check=True,
         )
@@ -234,8 +233,7 @@ class TestCommon(unittest.TestCase):
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
         proc = subprocess.run(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=GPG_TIMEOUT,
             check=True,
         )

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -44,6 +44,7 @@ from securesystemslib.gpg.common import (
     parse_signature_packet,
 )
 from securesystemslib.gpg.constants import (
+    GPG_TIMEOUT,
     PACKET_TYPE_PRIMARY_KEY,
     PACKET_TYPE_SUB_KEY,
     PACKET_TYPE_USER_ATTR,
@@ -218,14 +219,18 @@ class TestCommon(unittest.TestCase):
         # erroneous gpg data in tests below.
         keyid = "F557D0FF451DEF45372591429EA70BD13D883381"
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-        proc = process.run(cmd, stdout=process.PIPE, stderr=process.PIPE)
+        proc = process.run(
+            cmd, stdout=process.PIPE, stderr=process.PIPE, timeout=GPG_TIMEOUT
+        )
         self.raw_key_data = proc.stdout
         self.raw_key_bundle = parse_pubkey_bundle(self.raw_key_data)
 
         # Export pubkey bundle with expired key for key expiration tests
         keyid = "E8AC80C924116DABB51D4B987CB07D6D2C199C7C"
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-        proc = process.run(cmd, stdout=process.PIPE, stderr=process.PIPE)
+        proc = process.run(
+            cmd, stdout=process.PIPE, stderr=process.PIPE, timeout=GPG_TIMEOUT
+        )
         self.raw_expired_key_bundle = parse_pubkey_bundle(proc.stdout)
 
     def test_parse_pubkey_payload_errors(self):

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -21,6 +21,7 @@
 
 import os
 import shutil
+import subprocess  # nosec
 import tempfile
 import unittest
 
@@ -33,7 +34,6 @@ import cryptography.hazmat.primitives.hashes as hashing
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import serialization
 
-from securesystemslib import process
 from securesystemslib.formats import ANY_PUBKEY_DICT_SCHEMA, GPG_PUBKEY_SCHEMA
 from securesystemslib.gpg.common import (
     _assign_certified_key_info,
@@ -219,8 +219,12 @@ class TestCommon(unittest.TestCase):
         # erroneous gpg data in tests below.
         keyid = "F557D0FF451DEF45372591429EA70BD13D883381"
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-        proc = process.run(
-            cmd, stdout=process.PIPE, stderr=process.PIPE, timeout=GPG_TIMEOUT
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=GPG_TIMEOUT,
+            check=True,
         )
         self.raw_key_data = proc.stdout
         self.raw_key_bundle = parse_pubkey_bundle(self.raw_key_data)
@@ -228,8 +232,12 @@ class TestCommon(unittest.TestCase):
         # Export pubkey bundle with expired key for key expiration tests
         keyid = "E8AC80C924116DABB51D4B987CB07D6D2C199C7C"
         cmd = gpg_export_pubkey_command(keyid=keyid, homearg=homearg)
-        proc = process.run(
-            cmd, stdout=process.PIPE, stderr=process.PIPE, timeout=GPG_TIMEOUT
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=GPG_TIMEOUT,
+            check=True,
         )
         self.raw_expired_key_bundle = parse_pubkey_bundle(proc.stdout)
 


### PR DESCRIPTION
### Description of the changes being introduced by the pull request:

gpg interface function to sign and export public keys now have an optional subprocess timeout. This means, users no longer need to patch a global in order to configure this value. Moreover, the default timeout is now defined inside the gpg subpackage, and increased to 10.
--> The should reduce test failures on slow runners, and makes it more intuitive to override the default.

Internally the gpg subpackage now no longer uses the custom subprocess wrapper, which provides very little benefit over calling directly into stdlib `subprocess`. 
--> This is in preparation for deprecation of the process module

see commit message for details

### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


