### PR TITLE
add public key attribute to Signer interface

### DIFF
--- a/securesystemslib/signer/_aws_signer.py
+++ b/securesystemslib/signer/_aws_signer.py
@@ -64,9 +64,13 @@ class AWSSigner(Signer):
 
         self.hash_algorithm = self._get_hash_algorithm(public_key)
         self.aws_key_id = aws_key_id
-        self.public_key = public_key
+        self._public_key = public_key
         self.client = boto3.client("kms")
         self.aws_algo = self._get_aws_signing_algo(self.public_key.scheme)
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_priv_key_uri(

--- a/securesystemslib/signer/_azure_signer.py
+++ b/securesystemslib/signer/_azure_signer.py
@@ -81,7 +81,11 @@ class AzureSigner(Signer):
                 "Key %s has unsupported key type or unsupported elliptic curve"
             )
             raise e
-        self.public_key = public_key
+        self._public_key = public_key
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @staticmethod
     def _get_key_vault_key(

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -183,7 +183,11 @@ class CryptoSigner(Signer):
                 f"unsupported public key {public_key.keytype}/{public_key.scheme}"
             )
 
-        self.public_key = public_key
+        self._public_key = public_key
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_securesystemslib_key(

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -61,8 +61,12 @@ class GCPSigner(Signer):
 
         self.hash_algorithm = self._get_hash_algorithm(public_key)
         self.gcp_keyid = gcp_keyid
-        self.public_key = public_key
+        self._public_key = public_key
         self.client = kms.KeyManagementServiceClient()
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_priv_key_uri(

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -93,7 +93,11 @@ class GPGSigner(Signer):
         homedir: Optional[str] = None,
     ):
         self.homedir = homedir
-        self.public_key = public_key
+        self._public_key = public_key
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_priv_key_uri(

--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -144,8 +144,12 @@ class HSMSigner(Signer):
 
         self.hsm_keyid = hsm_keyid
         self.token_filter = token_filter
-        self.public_key = public_key
+        self._public_key = public_key
         self.pin_handler = pin_handler
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @staticmethod
     def _find_pkcs_slot(filters: Dict[str, str]) -> int:

--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -119,3 +119,12 @@ class Signer(metaclass=ABCMeta):
         return signer.from_priv_key_uri(
             priv_key_uri, public_key, secrets_handler
         )
+
+    @property
+    @abstractmethod
+    def public_key(self) -> Key:
+        """
+        Returns:
+            Public key the signer is based off.
+        """
+        raise NotImplementedError

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -131,10 +131,14 @@ class SigstoreSigner(Signer):
     SCHEME = "sigstore"
 
     def __init__(self, token: Any, public_key: Key):
-        self.public_key = public_key
+        self._public_key = public_key
         # token is of type sigstore.oidc.IdentityToken but the module should be usable
         # without sigstore so it's not annotated
         self._token = token
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_priv_key_uri(

--- a/securesystemslib/signer/_spx_signer.py
+++ b/securesystemslib/signer/_spx_signer.py
@@ -114,7 +114,11 @@ class SpxSigner(Signer):
 
     def __init__(self, private: bytes, public: SpxKey):
         self.private_key = private
-        self.public_key = public
+        self._public_key = public
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     @classmethod
     def from_priv_key_uri(

--- a/securesystemslib/signer/_sslib_signer.py
+++ b/securesystemslib/signer/_sslib_signer.py
@@ -48,6 +48,7 @@ class SSlibSigner(Signer):
     def __init__(self, key_dict: Dict):
         self.key_dict = key_dict
         self._crypto_signer = CryptoSigner.from_securesystemslib_key(key_dict)
+        self._public_key = SSlibKey.from_securesystemslib_key(key_dict)
 
     @classmethod
     def from_priv_key_uri(
@@ -98,6 +99,10 @@ class SSlibSigner(Signer):
         keydict["keyval"]["private"] = private
 
         return cls(keydict)
+
+    @property
+    def public_key(self) -> Key:
+        return self._public_key
 
     def sign(self, payload: bytes) -> Signature:
         """Signs a given payload by the key assigned to the SSlibSigner instance.


### PR DESCRIPTION
Added a abstract property of `public_key` to the Signer abstract base class. As `self.public_key` was being used by the signers inheriting from Signer, they were updated to `self._public_key` and the property added. 

The Signer property itself doesn't contain an implementation as that class doesn't define a constructor so you cannot ensure `self._public_key` would exist. 

Fixes #605
