### PR TITLE
ci/tests: workarounds for flaky windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,9 @@ jobs:
             echo "PYKCS11LIB=$(brew --prefix softhsm)/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
 
           elif [ "$RUNNER_OS" == "Windows" ]; then
-            choco install softhsm.install
-            echo "PYKCS11LIB=C:\SoftHSM2\lib\softhsm2-x64.dll" >> $GITHUB_ENV
+            echo "Skipping HSM tests on Windows"
+            # see https://github.com/secure-systems-lab/securesystemslib/issues/520
+
 
           else
               echo "$RUNNER_OS not supported"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
+"""Securesystemslib tests.
 
+NOTE: This file is only considered when running tests via aggregate_tests.py, or
+with the '-m' flag, when invoked individually.
+
+"""
+
+# Increase gpg subprocess timeout -- Windows CI fails frequently with default 10s.
+import securesystemslib.gpg.constants
+
+securesystemslib.gpg.constants.GPG_TIMEOUT = 120


### PR DESCRIPTION
Works around issues that would frequently fail Windows CI as documented in #520, by:

- disabling hsm tests on Windows,
- generally increaseing gpg subprocess timeout in tests



