### PR TITLE
ci: test macOS and Windows on latest Python only

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,13 +8,19 @@ jobs:
   test:
     strategy:
       fail-fast: false
-      # Run tests on each OS/Python combination
       matrix:
+        # Run tests once on each supported Python
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         toxenv: [py]
-
         include:
+          # Run macOS, Windows and "special" tests on latest Python version only
+          - python-version: "3.11"
+            os: macos-latest
+            toxenv: py
+          - python-version: "3.11"
+            os: windows-latest
+            toxenv: py
           - python-version: "3.11"
             os: ubuntu-latest
             toxenv: purepy311


### PR DESCRIPTION
CI started failing recently, because new macos-latest runs on arm, which does not include all older Python versions.

As workaround and for the sake of a slimmer test matrix, we drop all but latest Python tests on macOS and Windows.

The remaining matrix should still give us reasonable coverage.

Related discussion in: https://github.com/secure-systems-lab/securesystemslib/pull/792#issuecomment-2072359562
