### PR TITLE
signer: adopt upstream sigstore API change

### DIFF
--- a/.github/workflows/test-sigstore.yml
+++ b/.github/workflows/test-sigstore.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       id-token: 'write' # ambient credential is used to sign
+      issues: 'write' # for filing an issue on failure
 
     steps:
       - name: Checkout securesystemslib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ gcpkms = ["google-cloud-kms", "cryptography>=37.0.0"]
 hsm = ["asn1crypto", "cryptography>=37.0.0", "PyKCS11"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX>=0.5.0"]
-sigstore = ["sigstore"]
+sigstore = ["sigstore!=1.1.2"]
 
 [tool.hatch.version]
 path = "securesystemslib/__init__.py"

--- a/requirements-sigstore.txt
+++ b/requirements-sigstore.txt
@@ -1,1 +1,1 @@
-sigstore==1.1.2
+sigstore==1.1.1

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -141,6 +141,7 @@ class SigstoreSigner(Signer):
     ) -> "SigstoreSigner":
         # pylint: disable=import-outside-toplevel
         try:
+            from sigstore._internal.oidc import DEFAULT_AUDIENCE
             from sigstore.oidc import Issuer, detect_credential
         except ImportError as e:
             raise UnsupportedLibraryError(IMPORT_ERROR) from e
@@ -161,7 +162,9 @@ class SigstoreSigner(Signer):
             issuer = Issuer.production()
             token = issuer.identity_token()
         else:
-            token = detect_credential()
+            # Use internal default audience value just like the sigstore cli
+            # TODO: Do not use non-public sigstore global DEFAULT_AUDIENCE!
+            token = detect_credential(DEFAULT_AUDIENCE)
 
         return cls(token, public_key)
 

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -141,7 +141,6 @@ class SigstoreSigner(Signer):
     ) -> "SigstoreSigner":
         # pylint: disable=import-outside-toplevel
         try:
-            from sigstore._internal.oidc import DEFAULT_AUDIENCE
             from sigstore.oidc import Issuer, detect_credential
         except ImportError as e:
             raise UnsupportedLibraryError(IMPORT_ERROR) from e
@@ -162,9 +161,7 @@ class SigstoreSigner(Signer):
             issuer = Issuer.production()
             token = issuer.identity_token()
         else:
-            # Use internal default audience value just like the sigstore cli
-            # TODO: Do not use non-public sigstore global DEFAULT_AUDIENCE!
-            token = detect_credential(DEFAULT_AUDIENCE)
+            token = detect_credential()
 
         return cls(token, public_key)
 


### PR DESCRIPTION
Since sigstore 1.1.2 `detect_credential` requires an "audience" argument. This patch passes the internal (!) DEFAULT_AUDIENCE, which is also used by the related sigstore cli.

Using the non-public constant is only a temporary fix until I hear back from upstream devs.

The PR also adds a missing permission in a related GitHub workflow .