### PR TITLE
SigstoreSigner: Use sigstore 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ gcpkms = ["google-cloud-kms", "cryptography>=37.0.0"]
 hsm = ["asn1crypto", "cryptography>=37.0.0", "PyKCS11"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX>=0.5.0"]
-sigstore = ["sigstore!=1.1.2"]
+sigstore = ["sigstore==1.1.2"]
 
 [tool.hatch.version]
 path = "securesystemslib/__init__.py"

--- a/requirements-sigstore.txt
+++ b/requirements-sigstore.txt
@@ -1,1 +1,1 @@
-sigstore==1.1.1
+sigstore==1.1.2

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -161,7 +161,9 @@ class SigstoreSigner(Signer):
             issuer = Issuer.production()
             token = issuer.identity_token()
         else:
-            token = detect_credential()
+            # Note: this method signature only works with sigstore-python 1.1.2:
+            # dependencies must be updated when changing this
+            token = detect_credential("sigstore")
 
         return cls(token, public_key)
 


### PR DESCRIPTION
* 1.1.2 has an accidental API change that makes it incompatible with lower versions
* This change is reverted in next release, but next release has planned API breaks
* sigstore 1.1.1 has an unrelated bug that means it does not really work with current sigstore infrastructure (the current TUF repository to be exact)

So plan is:
1. Pin 1.1.2: it's the only version that fully works right now (even if the API is "wrong")
2. Upgrade to 2.0.0 once it comes out: this will require small code changes

This commit handles part 1.

Test run:
https://github.com/secure-systems-lab/securesystemslib/actions/runs/5065716114/jobs/9094614085

### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


