### PR TITLE
Hsm identification

### DIFF
--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -83,26 +83,34 @@ class HSMSigner(Signer):
 
     Supports signing schemes "ecdsa-sha2-nistp256" and "ecdsa-sha2-nistp384".
 
-    HSMSigner uses the first token it finds, if multiple tokens are available. They can
-    be instantiated with Signer.from_priv_key_uri(). These private key URI schemes are
-    supported:
+    HSMSigners should be instantiated with Signer.from_priv_key_uri() as in the usage
+    example below.
 
+    The private key URI scheme is: "hsm:<KEYID>?<FILTERS>" where both KEYID and
+    FILTERS are optional. Example URIs:
     * "hsm:":
-      Sign with key on PIV digital signature slot 9c.
+      Sign with a key with default keyid 2 (PIV digital signature slot 9c) on the
+      only token/smartcard available.
+    * "hsm:2?label=YubiKey+PIV+%2315835999":
+      Sign with key with keyid 2 (PIV slot 9c) on a token with label
+      "YubiKey+PIV+%2315835999"
 
     Usage::
+        # Store public key and URI for your HSM device for later use. By default
+        # slot 9c is selected.
+        uri, pubkey = HSMSigner.import_()
 
-        # sign with PIV slot 9c, verify with existing public key
+        # later, use the uri and pubkey to sign
         def pin_handler(secret: str) -> str:
             return getpass(f"Enter {secret}: ")
 
-        signer = Signer.from_priv_key_uri("hsm:", public_key, pin_handler)
+        signer = Signer.from_priv_key_uri(uri, pubkey, pin_handler)
         sig = signer.sign(b"DATA")
-
-        public_key.verify_signature(sig, b"DATA")
+        pubkey.verify_signature(sig, b"DATA")
 
     Arguments:
         hsm_keyid: Key identifier on the token.
+        token_filter: dictionary of token field names and values
         public_key: The related public key instance.
         pin_handler: A function that returns the HSM user login pin, needed for
                 signing. It receives the string argument "pin".

--- a/tests/test_hsm_signer.py
+++ b/tests/test_hsm_signer.py
@@ -114,6 +114,11 @@ class TestHSM(unittest.TestCase):
         slot = lib.getSlotList(tokenPresent=True)[0]
         lib.initToken(slot, so_pin, token_label)
 
+        # suddenly there are two slots (why?), use label to filter in tests
+        tokeninfo = lib.getTokenInfo(slot)
+        cls.token_filter = {"label": getattr(tokeninfo, "label")}
+        print(cls.token_filter)
+
         session = PYKCS11LIB().openSession(slot, PyKCS11.CKF_RW_SESSION)
         session.login(so_pin, PyKCS11.CKU_SO)
         session.initPin(cls.hsm_user_pin)
@@ -138,8 +143,10 @@ class TestHSM(unittest.TestCase):
         """Test HSM key export and signing."""
 
         for hsm_keyid in [self.hsm_keyid, self.hsm_keyid_default]:
-            _, key = HSMSigner.import_(hsm_keyid)
-            signer = HSMSigner(hsm_keyid, key, lambda sec: self.hsm_user_pin)
+            _, key = HSMSigner.import_(hsm_keyid, self.token_filter)
+            signer = HSMSigner(
+                hsm_keyid, self.token_filter, key, lambda sec: self.hsm_user_pin
+            )
             sig = signer.sign(b"DATA")
             key.verify_signature(sig, b"DATA")
 
@@ -149,7 +156,7 @@ class TestHSM(unittest.TestCase):
     def test_hsm_uri(self):
         """Test HSM default key export and signing from URI."""
 
-        uri, key = HSMSigner.import_(self.hsm_keyid_default)
+        uri, key = HSMSigner.import_(self.hsm_keyid_default, self.token_filter)
         signer = Signer.from_priv_key_uri(
             uri, key, lambda sec: self.hsm_user_pin
         )


### PR DESCRIPTION
I bought a second yubikey so need a way to tell them apart... so: Define a URI that contains identifying information for the HSM token:
 * URI path is the keyid
 * URI query can contain any token field filters (this is a bit overkill but since there's apparently no standards for this it seemed reasonable)

Example URI: `hsm:2?label=YubiKey+PIV+%2315835999`

This would use keyid 2 from a token with label "YubiKey PIV #15835999". This example is also what gets created by HSMSigner.import_() by default.

import_() stays backwards compatible, and old URIs keep working but there are some changes in functionality:
* Running import_() now fails if there are more than 1 tokens (but a filter can be provided there as well). Because of this the tests needed some changes (softhsm creates a new token in InitToken???) -- unfortunately this means the default import_() filter is not tested as I couldn't figure out how to remove the extra softhsm token.
* The constructor has a new required argument (this could be fixed but I didn't see it as that important).

I can be persuaded to do these differently.

### Please verify and check that the pull request fulfills the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature