### PR TITLE
signer API: improve graceful failure testing and fix thus revealed error handling bug

### DIFF
--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -175,6 +175,7 @@ class SSlibKey(Key):
             exceptions.CryptoError,
             exceptions.FormatError,
             exceptions.UnsupportedAlgorithmError,
+            exceptions.UnsupportedLibraryError,
         ) as e:
             logger.info("Key %s failed to verify sig: %s", self.keyid, str(e))
             raise exceptions.VerificationError(

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -317,13 +317,21 @@ class TestPublicInterfaces(
             securesystemslib.gpg.functions.export_pubkey("f00")
         self.assertEqual(expected_error_msg, str(ctx.exception))
 
-    def test_signer(self):
+    def test_signer_verify(self):
         """Assert generic VerificationError from UnsupportedLibraryError."""
-        key = GPGKey("aa", "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"})
-        sig = Signature("aa", "aaaaaaa", {"other_headers": "aaaaaa"})
-        with self.assertRaises(VerificationError) as ctx:
-            key.verify_signature(sig, b"data")
-        self.assertIsInstance(ctx.exception.__cause__, UnsupportedLibraryError)
+        keyid = "aa"
+        sig = Signature(keyid, "aaaaaaaa", {"other_headers": "aaaaaa"})
+
+        keys = [
+            GPGKey(keyid, "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"}),
+        ]
+
+        for key in keys:
+            with self.assertRaises(VerificationError) as ctx:
+                key.verify_signature(sig, b"data")
+            self.assertIsInstance(
+                ctx.exception.__cause__, UnsupportedLibraryError
+            )
 
 
 if __name__ == "__main__":

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -43,7 +43,8 @@ from securesystemslib.exceptions import (
     UnsupportedLibraryError,
     VerificationError,
 )
-from securesystemslib.signer import GPGKey, Key, Signature
+from securesystemslib.signer import GPGKey, Key, Signature, SSlibKey
+from securesystemslib.signer._sigstore_signer import SigstoreKey
 
 
 class TestPublicInterfaces(
@@ -324,13 +325,21 @@ class TestPublicInterfaces(
 
         keys = [
             GPGKey(keyid, "rsa", "pgp+rsa-pkcsv1.5", {"public": "val"}),
+            SSlibKey(keyid, "rsa", "rsa-pkcs1v15-sha512", {"public": "val"}),
+            SigstoreKey(
+                keyid,
+                "sigstore-oidc",
+                "Fulcio",
+                {"identity": "val", "issuer": "val"},
+            ),
         ]
 
         for key in keys:
             with self.assertRaises(VerificationError) as ctx:
                 key.verify_signature(sig, b"data")
+
             self.assertIsInstance(
-                ctx.exception.__cause__, UnsupportedLibraryError
+                ctx.exception.__cause__, (UnsupportedLibraryError, ImportError)
             )
 
     def test_signer_ed25519_fallback(self):


### PR DESCRIPTION
* Improve tests on runner that don't have extra dependencies installed:
  * refactor test to add new cases more easily
  * test that verify_signature of SSlibKey and SigstoreKey fails gracefully, if optional dependencies are missing
  * test that ed25519 pure python fallback works for verification

* Fix SSlibKey.verify_signature to re-raise UnsupportedLibraryError as VerificationError

