### PR TITLE
tests: make Vault process lifecycle explicit

### DIFF
--- a/tests/scripts/init-vault.sh
+++ b/tests/scripts/init-vault.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-vault server -dev -dev-root-token-id="${VAULT_TOKEN}" &
+VAULT_RUNTIME_DIR="${TOX_ENV_DIR:-${TMPDIR:-/tmp}}"
+VAULT_LOG="${VAULT_RUNTIME_DIR}/vault.log"
+VAULT_PID_FILE="${VAULT_RUNTIME_DIR}/vault.pid"
 
-until vault status
+nohup vault server -dev -dev-root-token-id="${VAULT_TOKEN}" >"${VAULT_LOG}" 2>&1 </dev/null &
+VAULT_PID=$!
+echo "${VAULT_PID}" >"${VAULT_PID_FILE}"
+
+until vault status >/dev/null 2>&1
 do
+    if ! kill -0 "${VAULT_PID}" 2>/dev/null; then
+        cat "${VAULT_LOG}"
+        exit 1
+    fi
     sleep 0.1
 done
 

--- a/tests/scripts/stop-vault.sh
+++ b/tests/scripts/stop-vault.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
+set -e
 
-pkill -f "vault server -dev"
+VAULT_RUNTIME_DIR="${TOX_ENV_DIR:-${TMPDIR:-/tmp}}"
+VAULT_PID_FILE="${VAULT_RUNTIME_DIR}/vault.pid"
+
+if [[ -f "${VAULT_PID_FILE}" ]]; then
+    VAULT_PID=$(cat "${VAULT_PID_FILE}")
+    kill "${VAULT_PID}" 2>/dev/null || true
+    rm -f "${VAULT_PID_FILE}"
+fi


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

Keep the dev Vault server independent from the shell that starts the test environment and track its PID explicitly.

`init-vault.sh` now starts Vault with `nohup`, redirects its output to the tox environment, records the server PID, and fails with the Vault log if the process exits before becoming ready.

`stop-vault.sh` stops that exact process instead of matching every `vault server -dev` process with `pkill`.

This complements #1154: that change removed the localhost/IPv6 ambiguity and made initialization fail early, while this change makes ownership of the background Vault process explicit for the lifetime of the `local-vault` tox run.

Validation: the `Run HashiCorp Vault tests` workflow passed on the fork with the cleaned branch, including the `local-vault` test job.

Fixes #1136