### PR TITLE
Add security policy in canonical location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install securesystemslib[hsm]
 - Questions and discussions:
   [`#securesystemslib-python`](https://cloud-native.slack.com/archives/C05PF3GA7AL)
   on [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)
-- Security issues: [*Report a vulnerability*](https://github.com/secure-systems-lab/securesystemslib/security/advisories/new)
+- Security issues: see [Security policy](docs/SECURITY.md)
 - Other issues and requests: [*Open a new
   issue*](https://github.com/secure-systems-lab/securesystemslib/issues/new)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,8 @@
+# Security policy
+
+To report a security issue or vulnerability in `securesystemslib`, you can use
+[*GitHub private reporting*](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
+
+- [**Report security issue**](https://github.com/secure-systems-lab/securesystemslib/security/advisories/new)
+
+Please do not use the public issue tracker to submit security issues.


### PR DESCRIPTION
Add docs/SECURITY.md with information previously pointed to directly from README.md.

This matches the GitHub community standards.
