### PR TITLE
Release 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## securesystemslib v0.30.0
+
+This release contains improved Sigstore support.
+
+### Changed
+
+* SigstoreSigner adapted to sigstore-python 2.0 API: This allows
+  improved UX where a new signing identity can be defined using
+  interactive credentials (browser login):
+  `SigstoreSigner.import_via_auth()`
+* Documentation improvements
+
+### Removed
+
+* Python 3.7 is no longer supported
+
 ## securesystemslib v0.29.0
 
 This release is reaping the rewards of the new signer API with four(!) new

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import logging
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
(following copied from changelog)

---

## securesystemslib v0.30.0

This release contains improved Sigstore support.

### Changed

* SigstoreSigner adapted to sigstore-python 2.0 API: This allows
  improved UX where a new signing identity can be defined using
  interactive credentials (browser login):
  `SigstoreSigner.import_via_auth()`
* Documentation improvements

### Removed

* Python 3.7 is no longer supported

---

Notes:
* Python 3.12 has been released. Did not add it to test matrix as github does not have it yet
* vendored ed25519 is not up to date (see issue #651) but there are no urgent changes
