### PR TITLE
Adapt to new sigstore api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ awskms = ["boto3", "botocore", "cryptography>=40.0.0"]
 hsm = ["asn1crypto", "cryptography>=40.0.0", "PyKCS11"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX>=0.5.0"]
-sigstore = ["sigstore~=2.0.0"]
+sigstore = ["sigstore~=2.0"]
 
 [tool.hatch.version]
 path = "securesystemslib/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ awskms = ["boto3", "botocore", "cryptography>=40.0.0"]
 hsm = ["asn1crypto", "cryptography>=40.0.0", "PyKCS11"]
 pynacl = ["pynacl>1.2.0"]
 PySPX = ["PySPX>=0.5.0"]
-sigstore = ["sigstore==1.1.2"]
+sigstore = ["sigstore~=2.0.0"]
 
 [tool.hatch.version]
 path = "securesystemslib/__init__.py"

--- a/requirements-sigstore.txt
+++ b/requirements-sigstore.txt
@@ -1,1 +1,1 @@
-sigstore==1.1.2
+sigstore==2.0.0

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -215,6 +215,25 @@ class SigstoreSigner(Signer):
 
         return uri, key
 
+    @classmethod
+    def import_via_auth(cls) -> Tuple[str, SigstoreKey]:
+        """Create public key and signer URI by interactive authentication
+
+        Returns a private key URI (for Signer.from_priv_key_uri()) and a public
+        key. This method always uses the interactive authentication.
+        """
+        # pylint: disable=import-outside-toplevel
+        try:
+            from sigstore.oidc import Issuer
+        except ImportError as e:
+            raise UnsupportedLibraryError(IMPORT_ERROR) from e
+
+        # authenticate to get the identity and issuer
+        token = Issuer.production().identity_token()
+        return cls.import_(
+            token.identity, token.expected_certificate_subject, False
+        )
+
     def sign(self, payload: bytes) -> Signature:
         """Signs payload using the OIDC token on the signer instance.
 

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -141,7 +141,7 @@ class SigstoreSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        _secrets_handler: Optional[SecretsHandler] = None,
+        secrets_handler: Optional[SecretsHandler] = None,
     ) -> "SigstoreSigner":
         # pylint: disable=import-outside-toplevel
         try:
@@ -163,8 +163,7 @@ class SigstoreSigner(Signer):
         if not ambient:
             # TODO: Restrict oauth flow to use identity/issuer from public_key
             # TODO: Use secrets_handler for identity_token() secret arg
-            issuer = Issuer.production()
-            token = issuer.identity_token()
+            token = Issuer.production().identity_token()
         else:
             credential = detect_credential()
             if not credential:

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -259,8 +259,7 @@ class SigstoreSigner(Signer):
         with context.signer(self._token) as sigstore_signer:
             result = sigstore_signer.sign(io.BytesIO(payload))
 
-        # TODO: Ask upstream if they can make this public
-        bundle = result._to_bundle()  # pylint: disable=protected-access
+        bundle = result.to_bundle()
 
         return Signature(
             self.public_key.keyid,

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -141,7 +141,7 @@ class SigstoreSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
+        _secrets_handler: Optional[SecretsHandler] = None,
     ) -> "SigstoreSigner":
         # pylint: disable=import-outside-toplevel
         try:


### PR DESCRIPTION
Not ready for merging as sigstore 2.0 is not released yet

This adapts SigstoreSigner to sigstore 2.x API
* tested on CI for ambient and manually for interactive signing
* I found an unexpected issue where in the ambient case we cannot know what the  signing identity is at signing time
* this prevents actually implementing a SigstoreSigner  import that would lookup the key content from the authenticated token (at least for ambient case) :(
* however, this already prevents a user from signing with the wrong identity: this is great


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


