### PR TITLE
dependabot: Add zizmor to lint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
         - "ruff"
         - "coverage"
         - "mypy"
+        - "zizmor"
     dependencies:
       # Python (developer) runtime dependencies. Also any new dependencies not
       # caught by earlier groups


### PR DESCRIPTION
This is just for more accurate Dependabot grouping
