### PR TITLE
Fix AWS KMS Signer 4KB Message Size Limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ tests/htmlcov/*
 .DS_Store
 .python-version
 
+# PyCharm IDE
+.idea/
+
 # Sphinx documentation
 docs/_build/

--- a/securesystemslib/signer/_aws_signer.py
+++ b/securesystemslib/signer/_aws_signer.py
@@ -191,7 +191,7 @@ class AWSSigner(Signer):
     def sign(self, payload: bytes) -> Signature:
         """Sign the payload with the AWS KMS key
 
-        This method computes the hash of the payload locally and sends only the 
+        This method computes the hash of the payload locally and sends only the
         digest to AWS KMS for signing, removing the 4KB message size limitation
         that exists when using MessageType="RAW".
 


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

## Problem
AWS KMS Signer fails when signing messages larger than 4KB due to using `MessageType="RAW"`, which has a hard 4096-byte limit in the AWS KMS Sign API.

## Changes Made
Modified `AWSSigner.sign()` method in `_aws_signer.py`:
- Added local hash computation using `hashlib.new(hash_algorithm)`
- Changed `MessageType` from `"RAW"` to `"DIGEST"`
- Send only the computed digest to AWS KMS instead of the full payload

## Benefits
- Removes 4KB payload size limitation
- Aligns with GCP and Azure signer implementations
- Follows AWS KMS best practices for larger messages
- Maintains backward compatibility


Fixes #1025 
