### PR TITLE
Remove all python shebang instances from package

### DIFF
--- a/securesystemslib/formats.py
+++ b/securesystemslib/formats.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   formats.py

--- a/securesystemslib/interface.py
+++ b/securesystemslib/interface.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   interface.py

--- a/securesystemslib/keys.py
+++ b/securesystemslib/keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   keys.py

--- a/securesystemslib/rsa_keys.py
+++ b/securesystemslib/rsa_keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   rsa_keys.py

--- a/securesystemslib/schema.py
+++ b/securesystemslib/schema.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   schema.py

--- a/securesystemslib/settings.py
+++ b/securesystemslib/settings.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   settings.py

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   aggregate_tests.py

--- a/tests/check_gpg_available.py
+++ b/tests/check_gpg_available.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   check_gpg_available.py

--- a/tests/check_kms_signers.py
+++ b/tests/check_kms_signers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 This module confirms that signing using KMS keys works.
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   check_public_interfaces.py

--- a/tests/check_public_interfaces_gpg.py
+++ b/tests/check_public_interfaces_gpg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 <Program Name>
   check_public_interfaces_gpg.py

--- a/tests/test_dsse.py
+++ b/tests/test_dsse.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Test cases for "metadata.py". """
 
 import copy

--- a/tests/test_ecdsa_keys.py
+++ b/tests/test_ecdsa_keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env/ python
-
 """
 <Program Name>
   test_ecdsa_keys.py

--- a/tests/test_ed25519_keys.py
+++ b/tests/test_ed25519_keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env/ python
-
 """
 <Program Name>
   test_ed25519_keys.py

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_exceptions.py

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_formats.py

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_gpg.py

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_hash.py

--- a/tests/test_hsm_signer.py
+++ b/tests/test_hsm_signer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Test HSMSigner
 """
 import os

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_interface.py

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_keys.py

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_rsa_keys.py

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_schema.py

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Test cases for "signer.py". """
 
 import copy

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
 <Program Name>
   test_util.py


### PR DESCRIPTION
Fixes: #544 and #498

### Other instances are in diff files, actual generated python code, or unrelated to python shebang instances

Followup from discussion / work in #544 and #498

Lines can be removed since Python2 support has been deprecated and all modules work with Python3 and do not need to specify which python instance to use.

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


