### PR TITLE
signer: _from/_to_dict helpers for Key base fields

### DIFF
--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -32,19 +32,11 @@ class GPGKey(Key):
 
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "GPGKey":
-        keytype = key_dict.pop("keytype")
-        scheme = key_dict.pop("scheme")
-        keyval = key_dict.pop("keyval")
-
+        keytype, scheme, keyval = cls._from_dict(key_dict)
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
     def to_dict(self) -> Dict:
-        return {
-            "keytype": self.keytype,
-            "scheme": self.scheme,
-            "keyval": self.keyval,
-            **self.unrecognized_fields,
-        }
+        return self._to_dict()
 
     def verify_signature(self, signature: Signature, data: bytes) -> None:
         try:

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -35,9 +35,7 @@ class SigstoreKey(Key):
 
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "SigstoreKey":
-        keytype = key_dict.pop("keytype")
-        scheme = key_dict.pop("scheme")
-        keyval = key_dict.pop("keyval")
+        keytype, scheme, keyval = cls._from_dict(key_dict)
 
         for content in ["identity", "issuer"]:
             if content not in keyval or not isinstance(keyval[content], str):
@@ -48,12 +46,7 @@ class SigstoreKey(Key):
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
     def to_dict(self) -> Dict:
-        return {
-            "keytype": self.keytype,
-            "scheme": self.scheme,
-            "keyval": self.keyval,
-            **self.unrecognized_fields,
-        }
+        return self._to_dict()
 
     def verify_signature(self, signature: Signature, data: bytes) -> None:
         # pylint: disable=import-outside-toplevel,import-error


### PR DESCRIPTION
Add de/serialization helpers for common fields in the Key base class, which may be used in subclass from/to_dict methods for convenience.

* _to_dict: This could be Key.to_dict, which subclasses default to, but we prefer that subclasses must implement a to_dict, to avoid unnoticed serialization errors.

* _from_dict: Other than from_dict, this one does not create a Key instance, but just returns the popped off fields. This makes usage in subclasses more flexible and less mystical (lessons learned from https://github.com/theupdateframework/python-tuf/commit/ace25e4ad3d731a66171f7b9e6978384e4629efb).
