### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       # Run tests on each OS/Python combination
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,15 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Security",
     "Topic :: Software Development",
 ]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 dynamic = ["version"]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint, py37, py38, py39, py310, py311, purepy311, py311-no-gpg, py311-test-gpg-fails
+envlist = lint, py38, py39, py310, py311, purepy311, py311-no-gpg, py311-test-gpg-fails
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
- Python 3.7 is EOL
- Our runtime dependencies are still ok with 3.7
- Testing dependencies have started requiring 3.8
- Our dependent python-tuf just dropped 3.7 (theupdateframework/python-tuf#2460)

Unrelated change: Add missing classifier for already supported 3.11 to pyproject.toml

h/t @jku 
