### PR TITLE
Refactor scheme parsing 

### DIFF
--- a/securesystemslib/signer/_aws_signer.py
+++ b/securesystemslib/signer/_aws_signer.py
@@ -74,7 +74,7 @@ class AWSSigner(Signer):
         "rsa-pkcs1v15-sha512": "RSASSA_PKCS1_V1_5_SHA_512",
     }
 
-    def __init__(self, aws_key_id: str, public_key: Key):
+    def __init__(self, aws_key_id: str, public_key: SSlibKey):
         if AWS_IMPORT_ERROR:
             raise UnsupportedLibraryError(AWS_IMPORT_ERROR)
 
@@ -84,7 +84,7 @@ class AWSSigner(Signer):
         self.aws_algo = self.aws_algos[self.public_key.scheme]
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @classmethod
@@ -94,6 +94,9 @@ class AWSSigner(Signer):
         public_key: Key,
         secrets_handler: SecretsHandler | None = None,
     ) -> AWSSigner:
+        if not isinstance(public_key, SSlibKey):
+            raise ValueError(f"Expected SSlibKey for {priv_key_uri}")
+
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:
@@ -121,7 +124,7 @@ class AWSSigner(Signer):
     @classmethod
     def import_(
         cls, aws_key_id: str, local_scheme: str | None = None
-    ) -> tuple[str, Key]:
+    ) -> tuple[str, SSlibKey]:
         """Loads a key and signer details from AWS KMS.
 
         Returns the private key uri and the public key. This method should only
@@ -133,7 +136,7 @@ class AWSSigner(Signer):
             Defaults to 'rsassa-pss-sha256' if not provided and RSA.
 
         Returns:
-            Tuple[str, Key]: A tuple where the first element is a string
+            Tuple[str, SSlibKey]: A tuple where the first element is a string
             representing the private key URI, and the second element is an
             instance of the public key.
 

--- a/securesystemslib/signer/_azure_signer.py
+++ b/securesystemslib/signer/_azure_signer.py
@@ -99,7 +99,7 @@ class AzureSigner(Signer):
         self.signature_algorithm = self._get_signature_algorithm(
             public_key.scheme,
         )
-        self.hash_algorithm = self._get_hash_algorithm(public_key)
+        self.hash_algorithm = public_key.get_hash_algorithm_name()
         self._public_key = public_key
 
     @property
@@ -149,23 +149,6 @@ class AzureSigner(Signer):
     def _get_signature_algorithm(scheme: str) -> SignatureAlgorithm:
         """Return SignatureAlgorithm after parsing the public key"""
         return SIGNATURE_ALGORITHMS[scheme]
-
-    @staticmethod
-    def _get_hash_algorithm(public_key: Key) -> str:
-        """Return the hash algorithm used by the public key"""
-        # Format is "ecdsa-sha2-nistp256"
-        comps = public_key.scheme.split("-")
-        if len(comps) != 3:  # noqa: PLR2004
-            raise UnsupportedKeyType("Invalid scheme found")
-
-        if comps[2] == "nistp256":
-            return "sha256"
-        if comps[2] == "nistp384":
-            return "sha384"
-        if comps[2] == "nistp521":
-            return "sha512"
-
-        raise UnsupportedKeyType("Unsupported curve supplied by key")
 
     @staticmethod
     def _get_keytype_and_scheme(crv: str) -> tuple[str, str]:

--- a/securesystemslib/signer/_azure_signer.py
+++ b/securesystemslib/signer/_azure_signer.py
@@ -96,9 +96,7 @@ class AzureSigner(Signer):
             az_key_uri,
             credential=cred,
         )
-        self.signature_algorithm = self._get_signature_algorithm(
-            public_key.scheme,
-        )
+        self.signature_algorithm = SIGNATURE_ALGORITHMS[public_key.scheme]
         self.hash_algorithm = public_key.get_hash_algorithm_name()
         self._public_key = public_key
 
@@ -144,11 +142,6 @@ class AzureSigner(Signer):
                 str(e),
             )
             raise e
-
-    @staticmethod
-    def _get_signature_algorithm(scheme: str) -> SignatureAlgorithm:
-        """Return SignatureAlgorithm after parsing the public key"""
-        return SIGNATURE_ALGORITHMS[scheme]
 
     @staticmethod
     def _get_keytype_and_scheme(crv: str) -> tuple[str, str]:

--- a/securesystemslib/signer/_azure_signer.py
+++ b/securesystemslib/signer/_azure_signer.py
@@ -66,7 +66,7 @@ class AzureSigner(Signer):
 
     SCHEME = "azurekms"
 
-    def __init__(self, az_key_uri: str, public_key: Key):
+    def __init__(self, az_key_uri: str, public_key: SSlibKey):
         if AZURE_IMPORT_ERROR:
             raise UnsupportedLibraryError(AZURE_IMPORT_ERROR)
 
@@ -86,7 +86,7 @@ class AzureSigner(Signer):
         self._public_key = public_key
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @staticmethod
@@ -129,7 +129,7 @@ class AzureSigner(Signer):
             raise e
 
     @staticmethod
-    def _get_signature_algorithm(public_key: Key) -> SignatureAlgorithm:
+    def _get_signature_algorithm(public_key: SSlibKey) -> SignatureAlgorithm:
         """Return SignatureAlgorithm after parsing the public key"""
         if public_key.keytype != "ecdsa":
             logger.info("only EC keys are supported for now")
@@ -183,6 +183,9 @@ class AzureSigner(Signer):
         public_key: Key,
         secrets_handler: SecretsHandler | None = None,
     ) -> AzureSigner:
+        if not isinstance(public_key, SSlibKey):
+            raise ValueError(f"Expected SSlibKey for {priv_key_uri}")
+
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:
@@ -192,7 +195,7 @@ class AzureSigner(Signer):
         return cls(az_key_uri, public_key)
 
     @classmethod
-    def import_(cls, az_vault_name: str, az_key_name: str) -> tuple[str, Key]:
+    def import_(cls, az_vault_name: str, az_key_name: str) -> tuple[str, SSlibKey]:
         """Load key and signer details from KMS
 
         Returns the private key uri and the public key. This method should only

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -38,10 +38,7 @@ try:
     )
     from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
     from cryptography.hazmat.primitives.hashes import (
-        SHA224,
         SHA256,
-        SHA384,
-        SHA512,
         HashAlgorithm,
     )
     from cryptography.hazmat.primitives.serialization import (
@@ -50,6 +47,9 @@ try:
         PrivateFormat,
         load_pem_private_key,
     )
+
+    from securesystemslib.signer._crypto_utils import get_hash_algorithm
+
 except ImportError:
     CRYPTO_IMPORT_ERROR = "'pyca/cryptography' library required"
 
@@ -75,21 +75,6 @@ class _NoSignArgs:
 # for backwards compat: use when spec-deprecated keytype ecdsa-sha2-nistp256
 # should be accepted in addition to "ecdsa"
 _ECDSA_KEYTYPES = ["ecdsa", "ecdsa-sha2-nistp256"]
-
-
-def _get_hash_algorithm(name: str) -> "HashAlgorithm":
-    """Helper to return hash algorithm for name."""
-    algorithm: HashAlgorithm
-    if name == "sha224":
-        algorithm = SHA224()
-    if name == "sha256":
-        algorithm = SHA256()
-    if name == "sha384":
-        algorithm = SHA384()
-    if name == "sha512":
-        algorithm = SHA512()
-
-    return algorithm
 
 
 def _get_rsa_padding(name: str, hash_algorithm: "HashAlgorithm") -> "AsymmetricPadding":
@@ -156,7 +141,7 @@ class CryptoSigner(Signer):
                 raise ValueError(f"invalid rsa key: {type(private_key)}")
 
             padding_name, hash_name = public_key.scheme.split("-")[1:]
-            hash_algo = _get_hash_algorithm(hash_name)
+            hash_algo = get_hash_algorithm(hash_name)
             padding = _get_rsa_padding(padding_name, hash_algo)
             self._sign_args = _RSASignArgs(padding, hash_algo)
             self._private_key = private_key

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -187,7 +187,7 @@ class CryptoSigner(Signer):
         self._public_key = public_key
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @property

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -140,9 +140,12 @@ class CryptoSigner(Signer):
             if not isinstance(private_key, RSAPrivateKey):
                 raise ValueError(f"invalid rsa key: {type(private_key)}")
 
-            padding_name, hash_name = public_key.scheme.split("-")[1:]
+            hash_name = public_key.get_hash_algorithm_name()
             hash_algo = get_hash_algorithm(hash_name)
+
+            padding_name = public_key.get_padding_name()
             padding = _get_rsa_padding(padding_name, hash_algo)
+
             self._sign_args = _RSASignArgs(padding, hash_algo)
             self._private_key = private_key
 

--- a/securesystemslib/signer/_crypto_utils.py
+++ b/securesystemslib/signer/_crypto_utils.py
@@ -1,0 +1,23 @@
+"""Signer utils for internal use that require pyca/cryptography."""
+
+from cryptography.hazmat.primitives.hashes import (
+    SHA224,
+    SHA256,
+    SHA384,
+    SHA512,
+    HashAlgorithm,
+)
+
+
+def get_hash_algorithm(name: str) -> HashAlgorithm:
+    """Helper to return hash algorithm object for name."""
+    if name == "sha224":
+        return SHA224()
+    elif name == "sha256":
+        return SHA256()
+    elif name == "sha384":
+        return SHA384()
+    elif name == "sha512":
+        return SHA512()
+
+    raise ValueError(f"Unsupported hash algorithm: {name}")

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -149,7 +149,7 @@ class GCPSigner(Signer):
         request = {"name": gcp_keyid}
         kms_pubkey = client.get_public_key(request)
         try:
-            keytype, scheme = cls._get_keytype_and_scheme(kms_pubkey.algorithm)
+            keytype, scheme = KEYTYPES_AND_SCHEMES[kms_pubkey.algorithm]
         except KeyError as e:
             raise exceptions.UnsupportedAlgorithmError(
                 f"{kms_pubkey.algorithm} is not a supported signing algorithm"
@@ -160,11 +160,6 @@ class GCPSigner(Signer):
         public_key = SSlibKey(keyid, keytype, scheme, keyval)
 
         return f"{cls.SCHEME}:{gcp_keyid}", public_key
-
-    @staticmethod
-    def _get_keytype_and_scheme(algorithm: int) -> tuple[str, str]:
-        """Return keytype and scheme for the KMS algorithm enum"""
-        return KEYTYPES_AND_SCHEMES[algorithm]
 
     def sign(self, payload: bytes) -> Signature:
         """Signs payload with Google Cloud KMS.

--- a/securesystemslib/signer/_gcp_signer.py
+++ b/securesystemslib/signer/_gcp_signer.py
@@ -56,7 +56,7 @@ class GCPSigner(Signer):
 
     SCHEME = "gcpkms"
 
-    def __init__(self, gcp_keyid: str, public_key: Key):
+    def __init__(self, gcp_keyid: str, public_key: SSlibKey):
         if GCP_IMPORT_ERROR:
             raise exceptions.UnsupportedLibraryError(GCP_IMPORT_ERROR)
 
@@ -66,7 +66,7 @@ class GCPSigner(Signer):
         self.client = kms.KeyManagementServiceClient()
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @classmethod
@@ -76,6 +76,9 @@ class GCPSigner(Signer):
         public_key: Key,
         secrets_handler: SecretsHandler | None = None,
     ) -> GCPSigner:
+        if not isinstance(public_key, SSlibKey):
+            raise ValueError(f"Expected SSlibKey for {priv_key_uri}")
+
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:
@@ -84,7 +87,7 @@ class GCPSigner(Signer):
         return cls(uri.path, public_key)
 
     @classmethod
-    def import_(cls, gcp_keyid: str) -> tuple[str, Key]:
+    def import_(cls, gcp_keyid: str) -> tuple[str, SSlibKey]:
         """Load key and signer details from KMS
 
         Returns the private key uri and the public key. This method should only

--- a/securesystemslib/signer/_hsm_signer.py
+++ b/securesystemslib/signer/_hsm_signer.py
@@ -128,7 +128,7 @@ class HSMSigner(Signer):
         self,
         hsm_keyid: int,
         token_filter: dict[str, str],
-        public_key: Key,
+        public_key: SSlibKey,
         pin_handler: SecretsHandler,
     ):
         if CRYPTO_IMPORT_ERROR:
@@ -149,7 +149,7 @@ class HSMSigner(Signer):
         self.pin_handler = pin_handler
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @staticmethod

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -43,7 +43,6 @@ try:
     )
     from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
     from cryptography.hazmat.primitives.hashes import (
-        SHA224,
         SHA256,
         SHA384,
         SHA512,
@@ -54,6 +53,9 @@ try:
         PublicFormat,
         load_pem_public_key,
     )
+
+    from securesystemslib.signer._crypto_utils import get_hash_algorithm
+
 except ImportError:
     CRYPTO_IMPORT_ERROR = "'pyca/cryptography' library required"
 
@@ -309,21 +311,6 @@ class SSlibKey(Key):
         return SSlibKey(keyid, keytype, scheme, keyval)
 
     @staticmethod
-    def _get_hash_algorithm(name: str) -> HashAlgorithm:
-        """Helper to return hash algorithm for name."""
-        algorithm: HashAlgorithm
-        if name == "sha224":
-            algorithm = SHA224()
-        if name == "sha256":
-            algorithm = SHA256()
-        if name == "sha384":
-            algorithm = SHA384()
-        if name == "sha512":
-            algorithm = SHA512()
-
-        return algorithm
-
-    @staticmethod
     def _get_rsa_padding(name: str, hash_algorithm: HashAlgorithm) -> AsymmetricPadding:
         """Helper to return rsa signature padding for name."""
         padding: AsymmetricPadding
@@ -372,7 +359,7 @@ class SSlibKey(Key):
                 key = cast(RSAPublicKey, self._crypto_key())
                 _validate_type(key, RSAPublicKey)
                 padding_name, hash_name = self.scheme.split("-")[1:]
-                hash_algorithm = self._get_hash_algorithm(hash_name)
+                hash_algorithm = get_hash_algorithm(hash_name)
                 padding = self._get_rsa_padding(padding_name, hash_algorithm)
                 key.verify(signature, data, padding, hash_algorithm)
 

--- a/securesystemslib/signer/_vault_signer.py
+++ b/securesystemslib/signer/_vault_signer.py
@@ -40,7 +40,7 @@ class VaultSigner(Signer):
 
     SCHEME = "hv"
 
-    def __init__(self, hv_key_name: str, public_key: Key, hv_key_version: int):
+    def __init__(self, hv_key_name: str, public_key: SSlibKey, hv_key_version: int):
         if VAULT_IMPORT_ERROR:
             raise UnsupportedLibraryError(VAULT_IMPORT_ERROR)
 
@@ -76,7 +76,7 @@ class VaultSigner(Signer):
         return Signature(self.public_key.keyid, sig)
 
     @property
-    def public_key(self) -> Key:
+    def public_key(self) -> SSlibKey:
         return self._public_key
 
     @classmethod
@@ -86,6 +86,9 @@ class VaultSigner(Signer):
         public_key: Key,
         secrets_handler: SecretsHandler | None = None,
     ) -> VaultSigner:
+        if not isinstance(public_key, SSlibKey):
+            raise ValueError(f"Expected SSlibKey for {priv_key_uri}")
+
         uri = parse.urlparse(priv_key_uri)
 
         if uri.scheme != cls.SCHEME:
@@ -96,7 +99,7 @@ class VaultSigner(Signer):
         return cls(name, public_key, int(version))
 
     @classmethod
-    def import_(cls, hv_key_name: str) -> tuple[str, Key]:
+    def import_(cls, hv_key_name: str) -> tuple[str, SSlibKey]:
         """Load key and signer details from HashiCorp Vault.
 
         If multiple keys exist in the vault under the passed name, only the


### PR DESCRIPTION
Fixes #594

This is an attempt to consolidate SSlibKey type and scheme parsing, to extract hash algo and padding names. It adds two new public methods on SSlibKey: (5fbeeaf17a07aede0b0bf2215e3fdf79874c93fc)
- `def get_hash_algorithm_name(self) -> str:`
- `def get_padding_name(self) -> str:`

and an internal helper to get pyca/cryptography hash objects from hash algo names: (166e457593d33286a9a200c62ee9077d5d4986c8)
- `def get_hash_algorithm(name: str) -> HashAlgorithm:`

Unfortunately, the diff is bigger than I wanted, and we don't really cut down on lines of code either. This is because there are two important prerequisites to use the new `SSlibKey` methods in the relevant signers
1. The public key attributes on the Signers need to be narrowed down from `Key` to `SSlibKey` type (3c6a34da1cc5ac4c98521c7cc123a104533d6978)
2. AzureSigner and GCPSigner relied on their custom scheme dissection helpers to validate the passed scheme. Since those signers, support only a subset of the schemes supported by SSlibKey, additional validation had to be added. (48c7523a2209491119ed5bf4be77703f89628812)

I think there's a value in parsing the schemes in one place only, and making scheme valdiation more explicit. But I am also fine, if others don't think it's worth such a big code change. 

