### PR TITLE
Tweak cryptosigner key check

### DIFF
--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -244,8 +244,7 @@ class CryptoSigner(Signer):
                 f"unsupported public key {public_key.keytype}/{public_key.scheme}"
             )
 
-        derived_public_key = SSlibKey.from_crypto(private_key.public_key())
-        if derived_public_key.keyval != public_key.keyval:
+        if public_key._crypto_key() != private_key.public_key():
             raise KeyMismatchError("CryptoSigner private key does not match public key")
 
         self._private_key = private_key

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -314,6 +314,10 @@ class SSlibKey(Key):
 
     def _crypto_key(self) -> PublicKeyTypes:
         """Helper to get a `cryptography` public key for this SSlibKey."""
+        if self.keytype == KEY_TYPE_ED25519:
+            return Ed25519PublicKey.from_public_bytes(
+                bytes.fromhex(self.keyval["public"])
+            )
         public_bytes = self.keyval["public"].encode("utf-8")
         return load_pem_public_key(public_bytes)
 
@@ -501,8 +505,8 @@ class SSlibKey(Key):
                 key.verify(signature, data, ECDSA(SHA512()))
 
             elif self.keytype == KEY_TYPE_ED25519 and self.scheme == ED25519:
-                public_bytes = bytes.fromhex(self.keyval["public"])
-                key = Ed25519PublicKey.from_public_bytes(public_bytes)
+                key = cast(Ed25519PublicKey, self._crypto_key())
+                _validate_type(key, Ed25519PublicKey)
                 key.verify(signature, data)
 
             elif self.keytype == KEY_TYPE_MLDSA and self.scheme == MLDSA_44_1:

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -452,6 +452,7 @@ class TestSSlibKey(unittest.TestCase):
             self.assertEqual(key.keytype, keytype)
             self.assertEqual(key.scheme, default_scheme)
             self.assertEqual(key.keyid, default_keyid)
+            self.assertEqual(key._crypto_key(), crypto_key)
 
         # Test with non-default scheme/keyid
         crypto_key = _from_file(PEMS_DIR / "rsa_public.pem")
@@ -797,6 +798,29 @@ class TestCryptoSigner(unittest.TestCase):
                     "CryptoSigner private key does not match public key",
                 ):
                     CryptoSigner(signer._private_key, other_signer.public_key)
+
+    def test_init_pem_formatting_variations(self):
+        """Test that CryptoSigner accepts public keys with PEM formatting variations."""
+        for name in ["rsa", "ecdsa", "mldsa65", "ed25519"]:
+            with self.subTest(key=name):
+                private_key = self.keys[name]
+                signer = CryptoSigner(private_key)
+                pem = signer.public_key.keyval["public"]
+
+                # Test without trailing newline
+                pubkey_no_newline = copy.deepcopy(signer.public_key)
+                pubkey_no_newline.keyval["public"] = pem.rstrip("\n")
+                CryptoSigner(private_key, pubkey_no_newline)
+
+                # Test with CRLF line endings
+                pubkey_crlf = copy.deepcopy(signer.public_key)
+                pubkey_crlf.keyval["public"] = pem.replace("\n", "\r\n")
+                CryptoSigner(private_key, pubkey_crlf)
+
+                # Test with extra surrounding whitespace
+                pubkey_whitespace = copy.deepcopy(signer.public_key)
+                pubkey_whitespace.keyval["public"] = f"  \n{pem}\n\n"
+                CryptoSigner(private_key, pubkey_whitespace)
 
     def test_sign(self):
         for name, private_key in self.keys.items():


### PR DESCRIPTION
#1196 added a check to CryptoSigner to verify the given public and private keys are actually a match: python-tuf test suite revealed that the check is a bit too simple: multiple keyvals can actually be the same cryptographic key.

* Use the cryptographic key for comparison instead: this means the check is a little more expensive but also more correct
* Also fix a related Ed25519 key bug (the ed25519 keyval is special, `_crypto_key()` needs to take that into account)

@ECD5A review welcome if you have any comments