### PR TITLE
Release 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## securesystemslib v0.29.0
+
+This release is reaping the rewards of the new signer API with four(!) new
+signing methods: Two cloud based KMSs, post-quantum crypto support and a
+"keyless" signing system.
+
+Advance notice to folks using the `keys`, `ecdsa_keys`, `rsa_keys` and
+`ed25519_keys` modules: these modules are headed for deprecation. Please have
+a look at the `signer` API and get in touch if the functionality you need
+isn't there (or if more documentation is needed).
+
+### Added
+* Sigstore as a new experimental signing method (#552)
+* SPHINCS+ as a new experimental signing method (#568)
+* Azure Key Vault as a new signing method (#588)
+* AWS KMS  as a new signing method (#609)
+* `CryptoSigner` as a more featureful replacement for `SSLibSigner` (#604)
+* Documentation that focuses on the signer API (#634, #622)
+
+### Changed
+* `SSLibSigner` has been deprecated: Please use `CryptoSigner` instead (#604)
+* `keys` module is not used for signature verification in `signer` API (#585)
+* Various minor fixes, please see git log for details
+
 ## securesystemslib v0.28.0
 
 ### Added

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import logging
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
Release new securesystemslib
* Fixes: #631
* Last release was in April, we now support loads of new signing systems so downstream projects are waiting for a release
* I've never done a securesystems release: comments are welcome
* changelog is edited from Martins proposal


I really wanted the new sigstore API (#630) in here but I guess that will be in the next release as sigstore still has blockers.