### PR TITLE
CryptoSigner: reject mismatched key pairs

### DIFF
--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -8,7 +8,7 @@ from dataclasses import astuple, dataclass
 from typing import cast
 from urllib import parse
 
-from securesystemslib.exceptions import UnsupportedLibraryError
+from securesystemslib.exceptions import KeyMismatchError, UnsupportedLibraryError
 from securesystemslib.signer._constants import (
     ECDSA_SHA2_NISTP256,
     ECDSA_SHA2_NISTP384,
@@ -244,6 +244,10 @@ class CryptoSigner(Signer):
                 f"unsupported public key {public_key.keytype}/{public_key.scheme}"
             )
 
+        derived_public_key = SSlibKey.from_crypto(private_key.public_key())
+        if derived_public_key.keyval != public_key.keyval:
+            raise KeyMismatchError("CryptoSigner private key does not match public key")
+
         self._private_key = private_key
         self._public_key = public_key
 
@@ -287,6 +291,7 @@ class CryptoSigner(Signer):
 
         Raises:
             UnsupportedLibraryError: pyca/cryptography not installed.
+            KeyMismatchError: Private key does not match public key.
             OSError: File cannot be read.
             ValueError: Invalid passed arguments.
             cryptography.exceptions.UnsupportedAlgorithm: pyca/cryptography

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -16,7 +16,11 @@ from cryptography.hazmat.primitives.serialization import (
 )
 
 from securesystemslib._gpg.constants import have_gpg
-from securesystemslib.exceptions import FormatError, UnverifiedSignatureError
+from securesystemslib.exceptions import (
+    FormatError,
+    KeyMismatchError,
+    UnverifiedSignatureError,
+)
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
     SIGNER_FOR_URI_SCHEME,
@@ -775,6 +779,24 @@ class TestCryptoSigner(unittest.TestCase):
             # Re-init with passed public key
             signer2 = CryptoSigner(private_key, signer.public_key)
             self.assertEqual(keytype, signer2.public_key.keytype)
+
+    def test_init_key_mismatch(self):
+        """Test that private and public keys must belong to the same key pair."""
+        generators = [
+            CryptoSigner.generate_rsa,
+            CryptoSigner.generate_ecdsa,
+            CryptoSigner.generate_ed25519,
+            CryptoSigner.generate_mldsa,
+        ]
+        for generate in generators:
+            with self.subTest(generator=generate.__name__):
+                signer = generate()
+                other_signer = generate()
+                with self.assertRaisesRegex(
+                    KeyMismatchError,
+                    "CryptoSigner private key does not match public key",
+                ):
+                    CryptoSigner(signer._private_key, other_signer.public_key)
 
     def test_sign(self):
         for name, private_key in self.keys.items():


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Validate that a `CryptoSigner` private key matches the supplied `SSlibKey` before the signer becomes usable. A mismatch now raises `KeyMismatchError`, matching the existing `TKeySigner` behavior.

Regression coverage exercises RSA, ECDSA, Ed25519, and ML-DSA. HSM and cloud-KMS signers remain outside this focused change because checking those keys can require device access or network requests.

Tests:

- `python -m pytest tests/test_signer.py tests/test_dsse.py -q`
- `python -m ruff format --check securesystemslib tests`
- `python -m ruff check securesystemslib tests`

Addresses the `CryptoSigner` portion of #1192.
