### PR TITLE
Modernize license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ build-backend = "hatchling.build"
 [project]
 name = "securesystemslib"
 authors = [{name = "https://www.updateframework.com", email = "theupdateframework@googlegroups.com"}]
-license = {text = "MIT"}
+license = "MIT"
+license-files = [ "LICENSE" ]
 description = "A library that provides cryptographic and general-purpose routines for Secure Systems Lab projects at NYU"
 readme = "README.md"
 keywords = [
@@ -22,7 +23,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
PEP-639 license metadata is now supported by hatchling, twine, pypi release action and pip.
 * license field is an SPDX license expression
 * license-files lists all the license files included in distribution
