### PR TITLE
CryptoSigner: Support ecdsa keytype that is no longer in spec

### DIFF
--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -68,9 +68,11 @@ class _ECDSASignArgs:
 class _NoSignArgs:
     pass
 
+
 # for backwards compat: use when spec-deprecated keytype ecdsa-sha2-nistp256
 # should be accepted in addition to "ecdsa"
 _ECDSA_KEYTYPES = ["ecdsa", "ecdsa-sha2-nistp256"]
+
 
 def _get_hash_algorithm(name: str) -> "HashAlgorithm":
     """Helper to return hash algorithm for name."""

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -68,6 +68,9 @@ class _ECDSASignArgs:
 class _NoSignArgs:
     pass
 
+# for backwards compat: use when spec-deprecated keytype ecdsa-sha2-nistp256
+# should be accepted in addition to "ecdsa"
+_ECDSA_KEYTYPES = ["ecdsa", "ecdsa-sha2-nistp256"]
 
 def _get_hash_algorithm(name: str) -> "HashAlgorithm":
     """Helper to return hash algorithm for name."""
@@ -156,7 +159,7 @@ class CryptoSigner(Signer):
             self._private_key = private_key
 
         elif (
-            public_key.keytype == "ecdsa"
+            public_key.keytype in _ECDSA_KEYTYPES
             and public_key.scheme == "ecdsa-sha2-nistp256"
         ):
             if not isinstance(private_key, EllipticCurvePrivateKey):
@@ -189,7 +192,7 @@ class CryptoSigner(Signer):
         public_key = SSlibKey.from_securesystemslib_key(key_dict)
 
         private_key: PrivateKeyTypes
-        if public_key.keytype in ["rsa", "ecdsa"]:
+        if public_key.keytype in ["rsa"] + _ECDSA_KEYTYPES:
             private_key = load_pem_private_key(private.encode(), password=None)
 
         elif public_key.keytype == "ed25519":

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -774,48 +774,44 @@ class TestCryptoSigner(unittest.TestCase):
                 "rsa",
                 "rsassa-pss-sha256",
                 "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwhX6rioiL/cX5Ys32InF\nU52H8tL14QeX0tacZdb+AwcH6nIh97h3RSHvGD7Xy6uaMRmGldAnSVYwJHqoJ5j2\nynVzU/RFpr+6n8Ps0QFg5GmlEqZboFjLbS0bsRQcXXnqJNsVLEPT3ULvu1rFRbWz\nAMFjNtNNk5W/u0GEzXn3D03jIdhD8IKAdrTRf0VMD9TRCXLdMmEU2vkf1NVUnOTb\n/dRX5QA8TtBylVnouZknbavQ0J/pPlHLfxUgsKzodwDlJmbPG9BWwXqQCmP0DgOG\nNIZ1X281MOBaGbkNVEuntNjCSaQxQjfALVVU5NAfal2cwMINtqaoc7Wa+TWvpFEI\nWwIDAQAB\n-----END PUBLIC KEY-----\n",
+                "rsa_private.pem",
             ),
             (
                 "ecdsa",
                 "ecdsa-sha2-nistp256",
                 "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n",
+                "ecdsa_private.pem",
             ),
             (
-                "ecdsa-sha2-nistp256", # keytype deprecated in TUF spec, tested for backwards compat with older metadata
+                "ecdsa-sha2-nistp256",  # keytype deprecated in TUF spec, tested for backwards compat with older metadata
                 "ecdsa-sha2-nistp256",
                 "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n",
+                "ecdsa_private.pem",
             ),
             (
                 "ed25519",
                 "ed25519",
                 "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f",
+                "ed25519_private.pem",
             ),
         ]
 
         signer_backup = SIGNER_FOR_URI_SCHEME[CryptoSigner.FILE_URI_SCHEME]
         SIGNER_FOR_URI_SCHEME[CryptoSigner.FILE_URI_SCHEME] = CryptoSigner
 
-        for keytype, scheme, public_key_value in test_data:
-            if keytype == "ecdsa-sha2-nistp256":
-                # special case for keytype that is deprecated in spec
-                keytype_for_filename = "ecdsa"
-            else:
-                keytype_for_filename = keytype
+        for keytype, scheme, public_key_value, fname in test_data:
             for encrypted in [True, False]:
-
                 if encrypted:
-                    file_name = f"{keytype_for_filename}_private_encrypted.pem"
-                    parameter = "true"
+                    priv_fname = fname.replace(".pem", "_encrypted.pem")
+                    uri = f"file:{PEMS_DIR / priv_fname}?encrypted=true"
 
                     def handler(_):
                         return "hunter2"
 
                 else:
-                    file_name = f"{keytype_for_filename}_private.pem"
-                    parameter = "false"
+                    uri = f"file:{PEMS_DIR / fname}?encrypted=false"
                     handler = None
 
-                uri = f"file:{PEMS_DIR / file_name}?encrypted={parameter}"
                 public_key = SSlibKey(
                     "abcdefg", keytype, scheme, {"public": public_key_value}
                 )

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -781,6 +781,11 @@ class TestCryptoSigner(unittest.TestCase):
                 "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n",
             ),
             (
+                "ecdsa-sha2-nistp256", # keytype deprecated in TUF spec, tested for backwards compat with older metadata
+                "ecdsa-sha2-nistp256",
+                "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcLYSZyFGeKdWNt5dWFbnv6N9NyHC\noUNLcG6GZIxLwN8Q8MUdHdOOxGkDnyBRSJpIZ/r/oDECSTwfCYhdogweLA==\n-----END PUBLIC KEY-----\n",
+            ),
+            (
                 "ed25519",
                 "ed25519",
                 "4f66dabebcf30628963786001984c0b75c175cdcf3bc4855933a2628f0cd0a0f",
@@ -791,16 +796,22 @@ class TestCryptoSigner(unittest.TestCase):
         SIGNER_FOR_URI_SCHEME[CryptoSigner.FILE_URI_SCHEME] = CryptoSigner
 
         for keytype, scheme, public_key_value in test_data:
+            if keytype == "ecdsa-sha2-nistp256":
+                # special case for keytype that is deprecated in spec
+                keytype_for_filename = "ecdsa"
+            else:
+                keytype_for_filename = keytype
             for encrypted in [True, False]:
+
                 if encrypted:
-                    file_name = f"{keytype}_private_encrypted.pem"
+                    file_name = f"{keytype_for_filename}_private_encrypted.pem"
                     parameter = "true"
 
                     def handler(_):
                         return "hunter2"
 
                 else:
-                    file_name = f"{keytype}_private.pem"
+                    file_name = f"{keytype_for_filename}_private.pem"
                     parameter = "false"
                     handler = None
 


### PR DESCRIPTION
We may be signing older metadata that has keys with keytype "ecdsa-sha2-nistp256": support that case.

I may have missed or forgotten plans about ECDSA, feel free to remind me... The related question here would be: the only supported scheme seems to be "ecdsa-sha2-nistp256", even though SSlibKey supports "ecdsa-sha2-nistp384" as well. Should that be added to CryptoSigner for balance?


### Please verify and check that the pull request fulfils the following requirements:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
