### PR TITLE
Prepare v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## securesystemslib v1.1.0
+
+This is a small release that only re-enables the use of SigstoreSigner.
+Note that SigstoreSigner and SigstoreKey are still not part of the default
+set of supported signers & keys but now they can be enabled.
+
+### Changed
+* SigstoreSigner: Re-enable compatibility with Sigstore (#781)
+
 ## securesystemslib v1.0.0
 
 Securesystemslib API is now considered stable. The core functionality is

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-module-docstring
 import logging
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
This is a small release just to enable Sigstore support again.

-- 

for context, this should allow me to finally upgrade tuf in tuf-on-ci