### PR TITLE
requirements: Pin aws (boto) less strictly

### DIFF
--- a/requirements-aws.txt
+++ b/requirements-aws.txt
@@ -1,2 +1,2 @@
-boto3==1.37.5
-botocore==1.37.5
+boto3~=1.37.5
+botocore~=1.37.5


### PR DESCRIPTION
Most of our dependabot PRs are for AWS libraries that release new versions constantly. We only pin these libraries for test result consistency: it seems that not pinning the patch version is harmless here and stops a lot of the dependabot spam.

Pin only minor.major version for AWS libs.
