### PR TITLE
SSlibKey: make '_from_crypto_public_key' public API and remove 'from_pem'

### DIFF
--- a/docs/CRYPTO_SIGNER.md
+++ b/docs/CRYPTO_SIGNER.md
@@ -82,13 +82,17 @@ os.environ.update({
 ```python
 import os
 from securesystemslib.signer import SSlibKey, Signer, CryptoSigner, SIGNER_FOR_URI_SCHEME
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
 
 # NOTE: Registration becomes obsolete once CryptoSigner is the default file signer
 SIGNER_FOR_URI_SCHEME.update({CryptoSigner.FILE_URI_SCHEME: CryptoSigner})
 
 # Read signer details
 uri = os.environ["SIGNER_URI"]
-public_key = SSlibKey.from_pem(os.environ["SIGNER_PUBLIC"].encode())
+public_key = SSlibKey.from_crypto(
+    load_pem_public_key(os.environ["SIGNER_PUBLIC"].encode())
+)
 secrets_handler = lambda sec: os.environ["SIGNER_SECRET"]
 
 # Load and sign

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -131,9 +131,7 @@ class CryptoSigner(Signer):
             raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
 
         if public_key is None:
-            public_key = SSlibKey._from_crypto_public_key(
-                private_key.public_key(), None, None
-            )
+            public_key = SSlibKey.from_crypto(private_key.public_key())
 
         self._private_key: PrivateKeyTypes
         self._sign_args: Union[_RSASignArgs, _ECDSASignArgs, _NoSignArgs]
@@ -276,7 +274,7 @@ class CryptoSigner(Signer):
             raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
 
         private_key = Ed25519PrivateKey.generate()
-        public_key = SSlibKey._from_crypto_public_key(  # pylint: disable=protected-access
+        public_key = SSlibKey.from_crypto(
             private_key.public_key(), keyid, "ed25519"
         )
         return CryptoSigner(private_key, public_key)
@@ -307,7 +305,7 @@ class CryptoSigner(Signer):
             public_exponent=65537,
             key_size=size,
         )
-        public_key = SSlibKey._from_crypto_public_key(  # pylint: disable=protected-access
+        public_key = SSlibKey.from_crypto(
             private_key.public_key(), keyid, scheme
         )
         return CryptoSigner(private_key, public_key)
@@ -331,7 +329,7 @@ class CryptoSigner(Signer):
             raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
 
         private_key = generate_ec_private_key(SECP256R1())
-        public_key = SSlibKey._from_crypto_public_key(  # pylint: disable=protected-access
+        public_key = SSlibKey.from_crypto(
             private_key.public_key(), keyid, "ecdsa-sha2-nistp256"
         )
         return CryptoSigner(private_key, public_key)

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -324,42 +324,6 @@ class SSlibKey(Key):
 
         return SSlibKey(keyid, keytype, scheme, keyval)
 
-    @classmethod
-    def from_pem(
-        cls,
-        pem: bytes,
-        scheme: Optional[str] = None,
-        keyid: Optional[str] = None,
-    ) -> "SSlibKey":
-        """Load SSlibKey from PEM.
-
-        NOTE: pyca/cryptography is used to decode the PEM payload. The expected
-        (and tested) format is subjectPublicKeyInfo (RFC 5280). Other formats
-        may but are not guaranteed to work.
-
-        Args:
-            pem: Public key PEM data.
-            scheme: SSlibKey signing scheme. Defaults are "rsassa-pss-sha256",
-                "ecdsa-sha2-nistp256", and "ed25519" according to the keytype
-            keyid: Key identifier. If not passed, a default keyid is computed.
-
-        Raises:
-            UnsupportedLibraryError: pyca/cryptography not installed
-            ValueError: Key type not supported
-            ValueError, \
-                    cryptography.exceptions.UnsupportedAlgorithm:
-                pyca/cryptography deserialization failed
-
-        Returns:
-            SSlibKey
-
-        """
-        if CRYPTO_IMPORT_ERROR:
-            raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
-
-        public_key = load_pem_public_key(pem)
-        return cls.from_crypto(public_key, keyid, scheme)
-
     @staticmethod
     def _get_hash_algorithm(name: str) -> "HashAlgorithm":
         """Helper to return hash algorithm for name."""

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -313,11 +313,6 @@ class TestPublicInterfaces(
         with self.assertRaises(UnsupportedLibraryError):
             SSlibKey.from_crypto("mock pyca/crypto pubkey")  # type: ignore
 
-    def test_sslib_key_from_pem(self):
-        """Assert raise UnsupportedLibraryError on SSlibKey.from_pem()."""
-        with self.assertRaises(UnsupportedLibraryError):
-            SSlibKey.from_pem(b"fail")
-
     def test_crypto_signer_from_priv_key_uri(self):
         """Assert raise UnsupportedLibraryError on 'from_priv_key_uri'."""
 

--- a/tests/check_public_interfaces.py
+++ b/tests/check_public_interfaces.py
@@ -308,6 +308,11 @@ class TestPublicInterfaces(
             securesystemslib.gpg.functions.export_pubkey("f00")
         self.assertEqual(expected_error_msg, str(ctx.exception))
 
+    def test_sslib_key_from_crypto(self):
+        """Assert raise UnsupportedLibraryError on SSlibKey.from_crypto()."""
+        with self.assertRaises(UnsupportedLibraryError):
+            SSlibKey.from_crypto("mock pyca/crypto pubkey")  # type: ignore
+
     def test_sslib_key_from_pem(self):
         """Assert raise UnsupportedLibraryError on SSlibKey.from_pem()."""
         with self.assertRaises(UnsupportedLibraryError):

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -8,7 +8,10 @@ import unittest
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
 
 import securesystemslib.keys as KEYS
 from securesystemslib.exceptions import (
@@ -289,8 +292,8 @@ class TestKey(unittest.TestCase):
 class TestSSlibKey(unittest.TestCase):
     """SSlibKey tests."""
 
-    def test_from_pem(self):
-        """Test load PEM/subjectPublicKeyInfo for each SSlibKey keytype"""
+    def test_from_crypto(self):
+        """Test load pyca/cryptography public key for each SSlibKey keytype"""
         test_data = [
             (
                 "rsa",
@@ -312,19 +315,21 @@ class TestSSlibKey(unittest.TestCase):
         def _from_file(path):
             with open(path, "rb") as f:
                 pem = f.read()
-            return pem
+
+            crypto_key = load_pem_public_key(pem)
+            return crypto_key
 
         for keytype, default_scheme, default_keyid in test_data:
-            pem = _from_file(PEMS_DIR / f"{keytype}_public.pem")
-            key = SSlibKey.from_pem(pem)
+            crypto_key = _from_file(PEMS_DIR / f"{keytype}_public.pem")
+            key = SSlibKey.from_crypto(crypto_key)
             self.assertEqual(key.keytype, keytype)
             self.assertEqual(key.scheme, default_scheme)
             self.assertEqual(key.keyid, default_keyid)
 
         # Test with non-default scheme/keyid
-        pem = _from_file(PEMS_DIR / "rsa_public.pem")
-        key = SSlibKey.from_pem(
-            pem,
+        crypto_key = _from_file(PEMS_DIR / "rsa_public.pem")
+        key = SSlibKey.from_crypto(
+            crypto_key,
             scheme="rsa-pkcs1v15-sha224",
             keyid="abcdef",
         )


### PR DESCRIPTION
Fixes #616 

This newly public SSlibKey factory allows more flexible usage than the existing `from_pem`, which was just a thin wrapper on top of it. 

Additional use cases are creating a key from an pyca/crypto private key object (see CryptoSigner) or from a different serialization format than PEM.

To keep the API small, this PR removes `from_pem`. It seems reasonable to just have application code call `pyca/cryptography`'s "from pem" function themselves.

