### PR TITLE
Sigstore, Spx: Add notes about metadata format stability

### DIFF
--- a/securesystemslib/signer/__init__.py
+++ b/securesystemslib/signer/__init__.py
@@ -38,6 +38,10 @@ SIGNER_FOR_URI_SCHEME.update(
     }
 )
 
+# Signers with currently unstable metadata formats, not supported by default:
+#   SigstoreSigner,
+#   SpxSigner (also does not yet support private key uri scheme)
+
 # Register supported key types and schemes, and the Keys implementing them
 KEY_FOR_TYPE_AND_SCHEME.update(
     {
@@ -54,9 +58,12 @@ KEY_FOR_TYPE_AND_SCHEME.update(
         ("rsa", "rsa-pkcs1v15-sha256"): SSlibKey,
         ("rsa", "rsa-pkcs1v15-sha384"): SSlibKey,
         ("rsa", "rsa-pkcs1v15-sha512"): SSlibKey,
-        ("sphincs", "sphincs-shake-128s"): SpxKey,
         ("rsa", "pgp+rsa-pkcsv1.5"): GPGKey,
         ("dsa", "pgp+dsa-fips-180-2"): GPGKey,
         ("eddsa", "pgp+eddsa-ed25519"): GPGKey,
     }
 )
+
+# Keys with currently unstable metadata formats, not supported by default:
+#       ("sphincs", "sphincs-shake-128s"): SpxKey,
+#       ("sigstore-oidc", "Fulcio"): SigstoreKey,

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -28,10 +28,9 @@ logger = logging.getLogger(__name__)
 class SigstoreKey(Key):
     """Sigstore verifier.
 
-    NOTE: The Sigstore key and signature metadata formats are not part of the
-    TUF specification and are not considered stable in securesystemslib. They
-    may change in future releases and may not be supported by other
-    implementations.
+    NOTE: The Sigstore key and signature serialization formats are not yet
+    considered stable in securesystemslib. They may change in future releases
+    and may not be supported by other implementations.
     """
 
     DEFAULT_KEY_TYPE = "sigstore-oidc"
@@ -90,10 +89,9 @@ class SigstoreKey(Key):
 class SigstoreSigner(Signer):
     """Sigstore signer.
 
-    NOTE: The Sigstore key and signature metadata formats are not part of the
-    TUF specification and are not considered stable in securesystemslib. They
-    may change in future releases and may not be supported by other
-    implementations.
+    NOTE: The Sigstore key and signature serialization formats are not yet
+    considered stable in securesystemslib. They may change in future releases
+    and may not be supported by other implementations.
 
     All signers should be instantiated with ``Signer.from_priv_key_uri()``.
     Unstable ``SigstoreSigner`` currently requires opt-in via

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 class SigstoreKey(Key):
     """Sigstore verifier.
 
-    NOTE: unstable API - routines and metadata formats may change!
+    NOTE: The Sigstore key and signature metadata formats are not part of the
+    TUF specification and are not considered stable in securesystemslib. They
+    may change in future releases and may not be supported by other
+    implementations.
     """
 
     DEFAULT_KEY_TYPE = "sigstore-oidc"
@@ -87,7 +90,10 @@ class SigstoreKey(Key):
 class SigstoreSigner(Signer):
     """Sigstore signer.
 
-    NOTE: unstable API - routines and metadata formats may change!
+    NOTE: The Sigstore key and signature metadata formats are not part of the
+    TUF specification and are not considered stable in securesystemslib. They
+    may change in future releases and may not be supported by other
+    implementations.
 
     All signers should be instantiated with ``Signer.from_priv_key_uri()``.
     Unstable ``SigstoreSigner`` currently requires opt-in via

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -189,8 +189,8 @@ class SigstoreSigner(Signer):
         key should be stored for later use.
 
         Arguments:
-            identity: The OIDC identity used to create a signing token.
-            issuer: The OIDC issuer URL used to create a signing token.
+            identity: The OIDC identity to use when verifying a signature.
+            issuer: The OIDC issuer to use when verifying a signature.
             ambient: Toggle usage of ambient credentials in returned URI.
         """
         keytype = SigstoreKey.DEFAULT_KEY_TYPE

--- a/securesystemslib/signer/_spx_signer.py
+++ b/securesystemslib/signer/_spx_signer.py
@@ -38,7 +38,13 @@ def generate_spx_key_pair() -> Tuple[bytes, bytes]:
 
 
 class SpxKey(Key):
-    """SPHINCS+ verifier."""
+    """SPHINCS+ verifier.
+
+    NOTE: The SPHINCS+ key and signature metadata formats are not part of the
+    TUF specification and are not considered stable in securesystemslib. They
+    may change in future releases and may not be supported by other
+    implementations.
+    """
 
     DEFAULT_KEY_TYPE = "sphincs"
     DEFAULT_SCHEME = "sphincs-shake-128s"
@@ -88,6 +94,11 @@ class SpxKey(Key):
 
 class SpxSigner(Signer):
     """SPHINCS+ signer.
+
+    NOTE: The SPHINCS+ key and signature metadata formats are not part of the
+    TUF specification and are not considered stable in securesystemslib. They
+    may change in future releases and may not be supported by other
+    implementations.
 
     Usage::
 

--- a/securesystemslib/signer/_spx_signer.py
+++ b/securesystemslib/signer/_spx_signer.py
@@ -40,10 +40,9 @@ def generate_spx_key_pair() -> Tuple[bytes, bytes]:
 class SpxKey(Key):
     """SPHINCS+ verifier.
 
-    NOTE: The SPHINCS+ key and signature metadata formats are not part of the
-    TUF specification and are not considered stable in securesystemslib. They
-    may change in future releases and may not be supported by other
-    implementations.
+    NOTE: The SPHINCS+ key and signature serialization formats are not yet
+    considered stable in securesystemslib. They may change in future releases
+    and may not be supported by other implementations.
     """
 
     DEFAULT_KEY_TYPE = "sphincs"
@@ -95,10 +94,9 @@ class SpxKey(Key):
 class SpxSigner(Signer):
     """SPHINCS+ signer.
 
-    NOTE: The SPHINCS+ key and signature metadata formats are not part of the
-    TUF specification and are not considered stable in securesystemslib. They
-    may change in future releases and may not be supported by other
-    implementations.
+    NOTE: The SPHINCS+ key and signature serialization formats are not yet
+    considered stable in securesystemslib. They may change in future releases
+    and may not be supported by other implementations.
 
     Usage::
 


### PR DESCRIPTION
Both of these metadata formats (e.g. the data encoding and field names) are basically invented in securesystemslib: there is no community consensus on them yet.

I've also tweaked the sigstore docstring to be more exact

EDIT: I noticed SpxKey was part of the default key set: I'd rather err on the side of caution and not enable new keys automatically if we're not sure there is a consensus about the metadata format: I removed the key from default set