### PR TITLE
Use __future__.annotations module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Security",
     "Topic :: Software Development",
 ]
-requires-python = "~=3.9"
+requires-python = "~=3.8"
 dynamic = ["version"]
 
 [project.urls]

--- a/securesystemslib/_gpg/constants.py
+++ b/securesystemslib/_gpg/constants.py
@@ -16,12 +16,13 @@
   handling
 """
 
+from __future__ import annotations
+
 import functools
 import logging
 import os
 import shlex
 import subprocess
-from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ GPG_TIMEOUT = 10
 
 
 @functools.lru_cache(maxsize=3)
-def is_available_gnupg(gnupg: str, timeout: Optional[int] = None) -> bool:
+def is_available_gnupg(gnupg: str, timeout: int | None = None) -> bool:
     """Returns whether gnupg points to a gpg binary."""
     if timeout is None:
         timeout = GPG_TIMEOUT

--- a/securesystemslib/dsse.py
+++ b/securesystemslib/dsse.py
@@ -1,5 +1,7 @@
 """Dead Simple Signing Envelope"""
 
+from __future__ import annotations
+
 import logging
 from typing import Any
 
@@ -41,7 +43,7 @@ class Envelope:
         )
 
     @classmethod
-    def from_dict(cls, data: dict) -> "Envelope":
+    def from_dict(cls, data: dict) -> Envelope:
         """Creates a DSSE Envelope from its JSON/dict representation.
 
         Arguments:

--- a/securesystemslib/signer/_aws_signer.py
+++ b/securesystemslib/signer/_aws_signer.py
@@ -1,7 +1,8 @@
 """Signer implementation for AWS Key Management Service"""
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 from urllib import parse
 
 from securesystemslib.exceptions import (
@@ -91,8 +92,8 @@ class AWSSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "AWSSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> AWSSigner:
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:
@@ -101,7 +102,7 @@ class AWSSigner(Signer):
         return cls(uri.path, public_key)
 
     @classmethod
-    def _get_default_scheme(cls, supported_by_key: list[str]) -> Optional[str]:
+    def _get_default_scheme(cls, supported_by_key: list[str]) -> str | None:
         # Iterate over supported AWS algorithms, pick the **first** that is also
         # supported by the key, and return the related securesystemslib scheme.
         for scheme, algo in cls.aws_algos.items():
@@ -119,7 +120,7 @@ class AWSSigner(Signer):
 
     @classmethod
     def import_(
-        cls, aws_key_id: str, local_scheme: Optional[str] = None
+        cls, aws_key_id: str, local_scheme: str | None = None
     ) -> tuple[str, Key]:
         """Loads a key and signer details from AWS KMS.
 

--- a/securesystemslib/signer/_azure_signer.py
+++ b/securesystemslib/signer/_azure_signer.py
@@ -1,7 +1,8 @@
 """Signer implementation for Azure Key Vault"""
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 from urllib import parse
 
 import securesystemslib.hash as sslib_hash
@@ -90,10 +91,10 @@ class AzureSigner(Signer):
 
     @staticmethod
     def _get_key_vault_key(
-        cred: "DefaultAzureCredential",
+        cred: DefaultAzureCredential,
         vault_name: str,
         key_name: str,
-    ) -> "KeyVaultKey":
+    ) -> KeyVaultKey:
         """Return KeyVaultKey created from the Vault name and key name"""
         vault_url = f"https://{vault_name}.vault.azure.net/"
 
@@ -112,9 +113,9 @@ class AzureSigner(Signer):
 
     @staticmethod
     def _create_crypto_client(
-        cred: "DefaultAzureCredential",
-        kv_key: "KeyVaultKey",
-    ) -> "CryptographyClient":
+        cred: DefaultAzureCredential,
+        kv_key: KeyVaultKey,
+    ) -> CryptographyClient:
         """Return CryptographyClient created Azure credentials and a KeyVaultKey"""
         try:
             return CryptographyClient(kv_key, credential=cred)
@@ -128,7 +129,7 @@ class AzureSigner(Signer):
             raise e
 
     @staticmethod
-    def _get_signature_algorithm(public_key: Key) -> "SignatureAlgorithm":
+    def _get_signature_algorithm(public_key: Key) -> SignatureAlgorithm:
         """Return SignatureAlgorithm after parsing the public key"""
         if public_key.keytype != "ecdsa":
             logger.info("only EC keys are supported for now")
@@ -148,7 +149,7 @@ class AzureSigner(Signer):
         raise UnsupportedKeyType("Unsupported curve supplied by key")
 
     @staticmethod
-    def _get_hash_algorithm(public_key: "Key") -> str:
+    def _get_hash_algorithm(public_key: Key) -> str:
         """Return the hash algorithm used by the public key"""
         # Format is "ecdsa-sha2-nistp256"
         comps = public_key.scheme.split("-")
@@ -180,8 +181,8 @@ class AzureSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "AzureSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> AzureSigner:
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -1,7 +1,8 @@
 """Signer implementation for Google Cloud KMS"""
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 from urllib import parse
 
 import securesystemslib.hash as sslib_hash
@@ -73,8 +74,8 @@ class GCPSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "GCPSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> GCPSigner:
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:

--- a/securesystemslib/signer/_gpg_signer.py
+++ b/securesystemslib/signer/_gpg_signer.py
@@ -1,7 +1,9 @@
 """Signer implementation for OpenPGP"""
 
+from __future__ import annotations
+
 import logging
-from typing import Any, Optional
+from typing import Any
 from urllib import parse
 
 from securesystemslib import exceptions
@@ -32,7 +34,7 @@ class GPGKey(Key):
     """
 
     @classmethod
-    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> "GPGKey":
+    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> GPGKey:
         keytype, scheme, keyval = cls._from_dict(key_dict)
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
@@ -84,7 +86,7 @@ class GPGSigner(Signer):
     def __init__(
         self,
         public_key: Key,
-        homedir: Optional[str] = None,
+        homedir: str | None = None,
     ):
         self.homedir = homedir
         self._public_key = public_key
@@ -98,8 +100,8 @@ class GPGSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "GPGSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> GPGSigner:
         if not isinstance(public_key, GPGKey):
             raise ValueError(f"expected GPGKey for {priv_key_uri}")
 
@@ -147,7 +149,7 @@ class GPGSigner(Signer):
         return GPGKey(keyid, keytype, scheme, keyval)
 
     @classmethod
-    def import_(cls, keyid: str, homedir: Optional[str] = None) -> tuple[str, Key]:
+    def import_(cls, keyid: str, homedir: str | None = None) -> tuple[str, Key]:
         """Load key and signer details from GnuPG keyring.
 
         NOTE: Information about the key validity (expiration, revocation, etc.)

--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -5,10 +5,11 @@ the related public keys.
 
 """
 
+from __future__ import annotations
+
 import binascii
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Optional
 from urllib import parse
 
 from securesystemslib.exceptions import UnsupportedLibraryError
@@ -184,7 +185,7 @@ class HSMSigner(Signer):
 
     @staticmethod
     @contextmanager
-    def _get_session(filters: dict[str, str]) -> Iterator["PyKCS11.Session"]:
+    def _get_session(filters: dict[str, str]) -> Iterator[PyKCS11.Session]:
         """Context manager to handle a HSM session.
 
         The cryptographic token is selected by filtering by token info fields.
@@ -201,9 +202,9 @@ class HSMSigner(Signer):
     @classmethod
     def _find_key(
         cls,
-        session: "PyKCS11.Session",
+        session: PyKCS11.Session,
         keyid: int,
-        key_type: Optional[int] = None,
+        key_type: int | None = None,
     ) -> int:
         """Find ecdsa key on HSM."""
         if key_type is None:
@@ -226,8 +227,8 @@ class HSMSigner(Signer):
 
     @classmethod
     def _find_key_values(
-        cls, session: "PyKCS11.Session", keyid: int
-    ) -> tuple["ECDomainParameters", bytes]:
+        cls, session: PyKCS11.Session, keyid: int
+    ) -> tuple[ECDomainParameters, bytes]:
         """Find ecdsa public key values on HSM."""
         key = cls._find_key(session, keyid)
         params, point = session.getAttributeValue(
@@ -261,8 +262,8 @@ class HSMSigner(Signer):
     @classmethod
     def import_(
         cls,
-        hsm_keyid: Optional[int] = None,
-        token_filter: Optional[dict[str, str]] = None,
+        hsm_keyid: int | None = None,
+        token_filter: dict[str, str] | None = None,
     ) -> tuple[str, SSlibKey]:
         """Import public key and signer details from HSM.
 
@@ -337,8 +338,8 @@ class HSMSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "HSMSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> HSMSigner:
         if not isinstance(public_key, SSlibKey):
             raise ValueError(f"expected SSlibKey for {priv_key_uri}")
 

--- a/securesystemslib/signer/_signature.py
+++ b/securesystemslib/signer/_signature.py
@@ -1,7 +1,9 @@
 """Signature container class"""
 
+from __future__ import annotations
+
 import logging
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ class Signature:
         self,
         keyid: str,
         sig: str,
-        unrecognized_fields: Optional[dict[str, Any]] = None,
+        unrecognized_fields: dict[str, Any] | None = None,
     ):
         self.keyid = keyid
         self.signature = sig
@@ -54,7 +56,7 @@ class Signature:
         )
 
     @classmethod
-    def from_dict(cls, signature_dict: dict) -> "Signature":
+    def from_dict(cls, signature_dict: dict) -> Signature:
         """Creates a Signature object from its JSON/dict representation.
 
         Arguments:

--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -1,8 +1,10 @@
 """Signer interface"""
 
+from __future__ import annotations
+
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Callable, Optional
+from typing import Callable
 
 from securesystemslib.signer._key import Key
 from securesystemslib.signer._signature import Signature
@@ -81,8 +83,8 @@ class Signer(metaclass=ABCMeta):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "Signer":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> Signer:
         """Factory constructor for a given private key URI
 
         Returns a specific Signer instance based on the private key URI and the

--- a/securesystemslib/signer/_sigstore_signer.py
+++ b/securesystemslib/signer/_sigstore_signer.py
@@ -1,8 +1,10 @@
 """Signer implementation for project sigstore."""
 
+from __future__ import annotations
+
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 from urllib import parse
 
 from securesystemslib.exceptions import (
@@ -40,7 +42,7 @@ class SigstoreKey(Key):
         keytype: str,
         scheme: str,
         keyval: dict[str, Any],
-        unrecognized_fields: Optional[dict[str, Any]] = None,
+        unrecognized_fields: dict[str, Any] | None = None,
     ):
         for content in ["identity", "issuer"]:
             if content not in keyval or not isinstance(keyval[content], str):
@@ -48,7 +50,7 @@ class SigstoreKey(Key):
         super().__init__(keyid, keytype, scheme, keyval, unrecognized_fields)
 
     @classmethod
-    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> "SigstoreKey":
+    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> SigstoreKey:
         keytype, scheme, keyval = cls._from_dict(key_dict)
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
@@ -149,8 +151,8 @@ class SigstoreSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "SigstoreSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> SigstoreSigner:
         try:
             from sigstore.oidc import IdentityToken, Issuer, detect_credential
         except ImportError as e:
@@ -271,7 +273,7 @@ class SigstoreSigner(Signer):
 
     @classmethod
     def import_github_actions(
-        cls, project: str, workflow_path: str, ref: Optional[str] = "refs/heads/main"
+        cls, project: str, workflow_path: str, ref: str | None = "refs/heads/main"
     ) -> tuple[str, SigstoreKey]:
         """Convenience method to build identity and issuer string for import_() from
         GitHub project and workflow path.

--- a/securesystemslib/signer/_spx_signer.py
+++ b/securesystemslib/signer/_spx_signer.py
@@ -1,8 +1,10 @@
 """Signer implementation for project SPHINCS+ post-quantum signature support."""
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 from securesystemslib.exceptions import (
     UnsupportedLibraryError,
@@ -48,12 +50,12 @@ class SpxKey(Key):
     DEFAULT_SCHEME = "sphincs-shake-128s"
 
     @classmethod
-    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> "SpxKey":
+    def from_dict(cls, keyid: str, key_dict: dict[str, Any]) -> SpxKey:
         keytype, scheme, keyval = cls._from_dict(key_dict)
         return cls(keyid, keytype, scheme, keyval, key_dict)
 
     @classmethod
-    def from_bytes(cls, public: bytes) -> "SpxKey":
+    def from_bytes(cls, public: bytes) -> SpxKey:
         """Create SpxKey instance from public key bytes."""
         keytype = cls.DEFAULT_KEY_TYPE
         scheme = cls.DEFAULT_SCHEME
@@ -121,8 +123,8 @@ class SpxSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "SpxSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> SpxSigner:
         raise NotImplementedError
 
     def sign(self, payload: bytes) -> Signature:

--- a/securesystemslib/signer/_utils.py
+++ b/securesystemslib/signer/_utils.py
@@ -1,6 +1,8 @@
 """Signer utils for internal use."""
 
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any
 
 from securesystemslib.exceptions import FormatError
 from securesystemslib.formats import encode_canonical
@@ -9,7 +11,7 @@ from securesystemslib.hash import digest
 
 def compute_default_keyid(keytype: str, scheme, keyval: dict[str, Any]) -> str:
     """Return sha256 hexdigest of the canonical json of the key."""
-    data: Union[str, None] = encode_canonical(
+    data: str | None = encode_canonical(
         {
             "keytype": keytype,
             "scheme": scheme,

--- a/securesystemslib/signer/_vault_signer.py
+++ b/securesystemslib/signer/_vault_signer.py
@@ -1,7 +1,8 @@
 """Signer implementation for HashiCorp Vault (Transit secrets engine)"""
 
+from __future__ import annotations
+
 from base64 import b64decode, b64encode
-from typing import Optional
 from urllib import parse
 
 from securesystemslib.exceptions import UnsupportedLibraryError
@@ -83,8 +84,8 @@ class VaultSigner(Signer):
         cls,
         priv_key_uri: str,
         public_key: Key,
-        secrets_handler: Optional[SecretsHandler] = None,
-    ) -> "VaultSigner":
+        secrets_handler: SecretsHandler | None = None,
+    ) -> VaultSigner:
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:

--- a/securesystemslib/storage.py
+++ b/securesystemslib/storage.py
@@ -15,6 +15,8 @@
   Provides an interface for filesystem interactions, StorageBackendInterface.
 """
 
+from __future__ import annotations
+
 import errno
 import logging
 import os
@@ -23,7 +25,7 @@ import stat
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import IO, BinaryIO, Optional
+from typing import IO, BinaryIO
 
 from securesystemslib import exceptions
 
@@ -64,7 +66,7 @@ class StorageBackendInterface(metaclass=ABCMeta):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def put(self, fileobj: IO, filepath: str, restrict: Optional[bool] = False) -> None:
+    def put(self, fileobj: IO, filepath: str, restrict: bool | None = False) -> None:
         """
         <Purpose>
           Store a file-like object in the storage backend.
@@ -204,7 +206,7 @@ class FilesystemBackend(StorageBackendInterface):
             if file_object is not None:
                 file_object.close()
 
-    def put(self, fileobj: IO, filepath: str, restrict: Optional[bool] = False) -> None:
+    def put(self, fileobj: IO, filepath: str, restrict: bool | None = False) -> None:
         # If we are passed an open file, seek to the beginning such that we are
         # copying the entire contents
         if not fileobj.closed:


### PR DESCRIPTION
The extra import is a little annoying but allows using even python 3.10 annotation features already, which I like.
* start using "X | None" instead of Optional[X]
* Drop the quotes from factory function return values

This also keeps us compatible with python 3.8 for the moment.

