### PR TITLE
signer: add SigstoreSigner from_priv_key_uri and import_ methods

### DIFF
--- a/.github/workflows/test-sigstore.yml
+++ b/.github/workflows/test-sigstore.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/tests/check_sigstore_signer.py
+++ b/tests/check_sigstore_signer.py
@@ -9,18 +9,9 @@ import os
 import unittest
 
 from securesystemslib.signer import (
-    KEY_FOR_TYPE_AND_SCHEME,
     SIGNER_FOR_URI_SCHEME,
-    Key,
     Signer,
-    SigstoreKey,
     SigstoreSigner,
-)
-
-KEY_FOR_TYPE_AND_SCHEME.update(
-    {
-        ("sigstore-oidc", "Fulcio"): SigstoreKey,
-    }
 )
 
 SIGNER_FOR_URI_SCHEME.update({SigstoreSigner.SCHEME: SigstoreSigner})
@@ -40,22 +31,12 @@ class TestSigstoreSigner(unittest.TestCase):
     def test_sign(self):
         identity = os.getenv("CERT_ID")
         self.assertIsNotNone(identity, "certificate identity required")
-
         issuer = os.getenv("CERT_ISSUER")
         self.assertIsNotNone(issuer, "OIDC issuer required")
 
-        public_key = Key.from_dict(
-            "abcdef",
-            {
-                "keytype": "sigstore-oidc",
-                "scheme": "Fulcio",
-                "keyval": {
-                    "issuer": issuer,
-                    "identity": identity,
-                },
-            },
-        )
-        signer = Signer.from_priv_key_uri("sigstore:", public_key)
+        uri, public_key = SigstoreSigner.import_(identity, issuer)
+        signer = Signer.from_priv_key_uri(uri, public_key)
+
         sig = signer.sign(b"data")
         public_key.verify_signature(sig, b"data")
 

--- a/tests/check_sigstore_signer.py
+++ b/tests/check_sigstore_signer.py
@@ -14,7 +14,7 @@ from securesystemslib.signer import (
     SigstoreSigner,
 )
 
-SIGNER_FOR_URI_SCHEME.update({SigstoreSigner.SCHEME: SigstoreSigner})
+SIGNER_FOR_URI_SCHEME[SigstoreSigner.SCHEME] = SigstoreSigner
 
 
 class TestSigstoreSigner(unittest.TestCase):

--- a/tests/check_sigstore_signer.py
+++ b/tests/check_sigstore_signer.py
@@ -8,11 +8,11 @@ only run when explicitly invoked in a suited environment.
 import os
 import unittest
 
-from sigstore.oidc import detect_credential  # pylint: disable=import-error
-
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
+    SIGNER_FOR_URI_SCHEME,
     Key,
+    Signer,
     SigstoreKey,
     SigstoreSigner,
 )
@@ -22,6 +22,8 @@ KEY_FOR_TYPE_AND_SCHEME.update(
         ("sigstore-oidc", "Fulcio"): SigstoreKey,
     }
 )
+
+SIGNER_FOR_URI_SCHEME.update({SigstoreSigner.SCHEME: SigstoreSigner})
 
 
 class TestSigstoreSigner(unittest.TestCase):
@@ -36,9 +38,6 @@ class TestSigstoreSigner(unittest.TestCase):
     """
 
     def test_sign(self):
-        token = detect_credential()
-        self.assertIsNotNone(token, "ambient credentials required")
-
         identity = os.getenv("CERT_ID")
         self.assertIsNotNone(identity, "certificate identity required")
 
@@ -56,8 +55,7 @@ class TestSigstoreSigner(unittest.TestCase):
                 },
             },
         )
-
-        signer = SigstoreSigner(token, public_key)
+        signer = Signer.from_priv_key_uri("sigstore:", public_key)
         sig = signer.sign(b"data")
         public_key.verify_signature(sig, b"data")
 

--- a/tests/check_sigstore_signer.py
+++ b/tests/check_sigstore_signer.py
@@ -40,10 +40,10 @@ class TestSigstoreSigner(unittest.TestCase):
         self.assertIsNotNone(token, "ambient credentials required")
 
         identity = os.getenv("CERT_ID")
-        self.assertIsNotNone(token, "certificate identity required")
+        self.assertIsNotNone(identity, "certificate identity required")
 
         issuer = os.getenv("CERT_ISSUER")
-        self.assertIsNotNone(token, "OIDC issuer required")
+        self.assertIsNotNone(issuer, "OIDC issuer required")
 
         public_key = Key.from_dict(
             "abcdef",


### PR DESCRIPTION
addresses most of #533 

- `from_priv_key_uri`supports token detection from ambient credentials (default), and token creation from OAuth2 + OpenID browser login (with '?ambient=false' URI param).
- `import_` creates  sigstoreKey from passed identity and issuer, and signer URI based on passed bool to toggle ambient credential usage.

TODOs (not necessarily in this PR)
- [ ] figure out appropriate CI trigger conditions
- [ ] add tests
- [ ] use identity/issuer from public key, passed to `from_priv_key_uri`, in the OAuth2 + OpenID flow
- [ ] validate if public key and token passed to SigstoreSigner's from_priv_key_uri and constructor match
- [ ] [#533](https://github.com/secure-systems-lab/securesystemslib/issues/533) also suggests adding an `SigstoreSigner.import_github_action()` 
