### PR TITLE
Cryptography compat fix

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -31,6 +31,9 @@ jobs:
             toxenv: purepy
           - python-version: "3.14"
             os: ubuntu-latest
+            toxenv: min-crypto
+          - python-version: "3.14"
+            os: ubuntu-latest
             toxenv: py-no-gpg
           - python-version: "3.14"
             os: ubuntu-latest

--- a/securesystemslib/signer/_crypto_signer.py
+++ b/securesystemslib/signer/_crypto_signer.py
@@ -36,6 +36,7 @@ from securesystemslib.signer._signer import SecretsHandler, Signer
 from securesystemslib.signer._utils import get_mldsa_payload
 
 CRYPTO_IMPORT_ERROR = None
+MLDSA_IMPORT_ERROR = None
 try:
     from cryptography.hazmat.primitives.asymmetric.ec import (
         ECDSA,
@@ -50,11 +51,6 @@ try:
     )
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PrivateKey,
-    )
-    from cryptography.hazmat.primitives.asymmetric.mldsa import (
-        MLDSA44PrivateKey,
-        MLDSA65PrivateKey,
-        MLDSA87PrivateKey,
     )
     from cryptography.hazmat.primitives.asymmetric.padding import (
         MGF1,
@@ -86,6 +82,20 @@ try:
 
 except ImportError:
     CRYPTO_IMPORT_ERROR = "'pyca/cryptography' library required"
+
+# Handle ML-DSA support separately for cryptography 48 dependency:
+# This should not be needed but https://github.com/secure-systems-lab/securesystemslib/issues/1203
+try:
+    from cryptography.hazmat.primitives.asymmetric.mldsa import (
+        MLDSA44PrivateKey,
+        MLDSA65PrivateKey,
+        MLDSA87PrivateKey,
+    )
+except ImportError:
+    MLDSA_IMPORT_ERROR = "'cryptography>=48.0.0' required for ML-DSA support"
+    MLDSA44PrivateKey = None  # type: ignore[assignment, misc]
+    MLDSA65PrivateKey = None  # type: ignore[assignment, misc]
+    MLDSA87PrivateKey = None  # type: ignore[assignment, misc]
 
 logger = logging.getLogger(__name__)
 
@@ -182,6 +192,9 @@ class CryptoSigner(Signer):
 
         if public_key is None:
             public_key = SSlibKey.from_crypto(private_key.public_key())
+
+        if public_key.keytype == KEY_TYPE_MLDSA and MLDSA_IMPORT_ERROR:
+            raise UnsupportedLibraryError(MLDSA_IMPORT_ERROR)
 
         self._private_key: PrivateKeyTypes
         self._sign_args: _RSASignArgs | _ECDSASignArgs | _NoSignArgs
@@ -410,6 +423,8 @@ class CryptoSigner(Signer):
         """
         if CRYPTO_IMPORT_ERROR:
             raise UnsupportedLibraryError(CRYPTO_IMPORT_ERROR)
+        if MLDSA_IMPORT_ERROR:
+            raise UnsupportedLibraryError(MLDSA_IMPORT_ERROR)
 
         scheme = MLDSA_65_1 if scheme is None else scheme
         if scheme == MLDSA_44_1:

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -42,6 +42,7 @@ from securesystemslib.signer._signature import Signature
 from securesystemslib.signer._utils import compute_default_keyid, get_mldsa_payload
 
 CRYPTO_IMPORT_ERROR = None
+MLDSA_IMPORT_ERROR = None
 try:
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.primitives.asymmetric.ec import (
@@ -54,11 +55,6 @@ try:
     )
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PublicKey,
-    )
-    from cryptography.hazmat.primitives.asymmetric.mldsa import (
-        MLDSA44PublicKey,
-        MLDSA65PublicKey,
-        MLDSA87PublicKey,
     )
     from cryptography.hazmat.primitives.asymmetric.padding import (
         MGF1,
@@ -86,6 +82,18 @@ try:
 
 except ImportError:
     CRYPTO_IMPORT_ERROR = "'pyca/cryptography' library required"
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.mldsa import (
+        MLDSA44PublicKey,
+        MLDSA65PublicKey,
+        MLDSA87PublicKey,
+    )
+except ImportError:
+    MLDSA_IMPORT_ERROR = "'cryptography>=48.0.0' required for ML-DSA support"
+    MLDSA44PublicKey = None  # type: ignore[assignment, misc]
+    MLDSA65PublicKey = None  # type: ignore[assignment, misc]
+    MLDSA87PublicKey = None  # type: ignore[assignment, misc]
 
 
 logger = logging.getLogger(__name__)
@@ -352,11 +360,11 @@ class SSlibKey(Key):
                 raise ValueError(f"unsupported curve '{public_key.curve.name}'")
         elif isinstance(public_key, Ed25519PublicKey):
             ret = (KEY_TYPE_ED25519, ED25519, _raw())
-        elif isinstance(public_key, MLDSA44PublicKey):
+        elif MLDSA44PublicKey is not None and isinstance(public_key, MLDSA44PublicKey):
             ret = (KEY_TYPE_MLDSA, MLDSA_44_1, _pem())
-        elif isinstance(public_key, MLDSA65PublicKey):
+        elif MLDSA65PublicKey is not None and isinstance(public_key, MLDSA65PublicKey):
             ret = (KEY_TYPE_MLDSA, MLDSA_65_1, _pem())
-        elif isinstance(public_key, MLDSA87PublicKey):
+        elif MLDSA87PublicKey is not None and isinstance(public_key, MLDSA87PublicKey):
             ret = (KEY_TYPE_MLDSA, MLDSA_87_1, _pem())
         else:
             raise ValueError(f"unsupported key '{type(public_key)}'")
@@ -435,6 +443,9 @@ class SSlibKey(Key):
         ) -> None:
             if not isinstance(key.curve, curve):
                 raise ValueError(f"bad curve {key.curve} for {self.scheme}")
+
+        if self.keytype == KEY_TYPE_MLDSA and MLDSA_IMPORT_ERROR:
+            raise UnsupportedLibraryError(MLDSA_IMPORT_ERROR)
 
         try:
             key: PublicKeyTypes

--- a/securesystemslib/signer/_key.py
+++ b/securesystemslib/signer/_key.py
@@ -360,6 +360,7 @@ class SSlibKey(Key):
                 raise ValueError(f"unsupported curve '{public_key.curve.name}'")
         elif isinstance(public_key, Ed25519PublicKey):
             ret = (KEY_TYPE_ED25519, ED25519, _raw())
+        # ML-DSA key types may be None as fallback for cryptography < 48
         elif MLDSA44PublicKey is not None and isinstance(public_key, MLDSA44PublicKey):
             ret = (KEY_TYPE_MLDSA, MLDSA_44_1, _pem())
         elif MLDSA65PublicKey is not None and isinstance(public_key, MLDSA65PublicKey):

--- a/tests/test_hsm_signer.py
+++ b/tests/test_hsm_signer.py
@@ -7,18 +7,27 @@ import tempfile
 import unittest
 from unittest import mock
 
-import pkcs11
-from asn1crypto.keys import (
-    ECDomainParameters,
-    NamedCurve,
-)
+try:
+    import pkcs11
+    from asn1crypto.keys import (
+        ECDomainParameters,
+        NamedCurve,
+    )
+
+    HAVE_PKCS11 = True
+except ImportError:
+    HAVE_PKCS11 = False
+
 from cryptography.hazmat.primitives.asymmetric.ec import SECP256R1, SECP384R1
 
 from securesystemslib.exceptions import UnverifiedSignatureError
 from securesystemslib.signer import HSMSigner, Signer
 
 
-@unittest.skipUnless(os.environ.get("PYKCS11LIB"), "set PYKCS11LIB to SoftHSM lib path")
+@unittest.skipUnless(
+    HAVE_PKCS11 and os.environ.get("PYKCS11LIB"),
+    "set PYKCS11LIB to SoftHSM lib path and install python-pkcs11",
+)
 class TestHSM(unittest.TestCase):
     """Test HSMSigner with SoftHSM
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -9,7 +9,6 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
 
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
@@ -36,6 +35,7 @@ from securesystemslib.signer import (
     Signer,
     SSlibKey,
 )
+from securesystemslib.signer._key import MLDSA_IMPORT_ERROR
 from securesystemslib.signer._utils import compute_default_keyid
 
 PEMS_DIR = Path(__file__).parent / "data" / "pems"
@@ -755,10 +755,15 @@ class TestCryptoSigner(unittest.TestCase):
             ("ecdsa_secp384r1", "ecdsa", ["ecdsa-sha2-nistp384"]),
             ("ecdsa_secp521r1", "ecdsa", ["ecdsa-sha2-nistp521"]),
             ("ed25519", "ed25519", ["ed25519"]),
-            ("mldsa44", "ml-dsa", ["ml-dsa-44/1"]),
-            ("mldsa65", "ml-dsa", ["ml-dsa-65/1"]),
-            ("mldsa87", "ml-dsa", ["ml-dsa-87/1"]),
         ]
+        if MLDSA_IMPORT_ERROR is None:
+            key_info.extend(
+                [
+                    ("mldsa44", "ml-dsa", ["ml-dsa-44/1"]),
+                    ("mldsa65", "ml-dsa", ["ml-dsa-65/1"]),
+                    ("mldsa87", "ml-dsa", ["ml-dsa-87/1"]),
+                ]
+            )
 
         for name, keytype, schemes in key_info:
             path = PEMS_DIR / f"{name}_private.pem"
@@ -790,8 +795,10 @@ class TestCryptoSigner(unittest.TestCase):
             CryptoSigner.generate_rsa,
             CryptoSigner.generate_ecdsa,
             CryptoSigner.generate_ed25519,
-            CryptoSigner.generate_mldsa,
         ]
+        if MLDSA_IMPORT_ERROR is None:
+            generators.append(CryptoSigner.generate_mldsa)
+
         for generate in generators:
             with self.subTest(generator=generate.__name__):
                 signer = generate()
@@ -804,7 +811,11 @@ class TestCryptoSigner(unittest.TestCase):
 
     def test_init_pem_formatting_variations(self):
         """Test that CryptoSigner accepts public keys with PEM formatting variations."""
-        for name in ["rsa", "ecdsa", "mldsa65", "ed25519"]:
+        names = ["rsa", "ecdsa", "ed25519"]
+        if MLDSA_IMPORT_ERROR is None:
+            names.append("mldsa65")
+
+        for name in names:
             with self.subTest(key=name):
                 private_key = self.keys[name]
                 signer = CryptoSigner(private_key)
@@ -847,8 +858,9 @@ class TestCryptoSigner(unittest.TestCase):
                 "ecdsa-sha2-nistp256",  # keytype deprecated in TUF spec, tested for backwards compat with older metadata
             ),
             ("ed25519_public.pem", "ed25519_private.pem", None),
-            ("mldsa65_public.pem", "mldsa65_private.pem", None),
         ]
+        if MLDSA_IMPORT_ERROR is None:
+            test_data.append(("mldsa65_public.pem", "mldsa65_private.pem", None))
 
         for pub_fname, priv_fname, keytype_override in test_data:
             pub_crypto_key = load_pem_public_key((PEMS_DIR / pub_fname).read_bytes())
@@ -885,8 +897,9 @@ class TestCryptoSigner(unittest.TestCase):
             (CryptoSigner.generate_rsa, "rsa", "rsassa-pss-sha256"),
             (CryptoSigner.generate_ecdsa, "ecdsa", "ecdsa-sha2-nistp256"),
             (CryptoSigner.generate_ed25519, "ed25519", "ed25519"),
-            (CryptoSigner.generate_mldsa, "ml-dsa", "ml-dsa-65/1"),
         ]
+        if MLDSA_IMPORT_ERROR is None:
+            test_data.append((CryptoSigner.generate_mldsa, "ml-dsa", "ml-dsa-65/1"))
         for generate, keytype, default_scheme in test_data:
             signer = generate()
             self.assertEqual(signer.public_key.keytype, keytype)
@@ -931,7 +944,11 @@ class TestCryptoSigner(unittest.TestCase):
         """Test private_bytes -> from_priv_key_uri"""
         with tempfile.TemporaryDirectory() as tempdir:
             priv_key_path = os.path.join(tempdir, "privkey.pem")
-            for pem in ["rsa", "ecdsa", "ed25519", "mldsa65"]:
+            pems = ["rsa", "ecdsa", "ed25519"]
+            if MLDSA_IMPORT_ERROR is None:
+                pems.append("mldsa65")
+
+            for pem in pems:
                 with open(PEMS_DIR / f"{pem}_private.pem", "rb") as f:
                     privkey = load_pem_private_key(f.read(), None)
                     signer = CryptoSigner(privkey)
@@ -975,24 +992,17 @@ class TestCryptoSigner(unittest.TestCase):
         with self.assertRaises(UnverifiedSignatureError):
             pubkey.verify_signature(sig, b"NOT DATA")
 
+    @unittest.skipIf(MLDSA_IMPORT_ERROR is None, "ML-DSA is supported")
     def test_mldsa_unsupported_library(self):
         """Test ML-DSA operations when ML-DSA support is missing in cryptography."""
-        with patch(
-            "securesystemslib.signer._crypto_signer.MLDSA_IMPORT_ERROR",
-            "cryptography>=48.0.0 required",
-        ):
-            with self.assertRaises(UnsupportedLibraryError):
-                CryptoSigner.generate_mldsa()
+        with self.assertRaises(UnsupportedLibraryError):
+            CryptoSigner.generate_mldsa()
 
-        with patch(
-            "securesystemslib.signer._key.MLDSA_IMPORT_ERROR",
-            "cryptography>=48.0.0 required",
-        ):
-            key = SSlibKey("mldsa_id", "ml-dsa", "ml-dsa-65/1", {"public": "some-pem"})
-            sig = Signature("mldsa_id", "1234")
-            with self.assertRaises(VerificationError) as ctx:
-                key.verify_signature(sig, b"data")
-            self.assertIsInstance(ctx.exception.__cause__, UnsupportedLibraryError)
+        key = SSlibKey("mldsa_id", "ml-dsa", "ml-dsa-65/1", {"public": "some-pem"})
+        sig = Signature("mldsa_id", "1234")
+        with self.assertRaises(VerificationError) as ctx:
+            key.verify_signature(sig, b"data")
+        self.assertIsInstance(ctx.exception.__cause__, UnsupportedLibraryError)
 
 
 # Run the unit tests.

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -9,6 +9,7 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from cryptography.hazmat.primitives.serialization import (
     load_pem_private_key,
@@ -19,7 +20,9 @@ from securesystemslib._gpg.constants import have_gpg
 from securesystemslib.exceptions import (
     FormatError,
     KeyMismatchError,
+    UnsupportedLibraryError,
     UnverifiedSignatureError,
+    VerificationError,
 )
 from securesystemslib.signer import (
     KEY_FOR_TYPE_AND_SCHEME,
@@ -971,6 +974,25 @@ class TestCryptoSigner(unittest.TestCase):
         pubkey.verify_signature(sig, b"DATA")
         with self.assertRaises(UnverifiedSignatureError):
             pubkey.verify_signature(sig, b"NOT DATA")
+
+    def test_mldsa_unsupported_library(self):
+        """Test ML-DSA operations when ML-DSA support is missing in cryptography."""
+        with patch(
+            "securesystemslib.signer._crypto_signer.MLDSA_IMPORT_ERROR",
+            "cryptography>=48.0.0 required",
+        ):
+            with self.assertRaises(UnsupportedLibraryError):
+                CryptoSigner.generate_mldsa()
+
+        with patch(
+            "securesystemslib.signer._key.MLDSA_IMPORT_ERROR",
+            "cryptography>=48.0.0 required",
+        ):
+            key = SSlibKey("mldsa_id", "ml-dsa", "ml-dsa-65/1", {"public": "some-pem"})
+            sig = Signature("mldsa_id", "1234")
+            with self.assertRaises(VerificationError) as ctx:
+                key.verify_signature(sig, b"data")
+            self.assertIsInstance(ctx.exception.__cause__, UnsupportedLibraryError)
 
 
 # Run the unit tests.

--- a/tests/test_tkey_signer.py
+++ b/tests/test_tkey_signer.py
@@ -4,6 +4,10 @@ from unittest.mock import MagicMock, patch
 
 from securesystemslib.exceptions import KeyMismatchError, UnsupportedLibraryError
 from securesystemslib.signer import SSlibKey, TKeySigner
+from securesystemslib.signer._tkey_signer import TKEY_IMPORT_ERROR
+
+if TKEY_IMPORT_ERROR is not None:
+    raise unittest.SkipTest(f"TKeySigner unavailable: {TKEY_IMPORT_ERROR}")
 
 
 class TestTKeySigner(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint, py, purepy, py-no-gpg, py-test-gpg-fails
+envlist = lint, py, min-crypto, purepy, py-no-gpg, py-test-gpg-fails
 skipsdist = True
 
 [testenv]
@@ -22,6 +22,11 @@ commands =
     python -m tests.check_gpg_available
     coverage run tests/aggregate_tests.py
     coverage report -m --fail-under 70
+
+[testenv:min-crypto]
+deps =
+    cryptography==44.0.0
+    -r{toxinidir}/requirements-test.txt
 
 [testenv:purepy]
 deps =


### PR DESCRIPTION

### Support older cryptography as  we can

Problem:
* We require users to select the extras they need, including `crypto` for cryptography.
* Many users already use cryptography themselves so may not include `crypto` extra because it seems to work without
* but there is a difference:
  * installing `securesystemslib[crypto]` and `cryptography<47` leads to securesystemslib==1.4.0
  * installing `securesystemslib` and `cryptography<47` leads to securesystemslib==1.5.0 **this will not work with the installed cryptography**


Solution:
* Only require ML-DSA types if ml-dsa keys are requested: this make s the code work with older cryptography
* Keep officially requiring cryptography 48: so anyone using the extra gets correct dependency resolution
* Add test env with with cryptography 44 -- the idea is to understand when we break this, not to promise that we support it


The real code change is 50 lines (but they are rather annoying). The rest of it is just test changes.

Fixes #1203 
