### PR TITLE
Prepare release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## securesystemslib v1.3.1
+
+### Fixed
+* AWSSigner: Don't send payload to AWS for signing, send hash only (#1026)
+* Set Development status classifier to "production/stable" in Python
+  packaging (#1030)
+
+### Internals
+* Minor infrastructure changes (#1005, #1013)
+
 ## securesystemslib v1.3.0
 
 The `hash` module will be removed in the next major version. Consider using

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "ecdsa",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",

--- a/securesystemslib/__init__.py
+++ b/securesystemslib/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # Configure a basic 'securesystemslib' top-level logger with a StreamHandler
 # (print to console) and the WARNING log level (print messages of type


### PR DESCRIPTION
Not a lot here but it's been a few months since previous release, doesn't hurt to do a release.

* There is an open PR for dependency updates but that's for pinned deps: these are not used in the released package
* Looking at git log, I used way too much "squash and merge" this summer: will avoid that in future unless there's a good reason as it seems to make git archaeology more difficult