### PR TITLE
Remove shebang line from hash.py #498

### DIFF
--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 """
 <Program Name>
   hash.py


### PR DESCRIPTION
Fixes: #498

### Remove shebang line from hash.py

Python2 support has been dropped and we do not need to run the module by itself.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


