### PR TITLE
Disable Sigstore tests for now

### DIFF
--- a/.github/workflows/test-sigstore.yml
+++ b/.github/workflows/test-sigstore.yml
@@ -1,10 +1,11 @@
 name: Run Sigstore Signer tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  ## Disabled temporarily: #781
+  #push:
+  #  branches:
+  #    - main
+  #pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -1,5 +1,10 @@
 """Signer implementation for project sigstore.
 
+NOTE: SigstoreSigner and -Key are disabled temporarily around
+the Securesystemslib 1.0 release as the cyclic dependency
+(securesystemslib -> sigstore-python -> tuf -> securesystemslib)
+is problematic during API deprecations.
+See issue #781.
 """
 
 import io


### PR DESCRIPTION
Disable Sigstore test: we can enable once  securesystemslib, python-tuf and sigstore have had releases.

This is part of #781.