### PR TITLE
CI: limit kms test runs to upstream repo

### DIFF
--- a/.github/workflows/test-kms.yml
+++ b/.github/workflows/test-kms.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   test-kms:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'secure-systems-lab' # only run upstream
 
     permissions:
       id-token: 'write' # for OIDC auth for GCP authentication


### PR DESCRIPTION
* tests can only pass if the KMS allows the repository to authenticate
* even the failure will fail on a fresh fork as the issue filing fails by default (as issues are not enabled on forks)

This seems to work:
* this PR was intentionally made to upstream repo so the check runs: https://github.com/secure-systems-lab/securesystemslib/actions/runs/4448127959/jobs/7810518318
* but same check in personal fork is skipped https://github.com/jku/securesystemslib/actions/runs/4448136505/jobs/7810539165