### PR TITLE
Pin test and lint requirements and split into two requirements files

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@
 tox
 -r requirements.txt
 -r requirements-test.txt
+-r requirements-lint.txt
 -e .

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,5 @@
+mypy==1.0.0
+black==22.12.0
+isort==5.12.0
+pylint==2.15.10
+bandit==1.7.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,2 @@
 # additional test tools
-coverage
-mypy
-black
-isort
-pylint
-bandit
+coverage==7.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,9 @@ commands =
     python -c "import securesystemslib.gpg.constants"
 
 [testenv:lint]
+deps =
+    -r{toxinidir}/requirements-pinned.txt
+    -r{toxinidir}/requirements-lint.txt
 commands =
     # TODO: Move configs to pyproject.toml
     black --check --diff --line-length=80 --extend-exclude=_vendor  .


### PR DESCRIPTION
* Pinning prevents unexpected linting failures in unrelated CI runs, due to tool updates.

    NOTE: `black` and `pylint` just made such updates, hence we pin to the previous versions, and address issues flagged by the new versions with the next Dependabot version-update-PR.

* Splitting reduces the Python version requirements for linting tools. Other than unittests, linting only runs in one (recent) Python version.

Fixes #501 