### PR TITLE
Fix redefined loop variable in Envelope.from_dict

### DIFF
--- a/securesystemslib/dsse.py
+++ b/securesystemslib/dsse.py
@@ -68,13 +68,10 @@ class Envelope:
         signatures = {}
         for signature in data["signatures"]:
             signature["sig"] = b64dec(signature["sig"]).hex()
-            signature = Signature.from_dict(signature)  # noqa: PLW2901
-            if signature.keyid in signatures:
-                raise ValueError(
-                    f"Multiple signatures found for keyid {signature.keyid}"
-                )
-            signatures[signature.keyid] = signature
-
+            sig = Signature.from_dict(signature)
+            if sig.keyid in signatures:
+                raise ValueError(f"Multiple signatures found for keyid {sig.keyid}")
+            signatures[sig.keyid] = sig
         return cls(payload, payload_type, signatures)
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
Fixes #838 (partially - addresses the PLW2901 suppression in dsse.py)

Renames the loop variable `signature` to `sig` after deserialisation in `Envelope.from_dict`, removing the need for the `# noqa: PLW2901` suppression. The remaining suppressions in the `_gpg` subpackage are intentional per maintainer comment in #838.

Verified: `tox -e lint,py,purepy,py-no-gpg` all pass.