### PR TITLE
tests: Make vault tests more robust

### DIFF
--- a/tests/scripts/init-vault.sh
+++ b/tests/scripts/init-vault.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 vault server -dev -dev-root-token-id="${VAULT_TOKEN}" &
 

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ allowlist_externals =
 setenv =
     AWS_ACCESS_KEY_ID = test
     AWS_SECRET_ACCESS_KEY = test
-    AWS_ENDPOINT_URL = http://localhost:4566/
+    AWS_ENDPOINT_URL = http://127.0.0.1:4566/
     AWS_DEFAULT_REGION = us-east-1
 
 commands_pre =
@@ -127,7 +127,7 @@ allowlist_externals =
     bash
 
 setenv =
-    VAULT_ADDR = http://localhost:8200
+    VAULT_ADDR = http://127.0.0.1:8200
     VAULT_TOKEN = test-root-token
 
 commands_pre =


### PR DESCRIPTION
AI suggestions to improve test reliability:
* Avoid potential IPv6 issues with URLs: Use 127.0.0.1 instead of localhost
* Make sure init-vault.sh fails early and loudly

Maybe helps with #1136 