### PR TITLE
Bumped cryptography dep to 40 as it's requried

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ Source = "https://github.com/secure-systems-lab/securesystemslib"
 Issues = "https://github.com/secure-systems-lab/securesystemslib/issues"
 
 [project.optional-dependencies]
-crypto = ["cryptography>=37.0.0"]
-gcpkms = ["google-cloud-kms", "cryptography>=37.0.0"]
-azurekms = ["azure-identity", "azure-keyvault-keys", "cryptography>=37.0.0"]
-hsm = ["asn1crypto", "cryptography>=37.0.0", "PyKCS11"]
+crypto = ["cryptography>=40.0.0"]
+gcpkms = ["google-cloud-kms", "cryptography>=40.0.0"]
+azurekms = ["azure-identity", "azure-keyvault-keys", "cryptography>=40.0.0"]
+hsm = ["asn1crypto", "cryptography>=40.0.0", "PyKCS11"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX>=0.5.0"]
 sigstore = ["sigstore==1.1.2"]


### PR DESCRIPTION
This line https://github.com/secure-systems-lab/securesystemslib/blob/main/securesystemslib/signer/_key.py#L36 requires cryptography v40 and higher.

### Description of the changes being introduced by the pull request:



### Please verify and check that the pull request fulfils the following requirements:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


