### PR TITLE
Add CryptoSigner.private_bytes

### DIFF
--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -45,6 +45,9 @@ try:
         HashAlgorithm,
     )
     from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
         load_pem_private_key,
     )
 except ImportError:
@@ -188,6 +191,18 @@ class CryptoSigner(Signer):
     @property
     def public_key(self) -> Key:
         return self._public_key
+
+    @property
+    def private_bytes(self) -> bytes:
+        """Return the PEM encoded PKCS8 format private key as bytes
+
+        The return value can be used as file content when a Signer is loaded with
+        `Signer.from_priv_key_uri('file2:<FILEPATH>')`."""
+        return self._private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.PKCS8,
+            encryption_algorithm=NoEncryption(),
+        )
 
     @classmethod
     def from_priv_key_uri(

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -703,6 +703,23 @@ class TestCryptoSigner(unittest.TestCase):
             with self.assertRaises(UnverifiedSignatureError):
                 signer.public_key.verify_signature(sig, b"NOT DATA")
 
+    def test_private_bytes(self):
+        """Test full cycle of generate -> private_bytes -> from_priv_key_uri"""
+        generate_funcs = [
+            CryptoSigner.generate_rsa,
+            CryptoSigner.generate_ecdsa,
+            CryptoSigner.generate_ed25519,
+        ]
+        for generate in generate_funcs:
+            signer = generate()
+            with open("privkey.pem", "wb") as f:
+                f.write(signer.private_bytes)
+
+            signer2 = Signer.from_priv_key_uri(
+                "file2:privkey.pem", signer.public_key
+            )
+            self.assertEqual(signer.private_bytes, signer2.private_bytes)
+
     def test_custom_crypto_signer(self):
         # setup
         key = self.keys[0]

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -705,18 +705,20 @@ class TestCryptoSigner(unittest.TestCase):
 
     def test_private_bytes(self):
         """Test private_bytes -> from_priv_key_uri"""
-        for pem in ["rsa", "ecdsa", "ed25519"]:
-            with open(PEMS_DIR / f"{pem}_private.pem", "rb") as f:
-                privkey = load_pem_private_key(f.read(), None)
-                signer = CryptoSigner(privkey)
+        with tempfile.TemporaryDirectory() as tempdir:
+            priv_key_path = os.path.join(tempdir, "privkey.pem")
+            for pem in ["rsa", "ecdsa", "ed25519"]:
+                with open(PEMS_DIR / f"{pem}_private.pem", "rb") as f:
+                    privkey = load_pem_private_key(f.read(), None)
+                    signer = CryptoSigner(privkey)
 
-            with open("privkey.pem", "wb") as f:
-                f.write(signer.private_bytes)
+                with open(priv_key_path, "wb") as f:
+                    f.write(signer.private_bytes)
 
-            signer2 = Signer.from_priv_key_uri(
-                "file2:privkey.pem", signer.public_key
-            )
-            self.assertEqual(signer.private_bytes, signer2.private_bytes)
+                signer2 = Signer.from_priv_key_uri(
+                    f"file2:{priv_key_path}", signer.public_key
+                )
+                self.assertEqual(signer.private_bytes, signer2.private_bytes)
 
     def test_custom_crypto_signer(self):
         # setup

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -704,14 +704,12 @@ class TestCryptoSigner(unittest.TestCase):
                 signer.public_key.verify_signature(sig, b"NOT DATA")
 
     def test_private_bytes(self):
-        """Test full cycle of generate -> private_bytes -> from_priv_key_uri"""
-        generate_funcs = [
-            CryptoSigner.generate_rsa,
-            CryptoSigner.generate_ecdsa,
-            CryptoSigner.generate_ed25519,
-        ]
-        for generate in generate_funcs:
-            signer = generate()
+        """Test private_bytes -> from_priv_key_uri"""
+        for pem in ["rsa", "ecdsa", "ed25519"]:
+            with open(PEMS_DIR / f"{pem}_private.pem", "rb") as f:
+                privkey = load_pem_private_key(f.read(), None)
+                signer = CryptoSigner(privkey)
+
             with open("privkey.pem", "wb") as f:
                 f.write(signer.private_bytes)
 


### PR DESCRIPTION
IMO this completes the MVP CryptoSigner API

Fixes #798

This is what the docs will look like: https://github.com/secure-systems-lab/securesystemslib/blob/cc68f4d1961da2bf274eab8b64baf4339ee06827/docs/CRYPTO_SIGNER.md