### PR TITLE
Upgrade sigstore dependency

### DIFF
--- a/.github/workflows/test-sigstore.yml
+++ b/.github/workflows/test-sigstore.yml
@@ -1,11 +1,10 @@
 name: Run Sigstore Signer tests
 
 on:
-  ## Disabled temporarily: #781
-  #push:
-  #  branches:
-  #    - main
-  #pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,9 +20,6 @@ ignore_missing_imports = True
 [mypy-asn1crypto.*]
 ignore_missing_imports = True
 
-[mypy-sigstore.*]
-ignore_missing_imports = True
-
 [mypy-sigstore_protobuf_specs.*]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ azurekms = ["azure-identity", "azure-keyvault-keys", "cryptography>=40.0.0"]
 awskms = ["boto3", "botocore", "cryptography>=40.0.0"]
 hsm = ["asn1crypto", "cryptography>=40.0.0", "PyKCS11"]
 PySPX = ["PySPX>=0.5.0"]
-sigstore = ["sigstore~=2.0"]
+sigstore = ["sigstore~=3.0"]
 vault = ["hvac", "cryptography>=40.0.0"]
 
 [tool.hatch.version]

--- a/requirements-sigstore.txt
+++ b/requirements-sigstore.txt
@@ -1,1 +1,1 @@
-sigstore==2.1.5
+sigstore==3.0.0

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -65,7 +65,10 @@ class SigstoreKey(Key):
             from sigstore.models import Bundle
             from sigstore.verify import Verifier
             from sigstore.verify.policy import Identity
+        except ImportError as e:
+            raise VerificationError(IMPORT_ERROR) from e
 
+        try:
             verifier = Verifier.production()
             identity = Identity(
                 identity=self.keyval["identity"], issuer=self.keyval["issuer"]

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
 deps =
     -r{toxinidir}/requirements-pinned.txt
     -r{toxinidir}/requirements-lint.txt
+    -r{toxinidir}/requirements-sigstore.txt
 commands =
     black --check --diff  .
     isort --check --diff  .


### PR DESCRIPTION
* Upgrade to sigstore 3.0 API. Everything was otherwise expected but the underlying "bundle" protobuf is no longer part of sigstore API (understandably): This does mean a weird json back-and-forth in our verify and sign but it works
* Include Sigstore in linting
* Enable sigstore test workflow again
* Add some failure test cases

Fixes #781 
