### PR TITLE
gpg: set default in function to allow global patch

### DIFF
--- a/securesystemslib/gpg/constants.py
+++ b/securesystemslib/gpg/constants.py
@@ -20,7 +20,7 @@ import logging
 import os
 import shlex
 import subprocess  # nosec
-from typing import List
+from typing import List, Optional
 
 log = logging.getLogger(__name__)
 
@@ -28,8 +28,11 @@ GPG_TIMEOUT = 10
 
 
 @functools.lru_cache(maxsize=3)
-def is_available_gnupg(gnupg: str, timeout=GPG_TIMEOUT) -> bool:
+def is_available_gnupg(gnupg: str, timeout: Optional[int] = None) -> bool:
     """Returns whether gnupg points to a gpg binary."""
+    if timeout is None:
+        timeout = GPG_TIMEOUT
+
     gpg_version_cmd = shlex.split(f"{gnupg} --version")
     try:
         subprocess.run(  # nosec


### PR DESCRIPTION
Patching globals to modify function behavior is an anti-pattern and should not be recommended to a user!!

But it seems acceptable in tests (see #542). For this to work, the global must not be used before being modified, which, AFAIK, is not possible, if the global is defined and used (e.g. in a function signature) in the same scope.

This commit changes the relevant function to access the default value in local scope, so that it global can be imported and modified before it.

More invasive but probably more correct solutions would be:
- move either GPG_TIMEOUT or is_available_gnupg to a different module, or
- call relevant functions in tests with an explicit timeout arg


