### PR TITLE
tests: Enable HSM tests on Mac

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -20,19 +20,19 @@ jobs:
           - python-version: "3.10"
             os: macos-latest
             toxenv: py
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: macos-latest
             toxenv: py
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: windows-latest
             toxenv: py
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: ubuntu-latest
             toxenv: purepy
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: ubuntu-latest
             toxenv: py-no-gpg
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: ubuntu-latest
             toxenv: py-test-gpg-fails
           - python-version: "3.10"
@@ -69,11 +69,8 @@ jobs:
             echo "PYKCS11LIB=/usr/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
 
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            ## disabled due to https://github.com/secure-systems-lab/securesystemslib/issues/1015
-            unset PYKCS11LIB
-            echo "Skipping HSM tests on MacOS"
-            # brew install softhsm
-            # echo "PYKCS11LIB=$(brew --prefix softhsm)/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
+            brew install softhsm
+            echo "PYKCS11LIB=$(brew --prefix softhsm)/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
           elif [ "$RUNNER_OS" == "Windows" ]; then
             echo "Skipping HSM tests on Windows"
             # see https://github.com/secure-systems-lab/securesystemslib/issues/520


### PR DESCRIPTION
Fixes #1015.

I disabled mac os HSM tests a while ago. 
* It looks like new softhsm2 release has fixed things so we can re-enable
* Also bump some tests to 3.14 as the newest python
