### PR TITLE
Add basic instructions for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,8 @@ pip install securesystemslib[hsm]
 - Other issues and requests: [*Open a new
   issue*](https://github.com/secure-systems-lab/securesystemslib/issues/new)
 
-## Testing
-`tox` is used for testing. It can be installed via
-[pip](https://tox.wiki/en/4.9.0/installation.html#via-pip) and executed from the
-command line in the root of the repository.
-
-```bash
-tox
-```
+## Contribute
+See [Instructions for contributors](docs/CONTRIBUTE.md).
 
 ## Legacy key migration
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install securesystemslib[hsm]
   issue*](https://github.com/secure-systems-lab/securesystemslib/issues/new)
 
 ## Contribute
-See [Instructions for contributors](docs/CONTRIBUTE.md).
+See [Instructions for contributors](docs/CONTRIBUTING.md).
 
 ## Legacy key migration
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Instructions for contributors
 Contribute by
-[submitting pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)	
+[submitting pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 against the *main* (default) branch of this repository.
 
 ## Install for development
-To install for local development 
+To install for local development
 [clone this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository),
 change into the project directory, and install with pip (using
 [`venv`](https://docs.python.org/3/library/venv.html) is recommended).
@@ -16,12 +16,12 @@ python3 -m pip install -r requirements-dev.txt
 
 *NOTE: Some dependencies may have system dependencies. If you face errors while
  installation, please consult with the documentation of the individual project,
- or [contact us](?tab=readme-ov-file#contact) for help.*
+ or [contact us](/?tab=readme-ov-file#contact) for help.*
 
 ## Test
 Run the test suite locally with [`tox`](https://tox.wiki/). Some tests, e.g.
-for *sigstore* or *Cloud KMS* signing, are excluded by default (see 
-[tox.ini](/tox.ini) for details). 
+for *sigstore* or *Cloud KMS* signing, are excluded by default (see
+[tox.ini](/tox.ini) for details).
 
 ```bash
 tox

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Instructions for contributors
+Contribute by
+[submitting pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)	
+against the *main* (default) branch of this repository.
+
+## Install for development
+To install for local development 
+[clone this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository),
+change into the project directory, and install with pip (using
+[`venv`](https://docs.python.org/3/library/venv.html) is recommended).
+
+
+```bash
+python3 -m pip install -r requirements-dev.txt
+```
+
+*NOTE: Some dependencies may have system dependencies. If you face errors while
+ installation, please consult with the documentation of the individual project,
+ or [contact us](?tab=readme-ov-file#contact) for help.*
+
+## Test
+Run the test suite locally with [`tox`](https://tox.wiki/). Some tests, e.g.
+for *sigstore* or *Cloud KMS* signing, are excluded by default (see 
+[tox.ini](/tox.ini) for details). 
+
+```bash
+tox
+```


### PR DESCRIPTION
Add docs/CONTRIBUTING.md with instructions to

- install securesystemslib for development
- run test suite with tox (moved from README.md)

Update README.md to remove section about Test and instead point to new doc.
