### PR TITLE
CryptoSigner: support key generation for nistp384 and nistp521 ecdsa schemes

### DIFF
--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -1,13 +1,18 @@
 """Signer implementation for pyca/cryptography signing."""
 
+from __future__ import annotations
+
 import logging
 import os
 from dataclasses import astuple, dataclass
+from typing import cast
 from urllib import parse
 
 from securesystemslib.exceptions import UnsupportedLibraryError
 from securesystemslib.signer._constants import (
     ECDSA_SHA2_NISTP256,
+    ECDSA_SHA2_NISTP384,
+    ECDSA_SHA2_NISTP521,
     ED25519,
     KEY_TYPE_ECDSA,
     KEY_TYPE_ED25519,
@@ -35,6 +40,9 @@ try:
     from cryptography.hazmat.primitives.asymmetric.ec import (
         ECDSA,
         SECP256R1,
+        SECP384R1,
+        SECP521R1,
+        EllipticCurve,
         EllipticCurvePrivateKey,
     )
     from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -63,6 +71,8 @@ try:
     from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
     from cryptography.hazmat.primitives.hashes import (
         SHA256,
+        SHA384,
+        SHA512,
         HashAlgorithm,
     )
     from cryptography.hazmat.primitives.serialization import (
@@ -82,13 +92,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _RSASignArgs:
-    padding: "AsymmetricPadding"
-    hash_algo: "HashAlgorithm"
+    padding: AsymmetricPadding
+    hash_algo: HashAlgorithm
 
 
 @dataclass
 class _ECDSASignArgs:
-    sig_algo: "ECDSA"
+    sig_algo: ECDSA
 
 
 @dataclass
@@ -96,12 +106,34 @@ class _NoSignArgs:
     pass
 
 
-# for backwards compat: use when spec-deprecated keytype ecdsa-sha2-nistp256
-# should be accepted in addition to "ecdsa"
-_ECDSA_KEYTYPES = [KEY_TYPE_ECDSA, ECDSA_SHA2_NISTP256]
+# keep in sync with _get_ecdsa_curve_and_hash() below
+_ECDSA_SCHEMES = [
+    ECDSA_SHA2_NISTP256,
+    ECDSA_SHA2_NISTP384,
+    ECDSA_SHA2_NISTP521,
+]
 
 
-def _get_rsa_padding(name: str, hash_algorithm: "HashAlgorithm") -> "AsymmetricPadding":
+def _get_ecdsa_curve_and_hash(
+    scheme: str,
+) -> tuple[type[EllipticCurve], HashAlgorithm]:
+    """Helper to return curve and hash algorithm for an ecdsa scheme.
+
+    An ecdsa scheme fixes both, and the pairs must agree with the ones
+    SSlibKey._verify() uses, or signatures will not verify.
+    """
+    # built here and not at module scope, so that importing this module
+    # still works when pyca/cryptography is not installed
+    curves_and_hashes: dict[str, tuple[type[EllipticCurve], HashAlgorithm]] = {
+        ECDSA_SHA2_NISTP256: (SECP256R1, SHA256()),
+        ECDSA_SHA2_NISTP384: (SECP384R1, SHA384()),
+        ECDSA_SHA2_NISTP521: (SECP521R1, SHA512()),
+    }
+
+    return curves_and_hashes[scheme]
+
+
+def _get_rsa_padding(name: str, hash_algorithm: HashAlgorithm) -> AsymmetricPadding:
     """Helper to return rsa signature padding for name."""
     padding: AsymmetricPadding
     if name == "pss":
@@ -139,7 +171,7 @@ class CryptoSigner(Signer):
 
     def __init__(
         self,
-        private_key: "PrivateKeyTypes",
+        private_key: PrivateKeyTypes,
         public_key: SSlibKey | None = None,
     ):
         def assert_type(
@@ -177,12 +209,22 @@ class CryptoSigner(Signer):
 
             self._sign_args = _RSASignArgs(padding, hash_algo)
 
+        # for backwards compat the spec-deprecated ecdsa keytypes (which are
+        # named after the scheme) are accepted in addition to "ecdsa"
         elif (
-            public_key.keytype in _ECDSA_KEYTYPES
-            and public_key.scheme == ECDSA_SHA2_NISTP256
+            public_key.keytype in [KEY_TYPE_ECDSA, public_key.scheme]
+            and public_key.scheme in _ECDSA_SCHEMES
         ):
             assert_type(KEY_TYPE_ECDSA, private_key, EllipticCurvePrivateKey)
-            self._sign_args = _ECDSASignArgs(ECDSA(SHA256()))
+            ec_key = cast(EllipticCurvePrivateKey, private_key)
+
+            curve, hash_algo = _get_ecdsa_curve_and_hash(public_key.scheme)
+            if not isinstance(ec_key.curve, curve):
+                raise ValueError(
+                    f"bad curve {ec_key.curve.name} for {public_key.scheme}"
+                )
+
+            self._sign_args = _ECDSASignArgs(ECDSA(hash_algo))
 
         elif public_key.keytype == KEY_TYPE_ED25519 and public_key.scheme == ED25519:
             assert_type(KEY_TYPE_ED25519, private_key, Ed25519PrivateKey)
@@ -230,7 +272,7 @@ class CryptoSigner(Signer):
         priv_key_uri: str,
         public_key: Key,
         secrets_handler: SecretsHandler | None = None,
-    ) -> "CryptoSigner":
+    ) -> CryptoSigner:
         """Constructor for Signer to call
 
         Please refer to Signer.from_priv_key_uri() documentation.
@@ -283,7 +325,7 @@ class CryptoSigner(Signer):
     @staticmethod
     def generate_ed25519(
         keyid: str | None = None,
-    ) -> "CryptoSigner":
+    ) -> CryptoSigner:
         """Generate new key pair as "ed25519" signer.
 
         Args:
@@ -307,7 +349,7 @@ class CryptoSigner(Signer):
         keyid: str | None = None,
         scheme: str | None = RSASSA_PSS_SHA256,
         size: int = 3072,
-    ) -> "CryptoSigner":
+    ) -> CryptoSigner:
         """Generate new key pair as rsa signer.
 
         Args:
@@ -334,14 +376,18 @@ class CryptoSigner(Signer):
     @staticmethod
     def generate_ecdsa(
         keyid: str | None = None,
-    ) -> "CryptoSigner":
-        """Generate new key pair as "ecdsa-sha2-nistp256" signer.
+        scheme: str | None = None,
+    ) -> CryptoSigner:
+        """Generate new key pair for an ecdsa signer.
 
         Args:
             keyid: Key identifier. If not passed, a default keyid is computed.
+            scheme: A valid ecdsa scheme, which also selects the curve. If not
+                passed, "ecdsa-sha2-nistp256" is used.
 
         Raises:
             UnsupportedLibraryError: pyca/cryptography not installed
+            ValueError: Invalid scheme
 
         Returns:
             CryptoSigner
@@ -349,17 +395,20 @@ class CryptoSigner(Signer):
         if CRYPTO_IMPORT_ERROR:
             raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
 
-        private_key = generate_ec_private_key(SECP256R1())
-        public_key = SSlibKey.from_crypto(
-            private_key.public_key(), keyid, ECDSA_SHA2_NISTP256
-        )
+        scheme = ECDSA_SHA2_NISTP256 if scheme is None else scheme
+        if scheme not in _ECDSA_SCHEMES:
+            raise ValueError(f"Invalid scheme for ecdsa: {scheme}")
+
+        curve, _ = _get_ecdsa_curve_and_hash(scheme)
+        private_key = generate_ec_private_key(curve())
+        public_key = SSlibKey.from_crypto(private_key.public_key(), keyid, scheme)
         return CryptoSigner(private_key, public_key)
 
     @staticmethod
     def generate_mldsa(
         keyid: str | None = None,
         scheme: str | None = None,
-    ) -> "CryptoSigner":
+    ) -> CryptoSigner:
         """Generate new key pair for a ML-DSA signer.
 
         Args:

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -770,6 +770,8 @@ class TestCryptoSigner(unittest.TestCase):
                 ],
             ),
             ("ecdsa", "ecdsa", ["ecdsa-sha2-nistp256"]),
+            ("ecdsa_secp384r1", "ecdsa", ["ecdsa-sha2-nistp384"]),
+            ("ecdsa_secp521r1", "ecdsa", ["ecdsa-sha2-nistp521"]),
             ("ed25519", "ed25519", ["ed25519"]),
             ("mldsa44", "ml-dsa", ["ml-dsa-44/1"]),
             ("mldsa65", "ml-dsa", ["ml-dsa-65/1"]),
@@ -871,6 +873,36 @@ class TestCryptoSigner(unittest.TestCase):
             self.assertIsNone(signer.public_key.verify_signature(sig, b"DATA"))
             with self.assertRaises(UnverifiedSignatureError):
                 signer.public_key.verify_signature(sig, b"NOT DATA")
+
+    def test_generate_ecdsa_scheme(self):
+        """Test generate ecdsa signer for each ecdsa scheme"""
+        for scheme in [
+            "ecdsa-sha2-nistp256",
+            "ecdsa-sha2-nistp384",
+            "ecdsa-sha2-nistp521",
+        ]:
+            signer = CryptoSigner.generate_ecdsa(scheme=scheme)
+            self.assertEqual(signer.public_key.keytype, "ecdsa")
+            self.assertEqual(signer.public_key.scheme, scheme)
+
+            sig = signer.sign(b"DATA")
+            self.assertIsNone(signer.public_key.verify_signature(sig, b"DATA"))
+
+        with self.assertRaises(ValueError):
+            CryptoSigner.generate_ecdsa(scheme="ecdsa-sha2-nistp192")
+
+    def test_init_ecdsa_curve_mismatch(self):
+        """Test that an ecdsa private key must match the scheme's curve.
+
+        Signing with a mismatched curve produces signatures that can never
+        be verified, because SSlibKey._verify() validates the curve.
+        """
+        signer = CryptoSigner.generate_ecdsa(scheme="ecdsa-sha2-nistp384")
+        for scheme in ["ecdsa-sha2-nistp256", "ecdsa-sha2-nistp521"]:
+            public_key = copy.copy(signer.public_key)
+            public_key.scheme = scheme
+            with self.assertRaises(ValueError):
+                CryptoSigner(signer._private_key, public_key)
 
     def test_private_bytes(self):
         """Test private_bytes -> from_priv_key_uri"""


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

`SSlibKey._verify()` already handles all three NIST ecdsa schemes, `SSlibKey.from_crypto()` already derives `ecdsa-sha2-nistp384` and `ecdsa-sha2-nistp521` from the curve, and both combinations are registered in `signer/__init__.py`. `CryptoSigner` was the only piece that refused them, so a key that `from_crypto()` produced could not be used to sign:

```python
priv = generate_private_key(SECP384R1())
pub = SSlibKey.from_crypto(priv.public_key())   # scheme: ecdsa-sha2-nistp384
CryptoSigner(priv, pub)
# ValueError: unsupported public key ecdsa/ecdsa-sha2-nistp384
```

Both bullets of the issue are addressed, in one commit but two independent hunks:

1. `CryptoSigner()` accepts `ecdsa-sha2-nistp384` and `ecdsa-sha2-nistp521`, using the curve and hash that `SSlibKey._verify()` uses for each.
2. `generate_ecdsa()` takes an optional `scheme`, defaulting to `ecdsa-sha2-nistp256` so existing calls are unaffected. This follows `generate_rsa()` and `generate_mldsa()`, which already take a `scheme`.

Happy to drop the second one if you would rather keep this to the part you called out as the real problem.

### A related bug this closes

@lukpueh's point on the issue, that the scheme fixes the key type rather than being freely combinable, turns out to be load-bearing here. `assert_type()` only checked for `EllipticCurvePrivateKey`, not for the curve, so on current main this is accepted:

```python
p384 = generate_private_key(SECP384R1())
k = SSlibKey.from_crypto(p384.public_key())
signer = CryptoSigner(p384, SSlibKey(k.keyid, "ecdsa", "ecdsa-sha2-nistp256", k.keyval))
sig = signer.sign(b"data")   # signs happily
```

The signature can never verify, because `SSlibKey._verify()` calls `_validate_curve()`. Extending the scheme check without also checking the curve would have widened that from one mismatched pair to six, so the constructor now validates the curve and raises `bad curve secp384r1 for ecdsa-sha2-nistp256`, matching the wording `_verify()` already uses.

For the same reason the deprecated keytype check is now `keytype in ["ecdsa", scheme]` rather than a fixed list. That mirrors `_verify()` exactly: it accepts a legacy keytype only when it equals the scheme, so `keytype=ecdsa-sha2-nistp256` with `scheme=ecdsa-sha2-nistp521` stays rejected.

### Notes on the implementation

The scheme to curve/hash mapping is built inside `_get_ecdsa_curve_and_hash()` rather than at module scope on purpose. Those symbols come from the guarded `try:` import block, so a module-level dict would raise `NameError` on import and break the `purepy` environment. I checked that case specifically.

I did not add a `CHANGELOG.md` entry, since there is no `Unreleased` section and the entries carry PR numbers, so it looks like you write those at release time. Glad to add one if you want it in the PR.

### Tests

`tests/data/pems/` already had `ecdsa_secp384r1_private.pem` and `ecdsa_secp521r1_private.pem`, so the two curves are added to the existing `key_info` table in `TestCryptoSigner`, which extends `test_init` and `test_sign` to cover them. Two new tests cover the `scheme` argument and the curve mismatch.

Reverting only `_crypto_signer.py` and keeping the tests fails 4 tests in `TestCryptoSigner`, including both new ones. With the change, `tests/` goes from 78 passed to 80 passed against the same single pre-existing failure in my environment (`TestSphincs::test_sphincs`, no pyspx installed; `test_hsm_signer.py` also fails to collect here, both identically on a clean checkout). `ruff format`, `ruff check` and `mypy securesystemslib` are clean, mypy back to the same 6 pre-existing sigstore stub errors as on main. `tests.check_public_interfaces` passes in a venv with no cryptography installed.

I used an AI assistant while working on this. The reproduction, the curve mismatch finding and the decision to flag the `generate_ecdsa()` hunk as separable are mine, and I ran every check above myself.

Fixes #1153
