### PR TITLE
Signer: lazy-load optional implementations

### DIFF
--- a/docs/signer.rst
+++ b/docs/signer.rst
@@ -19,8 +19,9 @@ generic *load* methods:
 
 * ``Signer.from_priv_key_uri`` -  Loads any specific signer from a URI. The
   specific signer implementation itself is responsible for the URI format and
-  resolution. To become discoverable, signers and their URI schemes are
-  registered in the ``SIGNER_FOR_URI_SCHEME`` lookup table.
+  resolution. Built-in signers are loaded on demand. Applications can register
+  custom signers or override built-ins in ``SIGNER_FOR_URI_SCHEME``. This table
+  contains custom entries and cached implementations, not all supported schemes.
 
 * ``Key.from_dict`` - Loads any specific key from a serialized format. The
   specific key implementation is responsible for the public key format and

--- a/securesystemslib/signer/__init__.py
+++ b/securesystemslib/signer/__init__.py
@@ -5,9 +5,9 @@ This module provides extensible interfaces for public keys and signers:
 Some implementations are provided by default but more can be added by users.
 """
 
-# ruff: noqa: F401
-from securesystemslib.signer._aws_signer import AWSSigner
-from securesystemslib.signer._azure_signer import AzureSigner
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 from securesystemslib.signer._constants import (
     ECDSA_SHA2_NISTP256,
     ECDSA_SHA2_NISTP384,
@@ -29,34 +29,96 @@ from securesystemslib.signer._constants import (
     RSASSA_PSS_SHA384,
     RSASSA_PSS_SHA512,
 )
-from securesystemslib.signer._crypto_signer import CryptoSigner
-from securesystemslib.signer._gcp_signer import GCPSigner
 from securesystemslib.signer._gpg_signer import GPGKey, GPGSigner
-from securesystemslib.signer._hsm_signer import HSMSigner
 from securesystemslib.signer._key import KEY_FOR_TYPE_AND_SCHEME, Key, SSlibKey
 from securesystemslib.signer._signature import Signature
 from securesystemslib.signer._signer import (
+    _BUILTIN_SIGNERS,
     SIGNER_FOR_URI_SCHEME,
     SecretsHandler,
     Signer,
 )
-from securesystemslib.signer._sigstore_signer import SigstoreKey, SigstoreSigner
-from securesystemslib.signer._tkey_signer import TKeySigner
-from securesystemslib.signer._vault_signer import VaultSigner
 
-# Register supported private key uri schemes and the Signers implementing them
-SIGNER_FOR_URI_SCHEME.update(
+if TYPE_CHECKING:
+    from securesystemslib.signer._aws_signer import AWSSigner
+    from securesystemslib.signer._azure_signer import AzureSigner
+    from securesystemslib.signer._crypto_signer import CryptoSigner
+    from securesystemslib.signer._gcp_signer import GCPSigner
+    from securesystemslib.signer._hsm_signer import HSMSigner
+    from securesystemslib.signer._sigstore_signer import SigstoreKey, SigstoreSigner
+    from securesystemslib.signer._tkey_signer import TKeySigner
+    from securesystemslib.signer._vault_signer import VaultSigner
+
+_LAZY_IMPORTS = {
+    class_name: (module_name, class_name)
+    for module_name, class_name in _BUILTIN_SIGNERS.values()
+}
+_LAZY_IMPORTS.update(
     {
-        CryptoSigner.SCHEME: CryptoSigner,
-        GCPSigner.SCHEME: GCPSigner,
-        HSMSigner.SCHEME: HSMSigner,
-        GPGSigner.SCHEME: GPGSigner,
-        AzureSigner.SCHEME: AzureSigner,
-        AWSSigner.SCHEME: AWSSigner,
-        VaultSigner.SCHEME: VaultSigner,
-        TKeySigner.SCHEME: TKeySigner,
+        "SigstoreKey": ("securesystemslib.signer._sigstore_signer", "SigstoreKey"),
+        "SigstoreSigner": (
+            "securesystemslib.signer._sigstore_signer",
+            "SigstoreSigner",
+        ),
     }
 )
+
+__all__ = [
+    "AWSSigner",
+    "AzureSigner",
+    "CryptoSigner",
+    "ECDSA_SHA2_NISTP256",
+    "ECDSA_SHA2_NISTP384",
+    "ECDSA_SHA2_NISTP521",
+    "ED25519",
+    "GCPSigner",
+    "GPGKey",
+    "GPGSigner",
+    "HSMSigner",
+    "KEY_FOR_TYPE_AND_SCHEME",
+    "KEY_TYPE_ECDSA",
+    "KEY_TYPE_ED25519",
+    "KEY_TYPE_MLDSA",
+    "KEY_TYPE_RSA",
+    "Key",
+    "MLDSA_44_1",
+    "MLDSA_65_1",
+    "MLDSA_87_1",
+    "RSA_PKCS1V15_SHA224",
+    "RSA_PKCS1V15_SHA256",
+    "RSA_PKCS1V15_SHA384",
+    "RSA_PKCS1V15_SHA512",
+    "RSASSA_PSS_SHA224",
+    "RSASSA_PSS_SHA256",
+    "RSASSA_PSS_SHA384",
+    "RSASSA_PSS_SHA512",
+    "SIGNER_FOR_URI_SCHEME",
+    "SSlibKey",
+    "SecretsHandler",
+    "Signature",
+    "Signer",
+    "SigstoreKey",
+    "SigstoreSigner",
+    "TKeySigner",
+    "VaultSigner",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Load optional signer implementations only when they are requested."""
+    try:
+        module_name, class_name = _LAZY_IMPORTS[name]
+    except KeyError as e:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from e
+
+    value = getattr(import_module(module_name), class_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _LAZY_IMPORTS.keys())
+
 
 # Signers with currently unstable metadata formats, not supported by default:
 #   SigstoreSigner

--- a/securesystemslib/signer/__init__.py
+++ b/securesystemslib/signer/__init__.py
@@ -33,7 +33,7 @@ from securesystemslib.signer._gpg_signer import GPGKey, GPGSigner
 from securesystemslib.signer._key import KEY_FOR_TYPE_AND_SCHEME, Key, SSlibKey
 from securesystemslib.signer._signature import Signature
 from securesystemslib.signer._signer import (
-    _BUILTIN_SIGNERS,
+    _DEFAULT_SIGNERS,
     SIGNER_FOR_URI_SCHEME,
     SecretsHandler,
     Signer,
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 _LAZY_IMPORTS = {
     class_name: (module_name, class_name)
-    for module_name, class_name in _BUILTIN_SIGNERS.values()
+    for module_name, class_name in _DEFAULT_SIGNERS.values()
 }
 _LAZY_IMPORTS.update(
     {

--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -2,22 +2,99 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterator, MutableMapping
 
 from securesystemslib.signer._key import Key
 from securesystemslib.signer._signature import Signature
 
 logger = logging.getLogger(__name__)
 
-# NOTE Signer dispatch table is defined here so it's usable by Signer,
-# but is populated in __init__.py (and can be appended by users).
-SIGNER_FOR_URI_SCHEME: dict[str, type] = {}
+_BUILTIN_SIGNERS = {
+    "awskms": ("securesystemslib.signer._aws_signer", "AWSSigner"),
+    "azurekms": ("securesystemslib.signer._azure_signer", "AzureSigner"),
+    "file2": ("securesystemslib.signer._crypto_signer", "CryptoSigner"),
+    "gcpkms": ("securesystemslib.signer._gcp_signer", "GCPSigner"),
+    "gnupg": ("securesystemslib.signer._gpg_signer", "GPGSigner"),
+    "hsm": ("securesystemslib.signer._hsm_signer", "HSMSigner"),
+    "hv": ("securesystemslib.signer._vault_signer", "VaultSigner"),
+    "tkey": ("securesystemslib.signer._tkey_signer", "TKeySigner"),
+}
+
+
+class _LazySignerRegistry(MutableMapping[str, type]):
+    """Mutable signer registry that resolves built-ins on first access."""
+
+    def __init__(self, builtins: dict[str, tuple[str, str]]) -> None:
+        self._builtins = builtins
+        self._loaded: dict[str, type] = {}
+        self._disabled: set[str] = set()
+
+    def __getitem__(self, scheme: str) -> type:
+        try:
+            return self._loaded[scheme]
+        except KeyError:
+            pass
+
+        if scheme in self._disabled:
+            raise KeyError(scheme)
+
+        try:
+            module_name, class_name = self._builtins[scheme]
+        except KeyError as e:
+            raise KeyError(scheme) from e
+
+        signer = getattr(importlib.import_module(module_name), class_name)
+        self._loaded[scheme] = signer
+        return signer
+
+    def __setitem__(self, scheme: str, signer: type) -> None:
+        self._loaded[scheme] = signer
+        self._disabled.discard(scheme)
+
+    def __delitem__(self, scheme: str) -> None:
+        if scheme in self._loaded:
+            del self._loaded[scheme]
+        elif scheme not in self._builtins or scheme in self._disabled:
+            raise KeyError(scheme)
+
+        if scheme in self._builtins:
+            self._disabled.add(scheme)
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._loaded
+        yield from (
+            scheme
+            for scheme in self._builtins
+            if scheme not in self._loaded and scheme not in self._disabled
+        )
+
+    def __len__(self) -> int:
+        return len(self._loaded) + sum(
+            scheme not in self._loaded and scheme not in self._disabled
+            for scheme in self._builtins
+        )
+
+    def __contains__(self, scheme: object) -> bool:
+        return scheme in self._loaded or (
+            scheme in self._builtins and scheme not in self._disabled
+        )
+
+    def copy(self) -> dict[str, type]:
+        """Return a regular dict, resolving all remaining built-ins."""
+        return dict(self.items())
+
+
+# The registry keeps built-in schemes visible while loading their implementations
+# only when callers request a value. Users can add or replace entries as before.
+SIGNER_FOR_URI_SCHEME: MutableMapping[str, type] = _LazySignerRegistry(_BUILTIN_SIGNERS)
 """Signer dispatch table for ``Signer.from_priv_key()``
 
-See ``securesystemslib.signer.SIGNER_FOR_URI_SCHEME`` for default URI schemes,
-and how to register custom implementations.
+Built-in implementations are loaded on first access. See
+``securesystemslib.signer.SIGNER_FOR_URI_SCHEME`` for how to register custom
+implementations.
 """
 
 # SecretsHandler is a function the calling code can provide to Signer:
@@ -104,10 +181,11 @@ class Signer(metaclass=ABCMeta):
         """
 
         scheme, _, _ = priv_key_uri.partition(":")
-        if scheme not in SIGNER_FOR_URI_SCHEME:
-            raise ValueError(f"Unsupported private key scheme {scheme}")
+        try:
+            signer = SIGNER_FOR_URI_SCHEME[scheme]
+        except KeyError as e:
+            raise ValueError(f"Unsupported private key scheme {scheme}") from e
 
-        signer = SIGNER_FOR_URI_SCHEME[scheme]
         return signer.from_priv_key_uri(priv_key_uri, public_key, secrets_handler)  # type: ignore
 
     @property

--- a/securesystemslib/signer/_signer.py
+++ b/securesystemslib/signer/_signer.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import importlib
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Callable, Iterator, MutableMapping
+from collections.abc import Callable
 
 from securesystemslib.signer._key import Key
 from securesystemslib.signer._signature import Signature
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_SIGNERS = {
+_DEFAULT_SIGNERS = {
     "awskms": ("securesystemslib.signer._aws_signer", "AWSSigner"),
     "azurekms": ("securesystemslib.signer._azure_signer", "AzureSigner"),
     "file2": ("securesystemslib.signer._crypto_signer", "CryptoSigner"),
@@ -24,77 +24,14 @@ _BUILTIN_SIGNERS = {
 }
 
 
-class _LazySignerRegistry(MutableMapping[str, type]):
-    """Mutable signer registry that resolves built-ins on first access."""
+SIGNER_FOR_URI_SCHEME: dict[str, type] = {}
+"""Custom signers and cached implementations for ``Signer.from_priv_key_uri()``.
 
-    def __init__(self, builtins: dict[str, tuple[str, str]]) -> None:
-        self._builtins = builtins
-        self._loaded: dict[str, type] = {}
-        self._disabled: set[str] = set()
-
-    def __getitem__(self, scheme: str) -> type:
-        try:
-            return self._loaded[scheme]
-        except KeyError:
-            pass
-
-        if scheme in self._disabled:
-            raise KeyError(scheme)
-
-        try:
-            module_name, class_name = self._builtins[scheme]
-        except KeyError as e:
-            raise KeyError(scheme) from e
-
-        signer = getattr(importlib.import_module(module_name), class_name)
-        self._loaded[scheme] = signer
-        return signer
-
-    def __setitem__(self, scheme: str, signer: type) -> None:
-        self._loaded[scheme] = signer
-        self._disabled.discard(scheme)
-
-    def __delitem__(self, scheme: str) -> None:
-        if scheme in self._loaded:
-            del self._loaded[scheme]
-        elif scheme not in self._builtins or scheme in self._disabled:
-            raise KeyError(scheme)
-
-        if scheme in self._builtins:
-            self._disabled.add(scheme)
-
-    def __iter__(self) -> Iterator[str]:
-        yield from self._loaded
-        yield from (
-            scheme
-            for scheme in self._builtins
-            if scheme not in self._loaded and scheme not in self._disabled
-        )
-
-    def __len__(self) -> int:
-        return len(self._loaded) + sum(
-            scheme not in self._loaded and scheme not in self._disabled
-            for scheme in self._builtins
-        )
-
-    def __contains__(self, scheme: object) -> bool:
-        return scheme in self._loaded or (
-            scheme in self._builtins and scheme not in self._disabled
-        )
-
-    def copy(self) -> dict[str, type]:
-        """Return a regular dict, resolving all remaining built-ins."""
-        return dict(self.items())
-
-
-# The registry keeps built-in schemes visible while loading their implementations
-# only when callers request a value. Users can add or replace entries as before.
-SIGNER_FOR_URI_SCHEME: MutableMapping[str, type] = _LazySignerRegistry(_BUILTIN_SIGNERS)
-"""Signer dispatch table for ``Signer.from_priv_key()``
-
-Built-in implementations are loaded on first access. See
-``securesystemslib.signer.SIGNER_FOR_URI_SCHEME`` for how to register custom
-implementations.
+Built-in implementations are added on first use through the URI factory.
+Entries registered by applications take precedence over built-ins. Iteration
+and copies contain only registered or cached entries, not all supported schemes.
+Deleting an entry clears its override or cache: a built-in can be loaded again
+on the next factory call.
 """
 
 # SecretsHandler is a function the calling code can provide to Signer:
@@ -118,7 +55,7 @@ class Signer(metaclass=ABCMeta):
     Applications should use generic try-except here if unexpected raises are
     not an option.
 
-    See ``SIGNER_FOR_URI_SCHEME`` for supported private key URI schemes.
+    See each signer implementation for its supported private key URI scheme.
 
     Interactive applications may also define a secrets handler that allows
     asking for user secrets if they are needed::
@@ -165,7 +102,7 @@ class Signer(metaclass=ABCMeta):
         """Factory constructor for a given private key URI
 
         Returns a specific Signer instance based on the private key URI and the
-        supported uri schemes listed in ``SIGNER_FOR_URI_SCHEME``.
+        built-in URI schemes or custom entries in ``SIGNER_FOR_URI_SCHEME``.
 
         Args:
             priv_key_uri: URI that identifies the private key
@@ -181,10 +118,14 @@ class Signer(metaclass=ABCMeta):
         """
 
         scheme, _, _ = priv_key_uri.partition(":")
-        try:
-            signer = SIGNER_FOR_URI_SCHEME[scheme]
-        except KeyError as e:
-            raise ValueError(f"Unsupported private key scheme {scheme}") from e
+        signer = SIGNER_FOR_URI_SCHEME.get(scheme)
+        if signer is None:
+            if scheme not in _DEFAULT_SIGNERS:
+                raise ValueError(f"Unsupported private key scheme {scheme}")
+
+            module_name, class_name = _DEFAULT_SIGNERS[scheme]
+            signer = getattr(importlib.import_module(module_name), class_name)
+            SIGNER_FOR_URI_SCHEME[scheme] = signer
 
         return signer.from_priv_key_uri(priv_key_uri, public_key, secrets_handler)  # type: ignore
 

--- a/tests/test_signer_imports.py
+++ b/tests/test_signer_imports.py
@@ -1,0 +1,91 @@
+"""Tests for lazy imports in the signer package."""
+
+import subprocess
+import sys
+import unittest
+
+
+class TestSignerImports(unittest.TestCase):
+    def _run_python(self, source: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-c", source],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_base_import_does_not_load_optional_signers(self) -> None:
+        result = self._run_python(
+            """
+import sys
+from securesystemslib.signer import SIGNER_FOR_URI_SCHEME, Signer
+
+optional_modules = {
+    "boto3",
+    "azure.identity",
+    "google.cloud.kms",
+    "hvac",
+    "pkcs11",
+    "sigstore",
+}
+loaded = optional_modules.intersection(sys.modules)
+if loaded:
+    raise AssertionError(f"optional signer modules were imported: {sorted(loaded)}")
+
+expected_schemes = {"awskms", "azurekms", "file2", "gcpkms", "gnupg", "hsm", "hv", "tkey"}
+assert set(SIGNER_FOR_URI_SCHEME) == expected_schemes
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_direct_signer_import_is_still_supported(self) -> None:
+        result = self._run_python(
+            """
+import sys
+from securesystemslib.signer import AWSSigner, SIGNER_FOR_URI_SCHEME
+
+assert AWSSigner.SCHEME == "awskms"
+assert "securesystemslib.signer._aws_signer" in sys.modules
+assert SIGNER_FOR_URI_SCHEME[AWSSigner.SCHEME] is AWSSigner
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_registry_override_takes_precedence_over_builtin(self) -> None:
+        result = self._run_python(
+            """
+import sys
+from securesystemslib.signer import SIGNER_FOR_URI_SCHEME
+
+class CustomSigner:
+    pass
+
+SIGNER_FOR_URI_SCHEME["awskms"] = CustomSigner
+assert SIGNER_FOR_URI_SCHEME["awskms"] is CustomSigner
+assert "securesystemslib.signer._aws_signer" not in sys.modules
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_registry_copy_retains_builtin_entries(self) -> None:
+        result = self._run_python(
+            """
+from securesystemslib.signer import AWSSigner, SIGNER_FOR_URI_SCHEME
+
+registry_copy = SIGNER_FOR_URI_SCHEME.copy()
+assert registry_copy.keys() == SIGNER_FOR_URI_SCHEME.keys()
+assert registry_copy["awskms"] is AWSSigner
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_star_import_keeps_public_signers(self) -> None:
+        result = self._run_python(
+            """
+namespace = {}
+exec("from securesystemslib.signer import *", namespace)
+expected = {"AWSSigner", "CryptoSigner", "GCPSigner", "Signer", "VaultSigner"}
+assert expected.issubset(namespace)
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_signer_imports.py
+++ b/tests/test_signer_imports.py
@@ -32,8 +32,9 @@ loaded = optional_modules.intersection(sys.modules)
 if loaded:
     raise AssertionError(f"optional signer modules were imported: {sorted(loaded)}")
 
-expected_schemes = {"awskms", "azurekms", "file2", "gcpkms", "gnupg", "hsm", "hv", "tkey"}
-assert set(SIGNER_FOR_URI_SCHEME) == expected_schemes
+assert isinstance(SIGNER_FOR_URI_SCHEME, dict)
+assert not SIGNER_FOR_URI_SCHEME
+assert "securesystemslib.signer._crypto_signer" not in sys.modules
 """
         )
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -46,7 +47,7 @@ from securesystemslib.signer import AWSSigner, SIGNER_FOR_URI_SCHEME
 
 assert AWSSigner.SCHEME == "awskms"
 assert "securesystemslib.signer._aws_signer" in sys.modules
-assert SIGNER_FOR_URI_SCHEME[AWSSigner.SCHEME] is AWSSigner
+assert not SIGNER_FOR_URI_SCHEME
 """
         )
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -55,26 +56,72 @@ assert SIGNER_FOR_URI_SCHEME[AWSSigner.SCHEME] is AWSSigner
         result = self._run_python(
             """
 import sys
-from securesystemslib.signer import SIGNER_FOR_URI_SCHEME
+from unittest.mock import Mock, sentinel
+from securesystemslib.signer import SIGNER_FOR_URI_SCHEME, Signer
 
 class CustomSigner:
-    pass
+    from_priv_key_uri = Mock(return_value=sentinel.signer)
 
-SIGNER_FOR_URI_SCHEME["awskms"] = CustomSigner
-assert SIGNER_FOR_URI_SCHEME["awskms"] is CustomSigner
+for scheme in ("awskms", "custom"):
+    SIGNER_FOR_URI_SCHEME[scheme] = CustomSigner
+    uri = f"{scheme}:key"
+    assert Signer.from_priv_key_uri(uri, sentinel.key, sentinel.handler) is sentinel.signer
+    CustomSigner.from_priv_key_uri.assert_called_with(uri, sentinel.key, sentinel.handler)
 assert "securesystemslib.signer._aws_signer" not in sys.modules
 """
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_registry_copy_retains_builtin_entries(self) -> None:
+    def test_factory_loads_and_caches_builtin(self) -> None:
         result = self._run_python(
             """
-from securesystemslib.signer import AWSSigner, SIGNER_FOR_URI_SCHEME
+import sys
+from unittest.mock import patch, sentinel
+from securesystemslib.signer import SIGNER_FOR_URI_SCHEME, Signer
+from securesystemslib.signer import _signer
+
+assert "securesystemslib.signer._aws_signer" not in sys.modules
+original_import = _signer.importlib.import_module
+
+with patch.object(_signer.importlib, "import_module", wraps=original_import) as load:
+    with patch("securesystemslib.signer._aws_signer.AWSSigner.from_priv_key_uri", return_value=sentinel.signer) as factory:
+        load.reset_mock()
+        for _ in range(2):
+            assert Signer.from_priv_key_uri("awskms:key", sentinel.key, sentinel.handler) is sentinel.signer
+        factory.assert_called_with("awskms:key", sentinel.key, sentinel.handler)
+        load.assert_called_once_with("securesystemslib.signer._aws_signer")
+
+from securesystemslib.signer import AWSSigner
+assert SIGNER_FOR_URI_SCHEME == {"awskms": AWSSigner}
 
 registry_copy = SIGNER_FOR_URI_SCHEME.copy()
-assert registry_copy.keys() == SIGNER_FOR_URI_SCHEME.keys()
-assert registry_copy["awskms"] is AWSSigner
+SIGNER_FOR_URI_SCHEME.clear()
+assert registry_copy == {"awskms": AWSSigner}
+with patch.object(AWSSigner, "from_priv_key_uri", return_value=sentinel.signer):
+    assert Signer.from_priv_key_uri("awskms:key", sentinel.key) is sentinel.signer
+assert SIGNER_FOR_URI_SCHEME == registry_copy
+assert "securesystemslib.signer._gcp_signer" not in sys.modules
+"""
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_factory_errors(self) -> None:
+        result = self._run_python(
+            """
+import unittest
+from unittest.mock import patch, sentinel
+from securesystemslib.signer import SIGNER_FOR_URI_SCHEME, Signer
+
+case = unittest.TestCase()
+with patch("securesystemslib.signer._signer.importlib.import_module") as load:
+    with case.assertRaisesRegex(ValueError, "Unsupported private key scheme unknown"):
+        Signer.from_priv_key_uri("unknown:key", sentinel.key)
+    load.assert_not_called()
+
+    load.side_effect = ImportError("missing optional dependency")
+    with case.assertRaisesRegex(ImportError, "missing optional dependency"):
+        Signer.from_priv_key_uri("awskms:key", sentinel.key)
+    assert "awskms" not in SIGNER_FOR_URI_SCHEME
 """
         )
         self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Load optional signer implementations only when their public class or private-key URI scheme is first used. Direct and wildcard imports remain available, custom registry entries continue to override defaults, and `Signer.from_priv_key_uri()` now loads and caches built-in implementations in a plain dictionary. Importing `Signer` alone no longer loads optional SDKs.

The regression tests cover lazy base imports, direct and wildcard imports, built-in loading and caching, custom overrides, and failure paths.

**Local performance check**

Command: `python -c "from securesystemslib.signer import Signer"`

Measured on Windows with Python 3.14 and the optional signer packages available in the development environment. Seven fresh-process runs were used; the values below are medians and include interpreter startup:

- `main` (parent of this PR): ~0.455 s
- this PR: ~0.167 s
- reduction: ~63%

Absolute timings vary by machine, but this confirms that the optional signer imports were removed from the base import path.

Fixes #1198
