### PR TITLE
lint: add pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ env/*
 tests/htmlcov/*
 .DS_Store
 .python-version
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # Automatically run checks over changed files prior to `git commit`.
 # Required one-time setup:
 #
+#   pip install pre-commit
 #   pre-commit install
 #
 # See https://pre-commit.com for details.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Automatically run checks over changed files prior to `git commit`.
+# Required one-time setup:
+#
+#   pre-commit install
+#
+# See https://pre-commit.com for details.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+        args: ["."]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,13 @@ include = [
   "/CHANGELOG.md",
   "/.coveragerc",
 ]
+
+[tool.black]
+line-length=80
+extend-exclude="_vendor"
+
+[tool.isort]
+profile="black"
+line_length=80
+known_first_party = ["securesystemslib"]
+extend_skip_glob=["*/_vendor/*"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # requirements for local testing with tox, and also for the running test suite
 # or individual tests manually
 tox
+pre-commit
 -r requirements.txt
 -r requirements-test.txt
 -r requirements-lint.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@
 # requirements for local testing with tox, and also for the running test suite
 # or individual tests manually
 tox
-pre-commit
 -r requirements.txt
 -r requirements-test.txt
 -r requirements-lint.txt

--- a/tox.ini
+++ b/tox.ini
@@ -72,10 +72,8 @@ deps =
     -r{toxinidir}/requirements-pinned.txt
     -r{toxinidir}/requirements-lint.txt
 commands =
-    # TODO: Move configs to pyproject.toml
-    black --check --diff --line-length=80 --extend-exclude=_vendor  .
-    isort --check --diff --line-length=80 --extend-skip-glob='*/_vendor/*' \
-                                          --profile=black --project=securesystemslib .
+    black --check --diff  .
+    isort --check --diff  .
 
     pylint -j 0 --rcfile=pylintrc securesystemslib tests
     bandit --recursive securesystemslib --exclude _vendor


### PR DESCRIPTION
Add basic pre-commit config file, with hooks for black and isort, plus two convenient builtin checkers.

**Related changes in this PR**
- Moves config for black and isort to pyproject.toml, to be re-used by tox and pre-commit
- Adds pre-commit to dev requirements
- Updates .gitignore to allow pre-commit config file.

**Caveat**
hooks in config file must be manually initialized and updated:
```
pre-commit install # once
pre-commit autoupdate # regularly
```