### PR TITLE
Dependabot: Use groups, update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,35 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    build-and-release-dependencies:
+      # Python dependencies known to be critical to our build/release security
+      patterns:
+        - "build"
+        - "hatchling"
+    test-and-lint-dependencies:
+      # Python dependencies that are only pinned to ensure test reproducibility
+      patterns:
+        - "bandit"
+        - "black"
+        - "coverage"
+        - "isort"
+        - "mypy"
+        - "pylint"
+    dependencies:
+      # Python (developer) runtime dependencies. Also any new dependencies not
+      # caught by earlier groups
+      patterns:
+        - "*"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
-    time: "10:00"
+    interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    action-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
Group weekly dependency updates to reduce maintenance burden.

Groups are:
  * critical python build/release deps
  * python test and lint deps (only pinned for test repro)
  * all other python dependencies
  * all github action dependencies

This was shamelessly copied from @jku's
theupdateframework/python-tuf#2530, here and in in-toto/in-toto#701.

Cheers!
