### PR TITLE
tests: Improve SigstoreSigner test

### DIFF
--- a/.github/workflows/test-sigstore.yml
+++ b/.github/workflows/test-sigstore.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions: {}
@@ -11,11 +12,6 @@ permissions: {}
 jobs:
   test-sigstore:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'secure-systems-lab' # only run upstream
-
-    permissions:
-      id-token: 'write' # ambient credential is used to sign
-      issues: 'write' # for filing an issue on failure
 
     steps:
       - name: Checkout securesystemslib
@@ -34,28 +30,4 @@ jobs:
           pip install --upgrade tox
 
       - run: |
-          export CERT_ID=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/test-sigstore.yml@${GITHUB_REF}
-          export CERT_ISSUER=https://token.actions.githubusercontent.com
           tox -e sigstore
-
-      - name: File an issue on failure
-        if: ${{ failure() }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        with:
-          script: |
-              const repo = context.repo.owner + "/" + context.repo.repo
-              const issues = await github.rest.search.issuesAndPullRequests({
-                q: "Sigstore+tests+failed+in:title+state:open+type:issue+repo:" + repo,
-              })
-              if (issues.data.total_count > 0) {
-                console.log("Issue open already, not creating.")
-              } else {
-                await github.rest.issues.create({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  title: "Sigstore tests failed",
-                  body: "Hey, it seems Sigstore tests have failed, please see - [workflow run](" +
-                        "https://github.com/" + repo + "/actions/runs/" + context.runId + ")"
-                })
-                console.log("New issue created.")
-              }

--- a/tests/check_sigstore_signer.py
+++ b/tests/check_sigstore_signer.py
@@ -1,13 +1,24 @@
 """
 Test SigstoreSigner API.
 
-NOTE: The filename prefix is check_ instead of test_ so that tests are
-only run when explicitly invoked in a suited environment.
+These tests require git and will use it to fetch a testing identity token from
+https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon
 
+Because of these unusual requirements (and because sometimes the fetch may take
+a longer time) the test file is named check_* and is not included in the default
+tests.
 """
 
+import json
 import os
+import subprocess
+import time
 import unittest
+from base64 import b64decode
+from datetime import datetime, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
 
 from securesystemslib.signer import (
     SIGNER_FOR_URI_SCHEME,
@@ -17,26 +28,76 @@ from securesystemslib.signer import (
 
 SIGNER_FOR_URI_SCHEME[SigstoreSigner.SCHEME] = SigstoreSigner
 
+TEST_IDENTITY = (
+    "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/"
+    "workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
+)
+TEST_ISSUER = "https://token.actions.githubusercontent.com"
+
+
+def identity_token() -> str:
+    """Return identity token for TEST_IDENTITY"""
+    # following code is modified from extremely-dangerous-public-oidc-beacon download-token.py.
+    # Caching can be made smarter (to return the cached token only if it is valid) if token
+    # starts going invalid during runs
+    min_validity = timedelta(seconds=5)
+    max_retry_time = timedelta(minutes=5 if os.getenv("CI") else 1)
+    retry_sleep_secs = 30 if os.getenv("CI") else 5
+    git_url = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon.git"
+
+    def git_clone(url: str, dir_: str) -> None:
+        base_cmd = [
+            "git",
+            "clone",
+            "--quiet",
+            "--branch",
+            "current-token",
+            "--depth",
+            "1",
+        ]
+        subprocess.run(base_cmd + [url, dir_], check=True)
+
+    def is_valid_at(token: str, reference_time: datetime) -> bool:
+        # split token, b64 decode (with padding), parse as json, validate expiry
+        payload = token.split(".")[1]
+        payload += "=" * (4 - len(payload) % 4)
+        payload_json = json.loads(b64decode(payload))
+
+        expiry = datetime.fromtimestamp(payload_json["exp"])
+        return reference_time < expiry
+
+    start_time = datetime.now()
+    while datetime.now() <= start_time + max_retry_time:
+        with TemporaryDirectory() as tempdir:
+            git_clone(git_url, tempdir)
+
+            with Path(tempdir, "oidc-token.txt").open(encoding="utf-8") as f:
+                token = f.read().rstrip()
+
+            if is_valid_at(token, datetime.now() + min_validity):
+                return token
+
+        print(
+            f"Current token expires too early, retrying in {retry_sleep_secs} seconds."
+        )
+        time.sleep(retry_sleep_secs)
+
+    raise TimeoutError(f"Failed to find a valid token in {max_retry_time}")
+
 
 class TestSigstoreSigner(unittest.TestCase):
-    """Test public key parsing, signature creation and verification.
+    """Test public key parsing, signature creation and verification."""
 
-    Requires ambient credentials for signing (e.g. from GitHub Action).
-
-    See sigstore-python docs for more infos about ambient credentials:
-    https://github.com/sigstore/sigstore-python#signing-with-ambient-credentials
-
-    See securesystemslib SigstoreSigner docs for how to test locally.
-    """
+    @classmethod
+    def setUpClass(cls):
+        cls.token = identity_token()
 
     def test_sign(self):
-        identity = os.getenv("CERT_ID")
-        self.assertIsNotNone(identity, "certificate identity required")
-        issuer = os.getenv("CERT_ISSUER")
-        self.assertIsNotNone(issuer, "OIDC issuer required")
-
-        uri, public_key = SigstoreSigner.import_(identity, issuer)
-        signer = Signer.from_priv_key_uri(uri, public_key)
+        uri, public_key = SigstoreSigner.import_(TEST_IDENTITY, TEST_ISSUER)
+        with mock.patch(
+            "sigstore.oidc.detect_credential", return_value=self.token
+        ):
+            signer = Signer.from_priv_key_uri(uri, public_key)
 
         sig = signer.sign(b"data")
         public_key.verify_signature(sig, b"data")

--- a/tox.ini
+++ b/tox.ini
@@ -49,13 +49,6 @@ commands =
 deps =
     -r{toxinidir}/requirements-pinned.txt
     -r{toxinidir}/requirements-sigstore.txt
-passenv =
-    # These are required to detect ambient credentials on GitHub
-    GITHUB_ACTIONS
-    ACTIONS_ID_TOKEN_REQUEST_TOKEN
-    ACTIONS_ID_TOKEN_REQUEST_URL
-    CERT_ID
-    CERT_ISSUER
 commands =
     python -m tests.check_sigstore_signer
 


### PR DESCRIPTION
* The test now works locally and in PRs
* Test does require git and uses it to fetch a test token: because of this the test is still not included  in the default set
* Since this now runs in PRs, I've removed the "file issue on failure" functionality
