### PR TITLE
validate Key instances in constructor not in deserialization

### DIFF
--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -95,7 +95,6 @@ class Key(metaclass=ABCMeta):
         keyval: Dict[str, Any],
         unrecognized_fields: Optional[Dict[str, Any]] = None,
     ):
-
         if not all(
             isinstance(at, str) for at in [keyid, keytype, scheme]
         ) or not isinstance(keyval, dict):
@@ -211,7 +210,6 @@ class SSlibKey(Key):
     ):
         if "public" not in keyval or not isinstance(keyval["public"], str):
             raise ValueError(f"public key string required for scheme {scheme}")
-
         super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
 
     @classmethod

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -95,7 +95,6 @@ class Key(metaclass=ABCMeta):
         keyval: Dict[str, Any],
         unrecognized_fields: Optional[Dict[str, Any]] = None,
     ):
-        from securesystemslib.signer._sigstore_signer import SigstoreKey
 
         if not all(
             isinstance(at, str) for at in [keyid, keytype, scheme]
@@ -110,20 +109,6 @@ class Key(metaclass=ABCMeta):
             unrecognized_fields = {}
 
         self.unrecognized_fields = unrecognized_fields
-
-        if isinstance(self, SSlibKey):
-            if "public" not in keyval or not isinstance(keyval["public"], str):
-                raise ValueError(
-                    f"public key string required for scheme {scheme}"
-                )
-        elif isinstance(self, SigstoreKey):
-            for content in ["identity", "issuer"]:
-                if content not in keyval or not isinstance(
-                    keyval[content], str
-                ):
-                    raise ValueError(
-                        f"{content} string required for scheme {scheme}"
-                    )
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Key):
@@ -215,6 +200,19 @@ class Key(metaclass=ABCMeta):
 
 class SSlibKey(Key):
     """Key implementation for RSA, Ed25519, ECDSA keys"""
+
+    def __init__(
+        self,
+        keyid: str,
+        keytype: str,
+        scheme: str,
+        keyval: Dict[str, Any],
+        unrecognized_fields: Optional[Dict[str, Any]] = None,
+    ):
+        if "public" not in keyval or not isinstance(keyval["public"], str):
+            raise ValueError(f"public key string required for scheme {scheme}")
+
+        super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
 
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "SSlibKey":

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -36,6 +36,22 @@ class SigstoreKey(Key):
     DEFAULT_KEY_TYPE = "sigstore-oidc"
     DEFAULT_SCHEME = "Fulcio"
 
+    def __init__(
+        self,
+        keyid: str,
+        keytype: str,
+        scheme: str,
+        keyval: Dict[str, Any],
+        unrecognized_fields: Optional[Dict[str, Any]] = None,
+    ):
+        for content in ["identity", "issuer"]:
+            if content not in keyval or not isinstance(keyval[content], str):
+                raise ValueError(
+                    f"{content} string required for scheme {scheme}"
+                )
+
+        super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
+
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "SigstoreKey":
         keytype, scheme, keyval = cls._from_dict(key_dict)

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -49,7 +49,6 @@ class SigstoreKey(Key):
                 raise ValueError(
                     f"{content} string required for scheme {scheme}"
                 )
-
         super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
 
     @classmethod

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -39,13 +39,6 @@ class SigstoreKey(Key):
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "SigstoreKey":
         keytype, scheme, keyval = cls._from_dict(key_dict)
-
-        for content in ["identity", "issuer"]:
-            if content not in keyval or not isinstance(keyval[content], str):
-                raise ValueError(
-                    f"{content} string required for scheme {scheme}"
-                )
-
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
     def to_dict(self) -> Dict:


### PR DESCRIPTION
<!--
Before submitting a pull request:
  * Run linter and tests locally: Use "tox"
  * Make sure new code has tests and is documented
-->

**Description of the changes being introduced by the pull request**:
Current behavior:
Key implementations validate inputs in from_dict

Expected behavior:
Key implementations validate inputs in __init__



Fixes #559 
