### PR TITLE
Make Key, Signature and Envelope actually hashable

### DIFF
--- a/securesystemslib/_internal/utils.py
+++ b/securesystemslib/_internal/utils.py
@@ -2,6 +2,29 @@
 
 import base64
 import binascii
+from typing import Any
+
+
+def make_hashable(value: Any) -> Any:
+    """Return a hashable equivalent of a dict or list, for use in __hash__
+
+    Dicts become frozensets of their items and lists become tuples, both
+    recursively. Values that are already hashable are returned as they are, so
+    the result compares equal whenever the input does, which is what __hash__
+    needs.
+
+    Arguments:
+        value: Value to convert
+
+    Returns:
+        A hashable equivalent of the value
+    """
+
+    if isinstance(value, dict):
+        return frozenset((k, make_hashable(v)) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return tuple(make_hashable(v) for v in value)
+    return value
 
 
 def b64enc(data: bytes) -> str:

--- a/securesystemslib/dsse.py
+++ b/securesystemslib/dsse.py
@@ -43,7 +43,13 @@ class Envelope:
         )
 
     def __hash__(self) -> int:
-        return hash((self.payload, self.payload_type, self.signatures))
+        return hash(
+            (
+                self.payload,
+                self.payload_type,
+                frozenset(self.signatures.items()),
+            )
+        )
 
     @classmethod
     def from_dict(cls, data: dict) -> Envelope:

--- a/securesystemslib/dsse.py
+++ b/securesystemslib/dsse.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from securesystemslib import exceptions
-from securesystemslib._internal.utils import b64dec, b64enc
+from securesystemslib._internal.utils import b64dec, b64enc, make_hashable
 from securesystemslib.signer import Key, Signature, Signer
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class Envelope:
             (
                 self.payload,
                 self.payload_type,
-                frozenset(self.signatures.items()),
+                make_hashable(self.signatures),
             )
         )
 

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, cast
@@ -133,8 +134,8 @@ class Key(metaclass=ABCMeta):
                 self.keyid,
                 self.keytype,
                 self.scheme,
-                self.keyval,
-                self.unrecognized_fields,
+                json.dumps(self.keyval, sort_keys=True),
+                json.dumps(self.unrecognized_fields, sort_keys=True),
             )
         )
 

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, cast
 
+from securesystemslib._internal.utils import make_hashable
 from securesystemslib._vendor.ed25519.ed25519 import (
     SignatureMismatch,
     checkvalid,
@@ -161,8 +161,8 @@ class Key(metaclass=ABCMeta):
                 self.keyid,
                 self.keytype,
                 self.scheme,
-                json.dumps(self.keyval, sort_keys=True),
-                json.dumps(self.unrecognized_fields, sort_keys=True),
+                make_hashable(self.keyval),
+                make_hashable(self.unrecognized_fields),
             )
         )
 

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from abc import ABCMeta, abstractmethod
 from typing import Any, cast
@@ -160,8 +161,8 @@ class Key(metaclass=ABCMeta):
                 self.keyid,
                 self.keytype,
                 self.scheme,
-                self.keyval,
-                self.unrecognized_fields,
+                json.dumps(self.keyval, sort_keys=True),
+                json.dumps(self.unrecognized_fields, sort_keys=True),
             )
         )
 

--- a/securesystemslib/signer/_signature.py
+++ b/securesystemslib/signer/_signature.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -56,7 +57,13 @@ class Signature:
         )
 
     def __hash__(self) -> int:
-        return hash((self.keyid, self.signature, self.unrecognized_fields))
+        return hash(
+            (
+                self.keyid,
+                self.signature,
+                json.dumps(self.unrecognized_fields, sort_keys=True),
+            )
+        )
 
     @classmethod
     def from_dict(cls, signature_dict: dict) -> Signature:

--- a/securesystemslib/signer/_signature.py
+++ b/securesystemslib/signer/_signature.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
+
+from securesystemslib._internal.utils import make_hashable
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,7 @@ class Signature:
             (
                 self.keyid,
                 self.signature,
-                json.dumps(self.unrecognized_fields, sort_keys=True),
+                make_hashable(self.unrecognized_fields),
             )
         )
 

--- a/tests/test_dsse.py
+++ b/tests/test_dsse.py
@@ -97,6 +97,15 @@ class TestEnvelope(unittest.TestCase):
         envelope_obj_2.signatures = [sig_obg]
         self.assertNotEqual(envelope_obj, envelope_obj_2)
 
+    def test_envelope_hash(self):
+        """Envelopes should be hashable despite the signatures dict."""
+        envelope_obj = Envelope.from_dict(copy.deepcopy(self.envelope_dict))
+        envelope_obj_2 = copy.deepcopy(envelope_obj)
+
+        # Equal envelopes hash equally and collapse in a set.
+        self.assertEqual(hash(envelope_obj), hash(envelope_obj_2))
+        self.assertEqual(len({envelope_obj, envelope_obj_2}), 1)
+
     def test_preauthencoding(self):
         """Test envelope Pre-Auth-Encoding."""
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -58,6 +58,21 @@ class TestKey(unittest.TestCase):
             self.assertIsInstance(key, key_impl)
             self.assertDictEqual(keydict, key.to_dict())
 
+    def test_key_hash(self):
+        """Keys should be hashable, even with dict keyval and extra fields."""
+        keydict = {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "extra": "somedata",
+            "keyval": {"public": "pubkeyval", "foo": "bar"},
+        }
+        key = Key.from_dict("aa", copy.deepcopy(keydict))
+        key_2 = Key.from_dict("aa", copy.deepcopy(keydict))
+
+        # Equal keys hash equally and collapse in a set.
+        self.assertEqual(hash(key), hash(key_2))
+        self.assertEqual(len({key, key_2}), 1)
+
     def test_sslib_key_from_dict_invalid(self):
         """Test from_dict for invalid data"""
         invalid_dicts = [
@@ -435,6 +450,20 @@ class TestSigner(unittest.TestCase):
         # Assert that making sig_obj_2 None will make the objects not equal.
         sig_obj_2 = None
         self.assertNotEqual(sig_obj, sig_obj_2)
+
+    def test_signature_hash(self):
+        """Signatures should be hashable, even with unrecognized fields."""
+        signature_dict = {
+            "sig": "30460221009342e4566528fcecf6a7a5d53ebacdb1df151e242f55f8775883469cb01dbc6602210086b426cc826709acfa2c3f9214610cb0a832db94bbd266fd7c5939a48064a851",
+            "keyid": "11fa391a0ed7a447cbfeb4b2667e286fc248f64d5e6d0eeed2e5e23f97f9f714",
+            "extra": "unrecognized",
+        }
+        sig_obj = Signature.from_dict(copy.deepcopy(signature_dict))
+        sig_obj_2 = Signature.from_dict(copy.deepcopy(signature_dict))
+
+        # Equal signatures hash equally and collapse in a set.
+        self.assertEqual(hash(sig_obj), hash(sig_obj_2))
+        self.assertEqual(len({sig_obj, sig_obj_2}), 1)
 
 
 @unittest.skipIf(not have_gpg(), "gpg not found")

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -484,6 +484,31 @@ class TestSigner(unittest.TestCase):
         self.assertEqual(hash(sig_obj), hash(sig_obj_2))
         self.assertEqual(len({sig_obj, sig_obj_2}), 1)
 
+    def test_signature_hash_equal_for_equal_field_values(self):
+        """Values that compare equal must hash equally.
+
+        Python treats 1, 1.0 and True as equal, so unrecognized fields that
+        differ only in those types make two equal Signatures, which have to
+        share a hash.
+        """
+        for first, second in [
+            ({"extra": 1}, {"extra": True}),
+            ({"extra": 1}, {"extra": 1.0}),
+            ({"extra": [{"nested": 1}]}, {"extra": [{"nested": True}]}),
+        ]:
+            with self.subTest(first=first, second=second):
+                sig = Signature("aa", "bb", first)
+                sig_2 = Signature("aa", "bb", second)
+
+                self.assertEqual(sig, sig_2)
+                self.assertEqual(hash(sig), hash(sig_2))
+
+    def test_signature_hash_non_json_field_value(self):
+        """Unrecognized field values need not be JSON types."""
+        sig = Signature("aa", "bb", {"extra": b"binary"})
+
+        self.assertIsInstance(hash(sig), int)
+
 
 @unittest.skipIf(not have_gpg(), "gpg not found")
 class TestGPGRSA(unittest.TestCase):

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -77,6 +77,21 @@ class TestKey(unittest.TestCase):
         finally:
             del KEY_FOR_TYPE_AND_SCHEME[("ml-dsa", "ml-dsa-65/1")]
 
+    def test_key_hash(self):
+        """Keys should be hashable, even with dict keyval and extra fields."""
+        keydict = {
+            "keytype": "ed25519",
+            "scheme": "ed25519",
+            "extra": "somedata",
+            "keyval": {"public": "pubkeyval", "foo": "bar"},
+        }
+        key = Key.from_dict("aa", copy.deepcopy(keydict))
+        key_2 = Key.from_dict("aa", copy.deepcopy(keydict))
+
+        # Equal keys hash equally and collapse in a set.
+        self.assertEqual(hash(key), hash(key_2))
+        self.assertEqual(len({key, key_2}), 1)
+
     def test_sslib_key_from_dict_invalid(self):
         """Test from_dict for invalid data"""
         invalid_dicts = [
@@ -454,6 +469,20 @@ class TestSigner(unittest.TestCase):
         # Assert that making sig_obj_2 None will make the objects not equal.
         sig_obj_2 = None
         self.assertNotEqual(sig_obj, sig_obj_2)
+
+    def test_signature_hash(self):
+        """Signatures should be hashable, even with unrecognized fields."""
+        signature_dict = {
+            "sig": "30460221009342e4566528fcecf6a7a5d53ebacdb1df151e242f55f8775883469cb01dbc6602210086b426cc826709acfa2c3f9214610cb0a832db94bbd266fd7c5939a48064a851",
+            "keyid": "11fa391a0ed7a447cbfeb4b2667e286fc248f64d5e6d0eeed2e5e23f97f9f714",
+            "extra": "unrecognized",
+        }
+        sig_obj = Signature.from_dict(copy.deepcopy(signature_dict))
+        sig_obj_2 = Signature.from_dict(copy.deepcopy(signature_dict))
+
+        # Equal signatures hash equally and collapse in a set.
+        self.assertEqual(hash(sig_obj), hash(sig_obj_2))
+        self.assertEqual(len({sig_obj, sig_obj_2}), 1)
 
 
 @unittest.skipIf(not have_gpg(), "gpg not found")


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

While reading through the signer code I noticed that the `__hash__` methods added in "lint: Make ruff happy" (d87eb73) never actually work. They drop the objects dict fields (`Key.keyval`/`unrecognized_fields`, `Signature.unrecognized_fields`, `Envelope.signatures`) straight into the hashed tuple, so any `hash()` call raises `TypeError: unhashable type: 'dict'`. That means Key, Signature and Envelope still cant go in a set or be used as dict keys, which is the thing defining `__hash__` was meant to enable.

The fix adds `make_hashable` to `securesystemslib/_internal/utils.py`, which recursively converts dicts to frozensets of their items and lists to tuples, and uses it on the dict fields of all three classes. Converting structurally rather than serializing means the result inherits Python's own equality for the leaf values, so objects that compare equal still hash equal.

An earlier revision of this PR used `json.dumps(..., sort_keys=True)` instead. That was wrong: `1`, `1.0` and `True` compare equal in Python but serialize differently, so equal objects came out with different hashes, and `json.dumps` raises on a field value that is not JSON serializable. Thanks to @jku for catching it.

Tests cover all three types plus the equal-values-hash-equally cases and a non-JSON field value; they fail on main with the TypeError and pass with the change, and the rest of test_signer.py / test_dsse.py stay green.

No linked issue, happy to open one if you would prefer to track it separately.