### PR TITLE
Remove unused function and schema checks in hash

### DIFF
--- a/securesystemslib/hash.py
+++ b/securesystemslib/hash.py
@@ -23,7 +23,7 @@
 
 import hashlib
 
-from securesystemslib import exceptions, formats
+from securesystemslib import exceptions
 from securesystemslib.storage import FilesystemBackend
 
 DEFAULT_CHUNK_SIZE = 4096
@@ -145,9 +145,6 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
         The crypto library to use for the given hash algorithm (e.g., 'hashlib').
 
     <Exceptions>
-      securesystemslib.exceptions.FormatError, if the arguments are
-      improperly formatted.
-
       securesystemslib.exceptions.UnsupportedAlgorithmError, if an unsupported
       hashing algorithm is specified, or digest could not be generated with given
       the algorithm.
@@ -165,11 +162,6 @@ def digest(algorithm=DEFAULT_HASH_ALGORITHM, hash_library=DEFAULT_HASH_LIBRARY):
         hashlib.new(algorithm) or
         PycaDiggestWrapper object
     """
-
-    # Are the arguments properly formatted?  If not, raise
-    # 'securesystemslib.exceptions.FormatError'.
-    formats.NAME_SCHEMA.check_match(algorithm)
-    formats.NAME_SCHEMA.check_match(hash_library)
 
     # Was a hashlib digest object requested and is it supported?
     # If so, return the digest object.
@@ -260,12 +252,6 @@ def digest_fileobject(
         hashlib.new(algorithm) or
         PycaDiggestWrapper object
     """
-
-    # Are the arguments properly formatted?  If not, raise
-    # 'securesystemslib.exceptions.FormatError'.
-    formats.NAME_SCHEMA.check_match(algorithm)
-    formats.NAME_SCHEMA.check_match(hash_library)
-
     # Digest object returned whose hash will be updated using 'file_object'.
     # digest() raises:
     # securesystemslib.exceptions.UnsupportedAlgorithmError
@@ -340,9 +326,6 @@ def digest_filename(
         passed a FilesystemBackend will be instantiated and used.
 
     <Exceptions>
-      securesystemslib.exceptions.FormatError, if the arguments are
-      improperly formatted.
-
       securesystemslib.exceptions.UnsupportedAlgorithmError, if the given
       'algorithm' is unsupported.
 
@@ -361,12 +344,6 @@ def digest_filename(
         hashlib.new(algorithm) or
         PycaDiggestWrapper object
     """
-    # Are the arguments properly formatted?  If not, raise
-    # 'securesystemslib.exceptions.FormatError'.
-    formats.PATH_SCHEMA.check_match(filename)
-    formats.NAME_SCHEMA.check_match(algorithm)
-    formats.NAME_SCHEMA.check_match(hash_library)
-
     digest_object = None
 
     if storage_backend is None:
@@ -383,47 +360,3 @@ def digest_filename(
         )
 
     return digest_object
-
-
-def digest_from_rsa_scheme(scheme, hash_library=DEFAULT_HASH_LIBRARY):
-    """
-    <Purpose>
-      Get digest object from RSA scheme.
-
-    <Arguments>
-      scheme:
-        A string that indicates the signature scheme used to generate
-        'signature'.
-
-      hash_library:
-        The crypto library to use for the given hash algorithm (e.g., 'hashlib').
-
-    <Exceptions>
-      securesystemslib.exceptions.FormatError, if the arguments are
-      improperly formatted.
-
-      securesystemslib.exceptions.UnsupportedAlgorithmError, if an unsupported
-      hashing algorithm is specified, or digest could not be generated with given
-      the algorithm.
-
-      securesystemslib.exceptions.UnsupportedLibraryError, if an unsupported
-      library was requested via 'hash_library'.
-
-    <Side Effects>
-      None.
-
-    <Returns>
-      Digest object
-
-      e.g.
-        hashlib.new(algorithm) or
-        PycaDiggestWrapper object
-    """
-    # Are the arguments properly formatted?  If not, raise
-    # 'securesystemslib.exceptions.FormatError'.
-    formats.RSA_SCHEME_SCHEMA.check_match(scheme)
-
-    # Get hash algorithm from rsa scheme (hash algorithm id is specified after
-    # the last dash; e.g. rsassa-pss-sha256 -> sha256)
-    hash_algorithm = scheme.split("-")[-1]
-    return digest(hash_algorithm, hash_library)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -256,35 +256,6 @@ class TestHash(unittest.TestCase):  # pylint: disable=missing-class-docstring
         # to always seek to the beginning.
         self.assertEqual(digest_object_truth.digest(), digest_object.digest())
 
-    def test_digest_from_rsa_scheme(self):
-        self._run_with_all_hash_libraries(
-            self._do_get_digest_from_rsa_valid_schemes, "sha256"
-        )
-        self._run_with_all_hash_libraries(
-            self._do_get_digest_from_rsa_non_valid_schemes, "sha256"
-        )
-
-    def _do_get_digest_from_rsa_valid_schemes(self, library, algorithm):
-        scheme = "rsassa-pss-sha256"
-        expected_digest_cls = type(
-            securesystemslib.hash.digest(algorithm, library)
-        )
-
-        self.assertIsInstance(
-            securesystemslib.hash.digest_from_rsa_scheme(scheme, library),
-            expected_digest_cls,
-        )
-
-    def _do_get_digest_from_rsa_non_valid_schemes(
-        self, library, algorithm
-    ):  # pylint: disable=unused-argument
-        self.assertRaises(
-            securesystemslib.exceptions.FormatError,
-            securesystemslib.hash.digest_from_rsa_scheme,
-            "rsassa-pss-sha123",
-            library,
-        )
-
     def test_unsupported_digest_algorithm_and_library(self):
         self.assertRaises(
             securesystemslib.exceptions.UnsupportedAlgorithmError,


### PR DESCRIPTION
- addresses part of [#731](https://github.com/secure-systems-lab/securesystemslib/issues/731)
- ~~blocks on [#772](https://github.com/secure-systems-lab/securesystemslib/pull/772) (commits are included in this PR)~~

---

In preparation for the removal of schema.py (https://github.com/secure-systems-lab/securesystemslib/issues/183), this patch removes schema checks of function arguments in hash.py and one entire function.

The removed checks are obfuscated "is string" checks, and without them invalid args in any of the relevant functions are still caught in the `digest` function, where they all end up and would raise a more meaningful UnsupportedLibraryError or UnsupportedAlgorithmError.

The removed function `digest_from_rsa_scheme` doesn't seem to be used anywhere (according to sourcegraph.com) not even in securesystemslib.signer, where the same functionality is replicated several times (see https://github.com/secure-systems-lab/securesystemslib/issues/594). Removing it here allows to ignore a slightly more complex schema check.