### PR TITLE
docs: Remove pre 1.0.0 disclaimers

### DIFF
--- a/docs/signer.rst
+++ b/docs/signer.rst
@@ -3,7 +3,7 @@ Signer API
 
 .. currentmodule:: securesystemslib.signer
 
-The signer module provides a simple and unified cryptographic signing and signature verification API designed to work consistently regardless of the underlying signing technology. This is achieved with abstract interfaces backed by multiple implementations:  
+The signer module provides a simple and unified cryptographic signing and signature verification API designed to work consistently regardless of the underlying signing technology. This is achieved with abstract interfaces backed by multiple implementations:
 
 * ``Signer.sign``
 * ``Key.verify_signature``
@@ -59,8 +59,7 @@ which may happen on different systems and at different points in time:
 
 4. **Verify**, given a configured public key
 
-.. warning::
-   The API is experimental and may change without warning in versions ``<1.0.0``.
+.. note::
 
    See `'New Signer API' <https://theupdateframework.github.io/python-tuf/2023/01/24/securesystemslib-signer-api.html>`_ blog post
    for background infos.

--- a/securesystemslib/dsse.py
+++ b/securesystemslib/dsse.py
@@ -116,9 +116,6 @@ class Envelope:
     def verify(self, keys: List[Key], threshold: int) -> Dict[str, Key]:
         """Verify the payload with the provided Keys.
 
-        NOTE: This API is experimental and might change (see
-        secure-systems-lab/dsse#55)
-
         Arguments:
             keys: A list of public keys to verify the signatures.
             threshold: Number of signatures needed to pass the verification.


### PR DESCRIPTION
Once we release 1.0.0 we will strictly follow semver. If anything that is released as public API now changes in a backwards-incompatible way, we will bump the major version.

This patch removes warnings about unexpected changes.




Related to #767 
