### PR TITLE
TKeySigner: raise KeyMismatchError for mismatched keys

### DIFF
--- a/securesystemslib/exceptions.py
+++ b/securesystemslib/exceptions.py
@@ -34,6 +34,10 @@ class UnsupportedLibraryError(Error):
     """Indicate that a supported library could not be located or imported."""
 
 
+class KeyMismatchError(ValueError):
+    """Indicate that a private key does not match the expected public key."""
+
+
 class StorageError(Error):
     """Indicate an error occured during interaction with an abstracted storage
     backend."""

--- a/securesystemslib/signer/_tkey_signer.py
+++ b/securesystemslib/signer/_tkey_signer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from urllib import parse
 
-from securesystemslib.exceptions import UnsupportedLibraryError
+from securesystemslib.exceptions import KeyMismatchError, UnsupportedLibraryError
 from securesystemslib.signer._constants import MLDSA_44_1
 from securesystemslib.signer._key import Key, SSlibKey
 from securesystemslib.signer._signature import Signature
@@ -70,7 +70,7 @@ class TKeySigner(Signer):
             raise ValueError(f"unsupported scheme {public_key.scheme}")
 
         if key.keyval != self.public_key.keyval:
-            raise RuntimeError(
+            raise KeyMismatchError(
                 "TKey public key does not match: This could mean incorrect Passphrase."
             )
 

--- a/tests/test_tkey_signer.py
+++ b/tests/test_tkey_signer.py
@@ -2,7 +2,7 @@ import hashlib
 import unittest
 from unittest.mock import MagicMock, patch
 
-from securesystemslib.exceptions import UnsupportedLibraryError
+from securesystemslib.exceptions import KeyMismatchError, UnsupportedLibraryError
 from securesystemslib.signer import SSlibKey, TKeySigner
 
 
@@ -69,7 +69,7 @@ class TestTKeySigner(unittest.TestCase):
 
         self.mock_public_key.keyval = "expected_keyval"
 
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaises(KeyMismatchError) as ctx:
             TKeySigner(
                 device_path="/dev/ttyACM0",
                 public_key=self.mock_public_key,


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Add a dedicated `KeyMismatchError` for TKey public-key mismatches. The exception subclasses `ValueError`, so callers can catch the specific mismatch without losing the conventional invalid-value behavior.

The existing mismatch test now verifies the specific exception type.

Testing:
- `python -m unittest tests.test_tkey_signer`
- `ruff format --check securesystemslib tests`
- `ruff check securesystemslib tests`
- `mypy securesystemslib`
- core test suite: 98 passed, 41 skipped

Fixes #1189