### PR TITLE
SigstoreSigner: convenience function for GitHub import

### DIFF
--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -268,3 +268,26 @@ class SigstoreSigner(Signer):
             bundle_json["messageSignature"]["signature"],
             {"bundle": bundle_json},
         )
+
+    @classmethod
+    def import_github_actions(
+        cls, project: str, workflow_path: str, ref: Optional[str] = "refs/heads/main"
+    ) -> Tuple[str, SigstoreKey]:
+        """Convenience method to build identity and issuer string for import_() from
+        GitHub project and workflow path.
+
+        Args:
+            project: GitHub project
+            worfklow_path: GitHub workflow path
+            ref: optional GitHub ref, defaults to refs/heads/main
+
+        Returns:
+            uri: string
+            key: SigstoreKey
+
+        """
+        identity = f"https://github.com/{project}/{workflow_path}@{ref}"
+        issuer = "https://token.actions.githubusercontent.com"
+        uri, key = cls.import_(identity, issuer)
+
+        return uri, key

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -277,8 +277,10 @@ class SigstoreSigner(Signer):
         GitHub project and workflow path.
 
         Args:
-            project: GitHub project
-            worfklow_path: GitHub workflow path
+            project: GitHub project name (example:
+               "secure-systems-lab/securesystemslib")
+            workflow_path: GitHub workflow path (example:
+               ".github/workflows/online-sign.yml")
             ref: optional GitHub ref, defaults to refs/heads/main
 
         Returns:


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
- `import_github_actions()` added that builds identity from function input and uses `https://token.actions.githubusercontent.com` for issuer. Calling `cls.import_()`.

Fixes #536 #533 
