### PR TITLE
Release securesystemslib v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## securesystemslib v0.31.0
+
+### Added
+* CryptoSigner: create from `cryptography` private key with new constructor (#675)
+* SSlibKey: create from `cryptography` public key with new `from_crypto` method (#678)
+* Release: auto-release with PyPI Trusted Publishing (#683)
+* Docs to migrate legacy key files (#658)
+
+### Removed
+* Removed `SSlibKey.from_pem` factory method in favor of `from_crypto` (#678)
+
 ## securesystemslib v0.30.0
 
 This release contains improved Sigstore support.

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import logging
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
## securesystemslib v0.31.0

### Added
* CryptoSigner: create from `cryptography` private key with new constructor (#675)
* SSlibKey: create from `cryptography` public key with new `from_crypto` method (#678)
* Release: auto-release with PyPI Trusted Publishing (#683)
* Docs to migrate legacy key files (#658)

### Removed
* Removed `SSlibKey.from_pem` factory method in favor of `from_crypto` (#678)