### PR TITLE
github: Fix check-upgstream workflow permission

### DIFF
--- a/.github/workflows/check-upstream-ed25519.yml
+++ b/.github/workflows/check-upstream-ed25519.yml
@@ -11,6 +11,9 @@ jobs:
   check-ed25519-upstream:
     name: Open an issue if upstream ed25519 has new commits
     runs-on: ubuntu-latest
+    permissions:
+      issues: 'write' # for filing an issue on failure
+
     steps:
     - name: Check out repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
I believe this broke in commit d082614 already, I think "issues" is the only permission we need here.

Fixes: #679
