### PR TITLE
tests: rm HSM availability assertion in tox.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
       - name:  Install system dependencies
         shell: bash
         run: |
+          # NOTE: HSM tests are skipped silently, if PYKCS11LIB is unset.
+
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get install -y softhsm2
             echo "PYKCS11LIB=/usr/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps =
 
 commands =
     python -m tests.check_gpg_available
-    python -c 'import os; os.environ["PYKCS11LIB"]' # assert HSM tests aren't skipped
     coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 90
 


### PR DESCRIPTION
Currently, tox asserts that PYKCS11LIB env var is set to not silently skip tests on SoftHSM (virtual HSM).

This is is unnecessary for CI, where we control the env var, and also hard to figure out locally, where we can't expect everyone to setup SoftHSM.

This patch removes the assertion and adds a note to ci.yml to point out the consequences of unsetting the env var.

Fixes #527 