### PR TITLE
Remove 3 stray global key type constants

### DIFF
--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -12,10 +12,3 @@ __version__ = "0.31.0"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.addHandler(logging.StreamHandler())
-
-
-# Global constants
-# TODO: Replace hard-coded key types with these constants (and add more)
-KEY_TYPE_RSA = "rsa"
-KEY_TYPE_ED25519 = "ed25519"
-KEY_TYPE_ECDSA = "ecdsa"

--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -10,13 +10,14 @@ from contextlib import contextmanager
 from typing import Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
-from securesystemslib import KEY_TYPE_ECDSA
 from securesystemslib.exceptions import UnsupportedLibraryError
 from securesystemslib.hash import digest
 from securesystemslib.signer._key import Key, SSlibKey
 from securesystemslib.signer._signature import Signature
 from securesystemslib.signer._signer import SecretsHandler, Signer
 from securesystemslib.signer._utils import compute_default_keyid
+
+_KEY_TYPE_ECDSA = "ecdsa"
 
 # pylint: disable=wrong-import-position
 CRYPTO_IMPORT_ERROR = None
@@ -217,11 +218,13 @@ class HSMSigner(Signer):
             ]
         )
         if not keys:
-            raise ValueError(f"could not find {KEY_TYPE_ECDSA} key for {keyid}")
+            raise ValueError(
+                f"could not find {_KEY_TYPE_ECDSA} key for {keyid}"
+            )
 
         if len(keys) > 1:
             raise ValueError(
-                f"found more than one {KEY_TYPE_ECDSA} key for {keyid}"
+                f"found more than one {_KEY_TYPE_ECDSA} key for {keyid}"
             )
 
         return keys[0]
@@ -327,8 +330,8 @@ class HSMSigner(Signer):
 
         keyval = {"public": public_pem}
         scheme = _SCHEME_FOR_CURVE[curve]
-        keyid = compute_default_keyid(KEY_TYPE_ECDSA, scheme, keyval)
-        key = SSlibKey(keyid, KEY_TYPE_ECDSA, scheme, keyval)
+        keyid = compute_default_keyid(_KEY_TYPE_ECDSA, scheme, keyval)
+        key = SSlibKey(keyid, _KEY_TYPE_ECDSA, scheme, keyval)
 
         return uri, key
 


### PR DESCRIPTION
These feel a bit lost in the package-level namespace and are also only a subset of the key types supported in the signer API.

Let's exclude them from the 1.0.0 API, and think of a suitable place when addressing #593.

The patch also refactors the only internal usage of one of the constants. Externally, they seem to be only imported (but unused) in in-toto, which is prepared for breaking changes in securesystemslib.



Follows suggestion from https://github.com/secure-systems-lab/securesystemslib/issues/593#issuecomment-1573755201
